### PR TITLE
Add effect to emit 'paint' signal

### DIFF
--- a/src/connections.js
+++ b/src/connections.js
@@ -39,6 +39,25 @@ var Connections = class Connections {
         this.process_connection(actor, id);
     }
 
+    disconnect_all_for(actor) {
+        actor_connections = this.buffer.filter((infos) => {
+            infos.actor == actor
+        });
+
+        actor_connections.forEach((connection) => {
+            // disconnect
+            try {
+                connection.actor.disconnect(connection.id)
+            } catch (e) {
+                this._log(`error removing connection: ${e}; continuing`)
+            }
+
+            // remove from buffer
+            let index = this.buffer.indexOf(connection);
+            this.buffer.splice(index, 1);
+        })
+    }
+
     disconnect_all() {
         this.buffer.forEach((connection) => {
             try {

--- a/src/dash_to_dock.js
+++ b/src/dash_to_dock.js
@@ -7,6 +7,7 @@ const Signals = imports.signals;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Settings = Me.imports.settings;
 const Utils = Me.imports.utilities;
+const PaintSignals = Me.imports.paint_signals;
 let prefs = new Settings.Prefs;
 
 const default_sigma = 30;
@@ -52,6 +53,7 @@ var DashBlur = class DashBlur {
     constructor(connections) {
         this.dashes = [];
         this.connections = connections;
+        this.paint_signals = new PaintSignals.PaintSignals(connections);
         this.sigma = default_sigma;
         this.brightness = default_brightness;
     }
@@ -142,6 +144,7 @@ var DashBlur = class DashBlur {
 
             if (prefs.HACKS_LEVEL.get() == 1) {
                 this._log("dash hack level 1");
+                this.paint_signals.disconnect_all();
 
                 let rp = () => {
                     effect.queue_repaint()
@@ -179,14 +182,11 @@ var DashBlur = class DashBlur {
             } else if (prefs.HACKS_LEVEL.get() == 2) {
                 this._log("dash hack level 2");
 
-                let rp = () => {
-                    effect.queue_repaint();
-                };
-
-                // disabled because of #31
-                /*
-                this.connections.connect(dash, 'paint', rp);
-                */
+                Main.panel.get_children().forEach(child => {
+                    this.paint_signals.connect(dash, this.effect);
+                });
+            } else {
+                this.paint_signals.disconnect_all();
             }
 
             // ! END OF DIRTY PART

--- a/src/dash_to_dock.js
+++ b/src/dash_to_dock.js
@@ -182,9 +182,7 @@ var DashBlur = class DashBlur {
             } else if (prefs.HACKS_LEVEL.get() == 2) {
                 this._log("dash hack level 2");
 
-                Main.panel.get_children().forEach(child => {
-                    this.paint_signals.connect(dash, this.effect);
-                });
+                this.paint_signals.connect(dash, this.effect);
             } else {
                 this.paint_signals.disconnect_all();
             }

--- a/src/paint_signals.js
+++ b/src/paint_signals.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { GObject, Clutter } = imports.gi;
+
+var PaintSignals = class PaintSignals {
+    constructor(connections) {
+        this.buffer = [];
+        this.connections = connections
+    }
+
+    connect(actor, blur_effect) {
+        let paint_effect = new EmitPaintSignal();
+        let infos = {
+            actor: actor,
+            paint_effect: paint_effect
+        };
+
+        actor.add_effect(paint_effect);
+        this.connections.connect(paint_effect, 'update-blur', () => {
+            blur_effect.queue_repaint();
+        });
+
+        this.buffer.push(infos)
+    }
+
+    disconnect_all() {
+        this.buffer.forEach((infos) => {
+            this.connections.disconnect_all_for(infos.paint_effect);
+            infos.actor.remove_effect(paint_effect);
+        });
+
+        this.buffer = []
+    }
+}
+
+var EmitPaintSignal = GObject.registerClass(
+    {
+        GTypeName: 'EmitPaintSignal',
+        Signals: {
+            'update-blur': {
+                param_types: []
+            },
+        }
+    },
+    class EmitPaintSignal extends Clutter.Effect {
+        vfunc_paint(node, paint_context, paint_flags) {
+            this.emit("update-blur");
+            super.vfunc_paint(node, paint_context, paint_flags);
+        }
+    }
+);

--- a/src/panel.js
+++ b/src/panel.js
@@ -7,6 +7,7 @@ const backgroundSettings = new Gio.Settings({ schema: 'org.gnome.desktop.backgro
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Settings = Me.imports.settings;
 const Utils = Me.imports.utilities;
+const PaintSignals = Me.imports.paint_signals;
 let prefs = new Settings.Prefs;
 
 const dash_to_panel_uuid = 'dash-to-panel@jderose9.github.com';
@@ -18,6 +19,7 @@ let sigma = 30;
 var PanelBlur = class PanelBlur {
     constructor(connections) {
         this.connections = connections;
+        this.paint_signals = new PaintSignals.PaintSignals(connections);
         this.effect = new Shell.BlurEffect({
             brightness: default_brightness,
             sigma: default_sigma,
@@ -107,6 +109,7 @@ var PanelBlur = class PanelBlur {
 
             if (prefs.HACKS_LEVEL.get() == 1) {
                 this._log("panel hack level 1");
+                this.paint_signals.disconnect_all();
 
                 let rp = () => {
                     this.effect.queue_repaint()
@@ -124,14 +127,11 @@ var PanelBlur = class PanelBlur {
             } else if (prefs.HACKS_LEVEL.get() == 2) {
                 this._log("panel hack level 2");
 
-                // FIXME need to remove the effect afterward
                 Main.panel.get_children().forEach(child => {
-                    let paint_effect = new Utils.EmitPaintSignal();
-                    child.add_effect(paint_effect);
-                    this.connections.connect(paint_effect, 'update-blur', () => {
-                        this.effect.queue_repaint();
-                    });
+                    this.paint_signals.connect(child, this.effect);
                 });
+            } else {
+                this.paint_signals.disconnect_all();
             }
 
             // ! END OF DIRTY PART

--- a/src/panel.js
+++ b/src/panel.js
@@ -123,14 +123,14 @@ var PanelBlur = class PanelBlur {
             } else if (prefs.HACKS_LEVEL.get() == 2) {
                 this._log("panel hack level 2");
 
-                // disabled because of #31
-                /*
+                // FIXME need to remove the effect afterward
                 Main.panel.get_children().forEach(child => {
-                    this.connections.connect(child, 'paint', () => {
+                    let paint_effect = new Utils.EmitPaintSignal();
+                    child.add_effect(paint_effect);
+                    this.connections.connect(paint_effect, 'update-blur', () => {
                         this.effect.queue_repaint();
                     });
                 });
-                */
             }
 
             // ! END OF DIRTY PART

--- a/src/prefs.ui
+++ b/src/prefs.ui
@@ -203,7 +203,7 @@
           <object class="GtkCheckButton" id="hacks_level2">
             <property name="label" translatable="yes">no artifacts, bad perfs</property>
             <property name="active">0</property>
-            <property name="sensitive">0</property>
+            <property name="sensitive">1</property>
             <property name="group">hacks_level0</property>
             <signal name="toggled" handler="hacks_level2_toggled" swapped="no" />
             <layout>

--- a/src/prefs.ui
+++ b/src/prefs.ui
@@ -189,7 +189,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="hacks_level1">
-            <property name="label" translatable="yes">less artifacts, perfs OK+</property>
+            <property name="label" translatable="yes">some artifacts, perfs OK+</property>
             <property name="active">1</property>
             <property name="group">hacks_level0</property>
             <signal name="toggled" handler="hacks_level1_toggled" swapped="no" />
@@ -201,9 +201,8 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="hacks_level2">
-            <property name="label" translatable="yes">no artifacts, bad perfs</property>
+            <property name="label" translatable="yes">nearly no artifacts, bad perfs</property>
             <property name="active">0</property>
-            <property name="sensitive">1</property>
             <property name="group">hacks_level0</property>
             <signal name="toggled" handler="hacks_level2_toggled" swapped="no" />
             <layout>

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { GLib, GObject, Clutter } = imports.gi;
+const GLib = imports.gi.GLib;
 
 let clearTimeout, clearInterval;
 clearInterval = clearTimeout = GLib.Source.remove;
@@ -18,20 +18,3 @@ var setInterval = function (func, delay, ...args) {
         return GLib.SOURCE_CONTINUE;
     });
 };
-
-const EmitPaintSignal = GObject.registerClass(
-    {
-        GTypeName: 'EmitPaintSignal',
-        Signals: {
-            'update-blur': {
-                param_types: []
-            },
-        }
-    },
-    class MyEffect extends Clutter.Effect {
-        vfunc_paint(node, paint_context, paint_flags) {
-            this.emit("update-blur");
-            super.vfunc_paint(node, paint_context, paint_flags);
-        }
-    }
-);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,5 +1,6 @@
 'use strict'
-const { GLib } = imports.gi;
+
+const { GLib, GObject, Clutter } = imports.gi;
 
 let clearTimeout, clearInterval;
 clearInterval = clearTimeout = GLib.Source.remove;
@@ -17,3 +18,20 @@ const setInterval = function (func, delay, ...args) {
         return GLib.SOURCE_CONTINUE;
     });
 };
+
+const EmitPaintSignal = GObject.registerClass(
+    {
+        GTypeName: 'EmitPaintSignal',
+        Signals: {
+            'update-blur': {
+                param_types: []
+            },
+        }
+    },
+    class MyEffect extends Clutter.Effect {
+        vfunc_paint(node, paint_context, paint_flags) {
+            this.emit("update-blur");
+            super.vfunc_paint(node, paint_context, paint_flags);
+        }
+    }
+);


### PR DESCRIPTION
I successfully added the effect to fix #31, and it works great!
I tested it for the panel, it works as great as the ancient 'paint' signal (so there are still some artefacts, due to windows shadows...).

We may need a way to instantly add this effect and connect it, keep track of it and maybe clean it afterwards? Just like we do for the connected signals, it would simplify the design a bit.