### PR TITLE
Update the blur when wm-class is changed

### DIFF
--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -106,18 +106,20 @@ var ApplicationsBlur = class ApplicationsBlur {
             this.window_map.delete(pid);
         });
 
-        // update the blur when the mutter-hint is changed
-        this.connections.connect(
-            meta_window,
-            'notify::mutter-hints',
-            _ => {
-                let pid = meta_window.blur_provider_pid;
-                this._log(`mutter-hint changed for pid ${pid}`);
+        // update the blur when mutter-hint or wm-class is changed
+        for (const prop of ['mutter-hints', 'wm-class']) {
+            this.connections.connect(
+                meta_window,
+                `notify::${prop}`,
+                _ => {
+                    let pid = meta_window.blur_provider_pid;
+                    this._log(`${prop} changed for pid ${pid}`);
 
-                let window_actor = meta_window.get_compositor_private();
-                this.check_blur(pid, window_actor, meta_window);
-            }
-        );
+                    let window_actor = meta_window.get_compositor_private();
+                    this.check_blur(pid, window_actor, meta_window);
+                }
+            );
+        }
 
         this.check_blur(pid, window_actor, meta_window);
     }


### PR DESCRIPTION
Some whitelisted programs (for example `xfce4-terminal` and `emacs`) have their windows blurred when the extension is first activated, but new windows are not blurred. I think this is because they set their wm-class after creating the window.

Steps to reproduce:
* Disable Blur my Shell extension
* Enable application blur and add `xfce4-terminal` to whitelist
* Open `xfce4-terminal`.
* Enable Blur my Shell
* Now `xfce4-terminal` should have a blur behind it
* Close and reopen `xfce4-terminal`
* The new window has no blur

This PR fixes this by watching for wm-class changes.

One problem that I haven't figured out is the blur rectangle is too large. Here's a screenshot showing this.

![image](https://user-images.githubusercontent.com/7348004/166896185-a88febe1-1219-4f54-ad1c-5c1890f167db.png)

This problem also only happens for new windows. If a window is already open when Blur my Shell is enabled, the blur is the right size. Any idea what this could be?
