### PR TITLE
Fix _prepareWorkspaceSwitch is undefined

### DIFF
--- a/src/overview.js
+++ b/src/overview.js
@@ -139,8 +139,13 @@ var OverviewBlur = class OverviewBlur {
         this.connections.disconnect_all();
 
         // restore original behavior
-        WorkspaceAnimationController.prototype._prepareWorkspaceSwitch = this._origPrepareSwitch;
-        WorkspaceAnimationController.prototype._finishWorkspaceSwitch = this._origFinishSwitch;
+        if (this._origPrepareSwitch) {
+            WorkspaceAnimationController.prototype._prepareWorkspaceSwitch = this._origPrepareSwitch;
+        }
+        
+        if (this._origFinishSwitch) {
+            WorkspaceAnimationController.prototype._finishWorkspaceSwitch = this._origFinishSwitch;
+        }
     }
 
     _log(str) {


### PR DESCRIPTION
The `disable()` method of the `OverviewBlur` can be called without a prior call to `enable()`. This can corrupt the prototype of the `WorkspaceAnimationController` if the extension is disabled while the overview blur is not enabled.