### PR TITLE
Blur, but in color 

### DIFF
--- a/resources/ui/coloreffect.ui
+++ b/resources/ui/coloreffect.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="blur-my-shell@aunetx">
+  <template class="Color_Effect" parent="AdwPreferencesPage">
+    <property name="name">Color_Effect</property>
+    <property name="title" translatable="yes">Color Blur</property>
+    <property name="icon-name">color-symbolic</property>
+
+    <child>
+      <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Color blur</property>
+        <property name="description" translatable="yes">Change the color of the blur</property>
+        <property name="header-suffix">
+          <object class="GtkSwitch" id="color_blur">
+            <property name="valign">center</property>
+          </object>
+        </property>
+
+       <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Red</property>
+            <property name="subtitle" translatable="yes">Amount of red that is added to the blur </property>
+            <property name="activatable-widget">red_scale</property>
+            <property name="sensitive" bind-source="color_blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkScale" id="red_scale">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="width-request">200px</property>
+                <property name="draw-value">true</property>
+                <property name="value-pos">right</property>
+                <property name="orientation">horizontal</property>
+                <property name="digits">2</property>
+                <property name="adjustment">red</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Green</property>
+            <property name="subtitle" translatable="yes">Amount of green that is added to the blur.</property>
+            <property name="activatable-widget">green_scale</property>
+            <property name="sensitive" bind-source="color_blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkScale" id="green_scale">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="width-request">200px</property>
+                <property name="draw-value">true</property>
+                <property name="value-pos">right</property>
+                <property name="orientation">horizontal</property>
+                <property name="digits">2</property>
+                <property name="adjustment">green</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Blue</property>
+            <property name="subtitle" translatable="yes">Amount of blue that is added to the blur</property>
+            <property name="activatable-widget">blue_scale</property>
+            <property name="sensitive" bind-source="color_blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkScale" id="blue_scale">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="width-request">200px</property>
+                <property name="draw-value">true</property>
+                <property name="value-pos">right</property>
+                <property name="orientation">horizontal</property>
+                <property name="digits">2</property>
+                <property name="adjustment">blue</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Blend</property>
+            <property name="subtitle" translatable="yes">Amount that the colors above are blended in </property>
+            <property name="activatable-widget">blend_scale</property>
+            <property name="sensitive" bind-source="color_blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkScale" id="blend_scale">
+                <property name="valign">center</property>
+                <property name="hexpand">true</property>
+                <property name="width-request">200px</property>
+                <property name="draw-value">true</property>
+                <property name="value-pos">right</property>
+                <property name="orientation">horizontal</property>
+                <property name="digits">2</property>
+                <property name="adjustment">blend</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+
+
+  <object class="GtkAdjustment" id="red">
+    <property name="lower">0</property>
+    <property name="upper">1.0</property>
+    <property name="step-increment">0.1</property>
+  </object>
+
+  <object class="GtkAdjustment" id="blue">
+    <property name="lower">0</property>
+    <property name="upper">1.0</property>
+    <property name="step-increment">0.1</property>
+  </object>
+
+  <object class="GtkAdjustment" id="green">
+    <property name="lower">0</property>
+    <property name="upper">1.0</property>
+    <property name="step-increment">0.1</property>
+  </object>
+
+  <object class="GtkAdjustment" id="blend">
+    <property name="lower">0</property>
+    <property name="upper">1.0</property>
+    <property name="step-increment">0.1</property>
+  </object>
+</interface>

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -296,7 +296,34 @@
             <description />
         </key>
 
+        <!-- COLOR BLUR OPTIONS -->
 
+         <key type="b" name="color-blur">
+            <default>false</default>
+            <summary>Toggle if color effect should be applied</summary>
+            <description />
+        </key>
+        <key type="d" name="red">
+            <default>0.6</default>
+            <summary>Global Red value</summary>
+            <description />
+        </key>
+        <key type="d" name="green">
+            <default>0.6</default>
+            <summary>Global Green value</summary>
+            <description />
+        </key>
+        <key type="d" name="blue">
+            <default>0.6</default>
+            <summary>Global Blue value</summary>
+            <description />
+        </key>
+        <key type="d" name="blend">
+            <default>0.1</default>
+            <summary>Global Mix value</summary>
+            <description />
+        </key>
+        
         <!-- ****** MISC / DIALOG ****** -->
 
         <!-- DEBUG -->

--- a/src/components/lockscreen.js
+++ b/src/components/lockscreen.js
@@ -30,12 +30,8 @@ var LockscreenBlur = class LockscreenBlur {
     }
 
     enable() {
+        
         this._log("blurring lockscreen");
-
-
-        log("fspadfdsf")
-        log(this.prefs.BLUE.get())
-
         this.update_lockscreen();
     }
 
@@ -87,7 +83,6 @@ var LockscreenBlur = class LockscreenBlur {
                 'blue': blue,
                 'blend' : blend,
             }));
-
         }
 
         widget.add_effect(new Shell.BlurEffect({ name: "blur" }));

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -207,9 +207,7 @@ var OverviewBlur = class OverviewBlur {
     }
 
     set_color(red, green, blue) {
-
         this.update_backgrounds();
-
     }
 
     disable() {

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -7,6 +7,8 @@ const { WorkspaceAnimationController } = imports.ui.workspaceAnimation;
 const wac_proto = WorkspaceAnimationController.prototype;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const ColorEffect = Me.imports.conveniences.color_effect.ColorEffect;
+
 
 
 var OverviewBlur = class OverviewBlur {
@@ -146,6 +148,17 @@ var OverviewBlur = class OverviewBlur {
                 : this.prefs.SIGMA.get(),
             mode: Shell.BlurMode.ACTOR
         });
+        
+        if(this.prefs.COLOR_BLUR.get()) {
+
+            let color_effect = new ColorEffect({
+                'red' : this.prefs.RED.get(), 
+                'green' : this.prefs.GREEN.get(), 
+                'blue' : this.prefs.BLUE.get(),
+                'blend' : this.prefs.BLEND.get(),
+            });
+            bg_actor.add_effect(color_effect);
+        }
 
         bg_actor.add_effect(effect);
         this.effects.push(effect);
@@ -191,6 +204,12 @@ var OverviewBlur = class OverviewBlur {
         this.effects.forEach(effect => {
             effect.brightness = b;
         });
+    }
+
+    set_color(red, green, blue) {
+
+        this.update_backgrounds();
+
     }
 
     disable() {

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -8,6 +8,7 @@ const backgroundSettings = new Gio.Settings({
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const PaintSignals = Me.imports.conveniences.paint_signals;
+const ColorEffect = Me.imports.conveniences.color_effect.ColorEffect;
 
 var PanelBlur = class PanelBlur {
     constructor(connections, prefs) {
@@ -112,6 +113,16 @@ var PanelBlur = class PanelBlur {
                 height: Main.panel.height,
             });
         this.effect.set_mode(is_static ? 0 : 1);
+
+        if (this.prefs.COLOR_BLUR.get()) {
+            this.background.add_effect(new ColorEffect({
+                'red': this.prefs.RED.get(),
+                'green': this.prefs.GREEN.get(),
+                'blue': this.prefs.BLUE.get(),
+                'blend' : this.prefs.BLEND.get(),
+            }));
+        }
+
         this.background.add_effect(this.effect);
         this.background_parent.add_child(this.background);
 
@@ -253,6 +264,12 @@ var PanelBlur = class PanelBlur {
 
     set_brightness(b) {
         this.effect.brightness = b;
+    }
+
+    set_color(red, blue, green) {
+
+        this.change_blur_type();
+
     }
 
     disable() {

--- a/src/components/screenshot.js
+++ b/src/components/screenshot.js
@@ -4,6 +4,8 @@ const { Shell, Gio, Meta } = imports.gi;
 const Main = imports.ui.main;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const ColorEffect = Me.imports.conveniences.color_effect.ColorEffect
+
 
 
 var ScreenshotBlur = class ScreenshotBlur {
@@ -82,6 +84,16 @@ var ScreenshotBlur = class ScreenshotBlur {
                 : this.prefs.SIGMA.get(),
             mode: Shell.BlurMode.ACTOR
         });
+
+        if(this.prefs.COLOR_BLUR.get()) {
+
+            bg_actor.add_effect(new ColorEffect({
+                'red': this.prefs.RED.get(),
+                'green': this.prefs.GREEN.get(),
+                'blue': this.prefs.BLUE.get(),
+                'blend' : this.prefs.BLEND.get(),
+            }))
+        }
 
         bg_actor.add_effect(effect);
         this.effects.push(effect);

--- a/src/conveniences/color_effect.js
+++ b/src/conveniences/color_effect.js
@@ -1,0 +1,157 @@
+const { GLib, GObject, Gio, Clutter } = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+const Me = ExtensionUtils.getCurrentExtension();
+const { Prefs } = Me.imports.conveniences.settings;
+const { Keys } = Me.imports.conveniences.keys;
+
+const Preferences = new Prefs(Keys);
+
+// new Clutter Shader Effect that simply mixes a color in, The class applies the GLSL shader programmed into
+// vfunc_get_static_shader_source and applies it to an Actor
+// 
+// Clutter Shader Source Code https://github.com/GNOME/clutter/blob/master/clutter/clutter-shader-effect.c
+// GJS Doc https://gjs-docs.gnome.org/clutter10~10_api/clutter.shadereffect
+
+var ColorEffect = new GObject.registerClass({
+  GTypeName: "Color_Effect",
+  Properties: {
+    'red' : GObject.ParamSpec.double(
+      `red`,
+      `red`,
+      `Red value in shader`,
+      GObject.ParamFlags.READWRITE,
+      0.0,
+      1.0,
+      0.4,
+    ),
+    'green' : GObject.ParamSpec.double(
+      `green`,
+      `green`,
+      `Green value in shader`,
+      GObject.ParamFlags.READWRITE,
+      0.0,
+      1.0,
+      0.4,
+    ),
+    'blue' : GObject.ParamSpec.double(
+      `blue`,
+      `blue`,
+      `Blue value in shader`,
+      GObject.ParamFlags.READWRITE,
+      0.0,
+      1.0,
+      0.4,
+    ),
+    'blend' : GObject.ParamSpec.double(
+      `blend`,
+      `blend`,
+      `Blend value in shader`,
+      GObject.ParamFlags.READWRITE,
+      0.0,
+      1.0,
+      0.4,
+    ),
+  }
+
+}, class ColorShader extends Clutter.ShaderEffect {
+
+  _init(params = {}) {
+
+
+    super._init(params);
+
+    this.set_shader_source(`
+
+    uniform sampler2D tex;
+  
+    void main() {
+      vec4 c = texture2D(tex, cogl_tex_coord_in[0].st);
+      vec3 color = vec3(c.x,c.y,c.z);
+  
+      vec3 red = vec3(` + this.red + "," + this.green + "," + this.blue + `);
+  
+     cogl_color_out = vec4(mix(color, red,` + this.blend + `),1.0);
+    }
+  `);
+
+  }
+
+  get red() {
+
+    if (this._red === undefined)
+      this._red = null;
+
+    return this._red;
+  }
+
+  set red(value) {
+
+    if (this._red !== value) {
+      this._red = value;
+
+      this.notify('red');
+    }
+  }
+
+  get green() {
+
+    if (this._green === undefined)
+      this._green = null;
+
+    return this._green;
+  }
+
+  set green(value) {
+
+    if (this._green !== value) {
+      this._green = value;
+
+      this.notify('green');
+    }
+  }
+
+  get blue() {
+
+    if (this._blue === undefined)
+      this._blue = null;
+
+    return this._blue;
+  }
+
+  set blue(value) {
+
+    if (this._blue !== value) {
+      this._blue = value;
+
+      this.notify('blue');
+    }
+  }
+
+  get blend() {
+
+    if (this._blend === undefined)
+      this._blend = null;
+
+    return this._blend;
+  }
+
+  set blend(value) {
+
+    if (this._blend !== value) {
+      this._blend = value;
+
+      this.notify('blend');
+    }
+  }
+
+
+  vfunc_paint_target(paint_node = null, paint_context = null) {
+    this.set_uniform_value("tex", 0);
+
+    if (paint_node && paint_context)
+      super.vfunc_paint_target(paint_node, paint_context);
+    else if (paint_node) super.vfunc_paint_target(paint_node);
+    else super.vfunc_paint_target();
+  }
+})

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -59,6 +59,12 @@ var Keys = [
     { type: Type.I, name: "screenshot-sigma" },
     { type: Type.D, name: "screenshot-brightness" },
 
+    { type: Type.B, name: "color-blur"},
+    { type: Type.D, name: "red" },
+    { type: Type.D, name: "green" },
+    { type: Type.D, name: "blue" },
+    { type: Type.D, name: "blend" },
+
     { type: Type.B, name: "hidetopbar-compatibility" },
 
     { type: Type.B, name: "debug" },

--- a/src/extension.js
+++ b/src/extension.js
@@ -194,7 +194,6 @@ class Extension {
         // global blur values changed, update everybody
 
         this._prefs.SIGMA.changed(() => {
-            log('h')
             this._update_sigma();
         });
         this._prefs.BRIGHTNESS.changed(() => {

--- a/src/extension.js
+++ b/src/extension.js
@@ -25,6 +25,10 @@ const INDEPENDENT_COMPONENTS = [
     "lockscreen", "window_list", "screenshot"
 ];
 
+const COLORED_COMPONENTS = [
+    "overview", "panel"
+]
+
 
 /// The main extension class, created when the GNOME Shell is loaded.
 class Extension {
@@ -190,6 +194,7 @@ class Extension {
         // global blur values changed, update everybody
 
         this._prefs.SIGMA.changed(() => {
+            log('h')
             this._update_sigma();
         });
         this._prefs.BRIGHTNESS.changed(() => {
@@ -356,6 +361,35 @@ class Extension {
                 this._screenshot_blur.disable();
             }
         });
+
+       
+
+        // ---------- COLOR ----------
+
+        this._prefs.RED.changed(() => {
+
+            this._update_color();
+        });
+
+        this._prefs.BLUE.changed(() => {
+
+            this._update_color();
+        });
+
+        this._prefs.GREEN.changed(() => {
+
+            this._update_color();
+        });
+
+        this._prefs.COLOR_BLUR.changed(() => {
+
+            this._update_color();
+        })
+
+        this._prefs.BLEND.changed(() => {
+
+            this._update_color();
+        })
     }
 
     /// Select the component by its name and connect it to its preferences
@@ -373,7 +407,7 @@ class Extension {
             component_brightness = this._prefs[accessible_name + '_BRIGHTNESS'],
             component = this['_' + name + '_blur'],
             general_sigma = this._prefs.SIGMA,
-            general_brightness = this._prefs.BRIGHTNESS;
+            general_brightness = this._prefs.BRIGHTNESS
 
         // general values switch is toggled
 
@@ -425,6 +459,18 @@ class Extension {
         });
     }
 
+    // Update the Color
+    _update_color() {
+
+        let red = this._prefs.RED.get();
+        let green = this._prefs.GREEN.get();
+        let blue = this._prefs.BLUE.get();
+
+        COLORED_COMPONENTS.forEach(component => {
+            this._change_color_for(component, red, green, blue);
+        });
+    }
+    
     /// Update sigma for a given component
     _change_sigma_for(name, general_sigma) {
         const accessible_name = name.toUpperCase();
@@ -459,6 +505,18 @@ class Extension {
             component.set_brightness(component_brightness.get());
         else
             component.set_brightness(general_brightness.get());
+    }
+
+    _change_color_for(name, red, green, blue) {
+        const accessible_name = name.toUpperCase();
+
+        
+        let customize = this._prefs[accessible_name + '_CUSTOMIZE'],
+            component_sigma = this._prefs[accessible_name + '_SIGMA'],
+            component = this['_' + name + '_blur'];
+
+        component.set_color(red,green,blue);
+
     }
 
     _log(str) {

--- a/src/preferences/color_effect.js
+++ b/src/preferences/color_effect.js
@@ -1,36 +1,3 @@
-//'use strict';
-//
-//const { Adw, GLib, GObject, Gio } = imports.gi;
-//const ExtensionUtils = imports.misc.extensionUtils;
-//
-//const Me = ExtensionUtils.getCurrentExtension();
-//const { Prefs } = Me.imports.conveniences.settings;
-//const { Keys } = Me.imports.conveniences.keys;
-//
-//const Preferences = new Prefs(Keys);
-//
-//
-//var ColorBlur = GObject.registerClass({
-//    GTypeName: 'ColorBlur',
-//    Template: `file://${GLib.build_filenamev([Me.path, 'ui', 'colorblur.ui'])}`,
-//    InternalChildren: [
-//        'color-blur-toggle',
-//        'red',
-//        'green',
-//        'blue',
-//    ],
-//}, class ColorBlur extends Adw.PreferencesPage {
-//    constructor(props = {}) {
-//        super(props);
-//
-//        //Preferences.settings.bind('color-blur-toggle', this._color_blur, 'state', Gio.SettingsBindFlags.DEFAULT);
-//
-//        Preferences.settings.bind('red', this.red, 'value', Gio.SettingsBindFlags.DEFAULT);
-//        //Preferences.settings.bind('green', this.green, 'value', Gio.SettingsBindFlags.DEFAULT);
-//        //Preferences.settings.bind('blue', this.blue, 'value', Gio.SettingsBindFlags.DEFAULT);
-//    }
-//});
-
 'use strict';
 
 const { Adw, GLib, GObject, Gio } = imports.gi;

--- a/src/preferences/color_effect.js
+++ b/src/preferences/color_effect.js
@@ -1,0 +1,67 @@
+//'use strict';
+//
+//const { Adw, GLib, GObject, Gio } = imports.gi;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//
+//const Me = ExtensionUtils.getCurrentExtension();
+//const { Prefs } = Me.imports.conveniences.settings;
+//const { Keys } = Me.imports.conveniences.keys;
+//
+//const Preferences = new Prefs(Keys);
+//
+//
+//var ColorBlur = GObject.registerClass({
+//    GTypeName: 'ColorBlur',
+//    Template: `file://${GLib.build_filenamev([Me.path, 'ui', 'colorblur.ui'])}`,
+//    InternalChildren: [
+//        'color-blur-toggle',
+//        'red',
+//        'green',
+//        'blue',
+//    ],
+//}, class ColorBlur extends Adw.PreferencesPage {
+//    constructor(props = {}) {
+//        super(props);
+//
+//        //Preferences.settings.bind('color-blur-toggle', this._color_blur, 'state', Gio.SettingsBindFlags.DEFAULT);
+//
+//        Preferences.settings.bind('red', this.red, 'value', Gio.SettingsBindFlags.DEFAULT);
+//        //Preferences.settings.bind('green', this.green, 'value', Gio.SettingsBindFlags.DEFAULT);
+//        //Preferences.settings.bind('blue', this.blue, 'value', Gio.SettingsBindFlags.DEFAULT);
+//    }
+//});
+
+'use strict';
+
+const { Adw, GLib, GObject, Gio } = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+const Me = ExtensionUtils.getCurrentExtension();
+const { Prefs } = Me.imports.conveniences.settings;
+const { Keys } = Me.imports.conveniences.keys;
+
+const Preferences = new Prefs(Keys);
+
+
+var ColorEffect = GObject.registerClass({
+    GTypeName: 'Color_Effect',
+    Template: `file://${GLib.build_filenamev([Me.path, 'ui', 'coloreffect.ui'])}`,
+    InternalChildren: [
+        'color_blur',
+        'red',
+        'green',
+        'blue',
+        'blend',
+    ],
+}, class ColorEffect extends Adw.PreferencesPage {
+    constructor(props = {}) {
+        super(props);
+
+        Preferences.settings.bind('color-blur', this._color_blur, 'state', Gio.SettingsBindFlags.DEFAULT)
+        Preferences.settings.bind('blend', this._blend, 'value', Gio.SettingsBindFlags.DEFAULT);
+        Preferences.settings.bind('red', this._red, 'value', Gio.SettingsBindFlags.DEFAULT);
+        Preferences.settings.bind('green', this._green, 'value', Gio.SettingsBindFlags.DEFAULT);
+        Preferences.settings.bind('blue', this._blue, 'value', Gio.SettingsBindFlags.DEFAULT);
+       
+    }
+});

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -14,6 +14,7 @@ const { Panel } = Me.imports.preferences.panel;
 const { Overview } = Me.imports.preferences.overview;
 const { Dash } = Me.imports.preferences.dash;
 const { Applications } = Me.imports.preferences.applications;
+const { ColorEffect } = Me.imports.preferences.color_effect;
 const { Other } = Me.imports.preferences.other;
 
 
@@ -31,6 +32,7 @@ function fillPreferencesWindow(window) {
     window.add(new Dash);
     window.add(new Applications);
     window.add(new Other);
+    window.add(new ColorEffect);
 
     window.search_enabled = true;
     window.set_default_size(680, 450);


### PR DESCRIPTION
So currently the extension kinda overrides shell themes with the blur, and if you try to make the overview background and other components transparent in the theme it leads to alot of bugs (especially the overview background), So I made a patch blends a color into some of the blurred components.

It uses the Clutter.ShaderEffect which allows us to apply any glsl shader to clutter actors, the glsl shader can only be compiled once per ShaderEffect , you need to create a new shadereffect if you want to change the effect so I had to implement it for certain objects differently than the blur effect.

Since gnome does not really support theming I understand though if wan't to keep your extension closer to a "vanilla" gnome experience (with blur!)

This was my first time with gnome extensions so if I made any really dumb mistakes feedback is appreciated. 

![image](https://user-images.githubusercontent.com/68133163/166065001-e79d71f8-6d7b-4a66-ae80-9cca15f43931.png)

![image](https://user-images.githubusercontent.com/68133163/166089763-40bf06e7-87bb-4c1e-962b-2a5966b55da1.png)

![image](https://user-images.githubusercontent.com/68133163/166065184-90607b22-22be-4b27-97ad-5667d9b84f8e.png)

![image](https://user-images.githubusercontent.com/68133163/166068464-a164ccba-e61d-4a3c-99df-aa13d4a4f1d8.png)

