### PR TITLE
Check workspace setting before blurring workspace switch

### DIFF
--- a/src/overview.js
+++ b/src/overview.js
@@ -55,10 +55,7 @@ var OverviewBlur = class OverviewBlur {
             outerThis._origPrepareSwitch.apply(this, params);
 
             Main.layoutManager.monitors.forEach(monitor => {
-              var blur_this_monitor = true;
-              if (Meta.prefs_get_workspaces_only_on_primary()) {
-                var blur_this_monitor = monitor == Main.layoutManager.primaryMonitor;
-              }
+              let blur_this_monitor = Meta.prefs_get_workspaces_only_on_primary() && (monitor == Main.layoutManager.primaryMonitor);
               if (blur_this_monitor) {
                 const bg_actor = outerThis.create_background_actor(monitor);
                 Main.uiGroup.insert_child_above(bg_actor, global.window_group);

--- a/src/overview.js
+++ b/src/overview.js
@@ -55,11 +55,17 @@ var OverviewBlur = class OverviewBlur {
             outerThis._origPrepareSwitch.apply(this, params);
 
             Main.layoutManager.monitors.forEach(monitor => {
+              var blur_this_monitor = true;
+              if (Meta.prefs_get_workspaces_only_on_primary()) {
+                var blur_this_monitor = monitor == Main.layoutManager.primaryMonitor;
+              }
+              if (blur_this_monitor) {
                 const bg_actor = outerThis.create_background_actor(monitor);
                 Main.uiGroup.insert_child_above(bg_actor, global.window_group);
 
                 // store the actors so that we can delete them later
                 outerThis._workspace_switch_bg_actors.push(bg_actor);
+              }
             });
         };
 


### PR DESCRIPTION
This PR adds an check before applying blurring to the workspace switch.

If "workspaces only on primary display" is activated, it will only apply the blur to the primary display, otherwise it behaves as previously.

Fixes #168