### PR TITLE
A corner effect, working... when no blur is used.

### DIFF
--- a/src/effects/color_effect.js
+++ b/src/effects/color_effect.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { GLib, GObject, Gio, Clutter, Shell } = imports.gi;
+const { GLib, GObject, Clutter, Shell } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 const Me = ExtensionUtils.getCurrentExtension();

--- a/src/effects/corner_effect.glsl
+++ b/src/effects/corner_effect.glsl
@@ -1,0 +1,42 @@
+uniform sampler2D tex;
+
+uniform float width;
+uniform float height;
+uniform float radius = 10;
+
+vec2 pixel_coord = cogl_tex_coord_in[0].xy;
+vec2 uv = pixel_coord * vec2(width, height);
+
+bool is_corner_to(float x, float y) {
+    return distance(uv, vec2(x, y)) > radius;
+}
+
+void main() {
+    vec4 pixel_color = texture2D(tex, pixel_coord);
+    float opacity = 1.;
+
+    // check if in the corners, and exclude the included circle
+    if(uv.x <= radius && uv.y <= radius) {
+        // top left
+        if(is_corner_to(radius, radius)) {
+            opacity = 0.;
+        }
+    } else if(uv.x >= width - radius && uv.y <= radius) {
+        // top right
+        if(is_corner_to(width - radius, radius)) {
+            opacity = 0.;
+        }
+    } else if(uv.x <= radius && uv.y >= height - radius) {
+        // bottom left
+        if(is_corner_to(radius, height - radius)) {
+            opacity = 0.;
+        }
+    } else if(uv.x >= width - radius && uv.y >= height - radius) {
+        // bottom right
+        if(is_corner_to(width - radius, height - radius)) {
+            opacity = 0.;
+        }
+    }
+
+    cogl_color_out = vec4(pixel_color * opacity);
+}

--- a/src/effects/corner_effect.js
+++ b/src/effects/corner_effect.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { GLib, GObject, Clutter, Shell } = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+const Me = ExtensionUtils.getCurrentExtension();
+
+
+const SHADER_PATH = GLib.build_filenamev(
+    [Me.path, 'effects', 'corner_effect.glsl']
+);
+
+const get_shader_source = _ => {
+    try {
+        return Shell.get_file_contents_utf8_sync(SHADER_PATH);
+    } catch (e) {
+        log(`[Blur my Shell] error loading shader from ${SHADER_PATH}: ${e}`);
+        return null;
+    }
+};
+
+var test = () => {
+    let w = new imports.gi.St.Widget({
+        width: 150,
+        height: 150,
+        x: 150,
+        y: 150
+    });
+    global.w = w;
+    w.style = "background-color:red;";
+
+    imports.ui.main.uiGroup.add_child(w);
+
+    let e = new global.blur_my_shell.corner_effect;
+    e.set_uniform_value("width", 150.000001 / 2);
+    e.set_uniform_value("height", 150.000001 / 2);
+
+    w.add_effect(e);
+
+    global.e = e;
+};
+
+
+var CornerEffect = new GObject.registerClass({
+    GTypeName: "CornerEffect",
+}, class CornerShader extends Clutter.ShaderEffect {
+    _init(params) {
+        super._init(params);
+        this._source = get_shader_source();
+
+        if (this._source)
+            this.set_shader_source(this._source);
+    }
+
+
+    vfunc_paint_target(paint_node = null, paint_context = null) {
+        this.set_uniform_value("tex", 0);
+
+        if (paint_node && paint_context)
+            super.vfunc_paint_target(paint_node, paint_context);
+        else if (paint_node)
+            super.vfunc_paint_target(paint_node);
+        else
+            super.vfunc_paint_target();
+    }
+});

--- a/src/effects/noise_effect.js
+++ b/src/effects/noise_effect.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { GLib, GObject, Gio, Clutter, Shell } = imports.gi;
+const { GLib, GObject, Clutter, Shell } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 const Me = ExtensionUtils.getCurrentExtension();

--- a/src/extension.js
+++ b/src/extension.js
@@ -28,7 +28,10 @@ const INDEPENDENT_COMPONENTS = [
 
 /// The main extension class, created when the GNOME Shell is loaded.
 class Extension {
-    constructor() { }
+    constructor() {
+        this.c = Me.imports.effects.corner_effect;
+        this.corner_effect = this.c.CornerEffect;
+    }
 
     /// Enables the extension
     enable() {


### PR DESCRIPTION
The effect kinda works, but can't be used in conjunction to `Shell.BlurEffect`. This was the goal, obviously.

Next steps:
1. create a custom glsl effect for a gaussian blur effect -- or kawase, of fast blur, or anything that is good looking and fast enough (if anybody wants to provide something, I'm very very open...)
  - OR just get [the original from the horn of plenty GNOME shell code](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/src/shell-blur-effect.c), although I don't understand it... how is it not GLSL?
  - OR use and modify [the original blyr effect](https://github.com/yozoon/gnome-shell-extension-blyr/blob/master/blyr%40yozoon.dev.gmail.com/shader.glsl), if @yozoon is okay with that (at least I understand the code :p)
3. integrate it with the corners effect (which is kinda simple, just checking if the pixel is or not in the corner with the type of conditions I put here, and here we go)
4. integrate the noise and color effect with it (which would really be easy I guess)
5. change the way the extension asks for blur, to use this effect instead of `Shell.BlurEffect`

If done well, this could be approximately as fast as the default `Shell.BlurEffect`, or faster if the other effects are used with it, as it would not need to mix different effects.

However, this very probably won't work for any kind or dynamic blur, but at this point I'm not even asking for this... especially if #170 can be finally finished, as nearly all the important parts of the shell would then be appropriately blurred.