### PR TITLE
Fix static blur being broken in setups in which the main monitor is not the leftmost-topmost one.

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -151,8 +151,8 @@ var PanelBlur = class PanelBlur {
         this.background.height = Main.panel.height;
         if (is_static) {
             this.background.set_clip(
-                this.monitor.x,
-                this.monitor.y,
+                0,
+                0,
                 this.monitor.width,
                 Main.panel.height
             );


### PR DESCRIPTION
This is a fix for the issue I reported in #47.

This bit of code originally set the clip rectangle of the actor responsible for static panel blur to be offset to be the same as the offset of the monitor from the top left corner of the screen. This would break static blur in setups in which the main monitor is not the topmost-leftmost one.

The offsets handed out to the `Meta.BackgroundActor.set_clip` method, inherited from `Clutter.Actor.set_clip`, are specified in [the documentation](https://developer.gnome.org/cluttermm/unstable/classClutter_1_1Actor.html#a04bd53cedd2e186a0e56d93aa6f6ca73) as being offsets from the top-left corner of the _actor itself_. Thus, since the actor responsible for the blur is already positioned at the top-left corner of the main monitor, this offset should be `0, 0`, rather than the position of the actor.