### PR TITLE
Added gnome 40.1 support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,8 @@
     "description": "Adds a blur look to different parts of the GNOME Shell, including the top panel, dash and overview.\n\nContains some bugs due to the implementation of the blur effect on gnome shell, see https: //gitlab.gnome.org/GNOME/gnome-shell/-/issues/2857 for more informations.\n\nAdded support for Gnome 40, and a way to entirely remove artifacts from top panel :)",
     "name": "Blur my Shell",
     "shell-version": [
-        "40"
+        "40",
+        "40.1"
     ],
     "url": "https://github.com/aunetx/gnome-shell-extension-blur-my-shell",
     "uuid": "blur-my-shell@aunetx"


### PR DESCRIPTION
Works fine in Fedora 34, gnome 40.1, so why not bump shell version?
![Screenshot from 2021-05-12 15-16-13](https://user-images.githubusercontent.com/49311640/117959038-0f85d600-b335-11eb-8234-8440ca4993f9.png)
