### PR TITLE
Remove background_panel first to avoid duplicates

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -26,6 +26,7 @@ var PanelBlur = class PanelBlur {
             mode: prefs.STATIC_BLUR.get() ? 0 : 1
         });
         this.background_parent = new St.Widget({
+            name: 'topbar-blurred-background-parent',
             style_class: 'topbar-blurred-background-parent',
             x: this.monitor.x,
             y: this.monitor.y,
@@ -46,6 +47,10 @@ var PanelBlur = class PanelBlur {
         this._log("blurring top panel");
 
         // insert background parent
+        let children = Main.layoutManager.panelBox.get_children();
+        for (let i = 0; i < children.length; ++i)
+            if (children[i].name == 'topbar-blurred-background-parent')
+                Main.layoutManager.panelBox.remove_child(children[i]);
         Main.layoutManager.panelBox.insert_child_at_index(this.background_parent, 0);
         // hide corners, can't style them
         Main.panel._leftCorner.hide();


### PR DESCRIPTION
Looked at lg why the panel background is not being updated after a lock and noticed that for each lock, the background_panel gets created as a new instance. That means that the old background_panel is still there so that's why the panel background wasn't get updated. 

Here's a workaround which removes the old background_panel(s) before inserting a new one.

Fixes: #85 