### PR TITLE
Fix some issues with dynamic blur and dash-to-panel

### DIFF
--- a/src/dash_to_dock.js
+++ b/src/dash_to_dock.js
@@ -180,7 +180,7 @@ var DashBlur = class DashBlur {
             } else if (this.prefs.HACKS_LEVEL.get() == 2) {
                 this._log("dash hack level 2");
 
-                this.paint_signals.connect(dash, this.effect);
+                this.paint_signals.connect(background, effect);
             } else {
                 this.paint_signals.disconnect_all();
             }

--- a/src/paint_signals.js
+++ b/src/paint_signals.js
@@ -15,11 +15,18 @@ var PaintSignals = class PaintSignals {
             actor: actor,
             paint_effect: paint_effect
         };
+        let queue_repaint_has_been_called = false;
 
         actor.add_effect(paint_effect);
         this.connections.connect(paint_effect, 'update-blur', () => {
             try {
-                blur_effect.queue_repaint();
+                // check if blur_effect.queue_repaint() has been called
+                if (!queue_repaint_has_been_called) {
+                    queue_repaint_has_been_called = true;
+                    blur_effect.queue_repaint();
+                }
+                else
+                    queue_repaint_has_been_called = false;
             } catch (e) { }
         });
 

--- a/src/paint_signals.js
+++ b/src/paint_signals.js
@@ -15,18 +15,17 @@ var PaintSignals = class PaintSignals {
             actor: actor,
             paint_effect: paint_effect
         };
-        let queue_repaint_has_been_called = false;
+        let counter = 0;
 
         actor.add_effect(paint_effect);
         this.connections.connect(paint_effect, 'update-blur', () => {
             try {
-                // check if blur_effect.queue_repaint() has been called
-                if (!queue_repaint_has_been_called) {
-                    queue_repaint_has_been_called = true;
+                // checking if blur_effect.queue_repaint() has been recently called
+                if (counter === 0) {
+                    counter = 2;
                     blur_effect.queue_repaint();
                 }
-                else
-                    queue_repaint_has_been_called = false;
+                else counter--;
             } catch (e) { }
         });
 

--- a/src/panel.js
+++ b/src/panel.js
@@ -151,8 +151,8 @@ var PanelBlur = class PanelBlur {
     update_size(is_static) {
         this.background_parent.width = Main.panel.width;
         this.background.width = Main.panel.width;
-        this.background.height = Main.panel.height;
         let panel_box = Main.layoutManager.panelBox;
+        this.background.height = panel_box.height;
         let clip_box = panel_box.get_parent();
         if (is_static) {
             this.background.set_clip(

--- a/src/panel.js
+++ b/src/panel.js
@@ -128,10 +128,7 @@ var PanelBlur = class PanelBlur {
                 this._log("panel hack level 2");
                 this.paint_signals.disconnect_all();
 
-                this.paint_signals.connect(Main.panel, this.effect);
-                Main.panel.get_children().forEach(child => {
-                    this.paint_signals.connect(child, this.effect);
-                });
+                this.paint_signals.connect(this.background, this.effect);
             } else {
                 this.paint_signals.disconnect_all();
             }


### PR DESCRIPTION
Mutter is compositing window manager so it stores a texture buffer for each widget. For this reason widgets above a blurred background will not emit paint signal in some cases (because the compositor doesn't need to redraw them). This merge request fix issue by ensuring that the widget with the blur effect applied will be repainted entirely when some part of it is redrawn.

This merge request also contains small fix for problem with dynamic blur and dash-to-panel extension that occurs after locking screen.