### PR TITLE
feat: disable panel blur when window is close to panel

### DIFF
--- a/resources/ui/panel.ui
+++ b/resources/ui/panel.ui
@@ -50,6 +50,21 @@
             </child>
           </object>
         </child>
+
+        <child>
+          <object class="AdwActionRow">
+            <property name="title" translatable="yes">Disable in fullscreen</property>
+            <property name="subtitle" translatable="yes">Disables the blur from the panel when a window is near it.</property>
+            <property name="activatable-widget">unblur_in_fullscreen</property>
+            <property name="sensitive" bind-source="blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkSwitch" id="unblur_in_fullscreen">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
 

--- a/resources/ui/panel.ui
+++ b/resources/ui/panel.ui
@@ -53,13 +53,13 @@
 
         <child>
           <object class="AdwActionRow">
-            <property name="title" translatable="yes">Disable in fullscreen</property>
+            <property name="title" translatable="yes">Disable when a window is near</property>
             <property name="subtitle" translatable="yes">Disables the blur from the panel when a window is near it.</property>
-            <property name="activatable-widget">unblur_in_fullscreen</property>
+            <property name="activatable-widget">unblur_dynamically</property>
             <property name="sensitive" bind-source="blur" bind-property="state" bind-flags="sync-create" />
 
             <child>
-              <object class="GtkSwitch" id="unblur_in_fullscreen">
+              <object class="GtkSwitch" id="unblur_dynamically">
                 <property name="valign">center</property>
               </object>
             </child>

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -189,8 +189,8 @@
             <default>true</default>
             <summary>Boolean, whether to disable blur from this component when opening the overview or not</summary>
         </key>
-        <!-- UNBLUR IN FULLSCREEN -->
-        <key type="b" name="unblur-in-fullscreen">
+        <!-- UNBLUR DYNAMICALLY -->
+        <key type="b" name="unblur-dynamically">
             <default>false</default>
             <summary>Boolean, whether to disable blur from this component when a window is close to the panel</summary>
         </key>

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -189,6 +189,11 @@
             <default>true</default>
             <summary>Boolean, whether to disable blur from this component when opening the overview or not</summary>
         </key>
+        <!-- UNBLUR IN FULLSCREEN -->
+        <key type="b" name="unblur-in-fullscreen">
+            <default>false</default>
+            <summary>Boolean, whether to disable blur from this component when a window is close to the panel</summary>
+        </key>
     </schema>
 
     <!-- DASH TO DOCK -->

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -13,6 +13,8 @@ const NoiseEffect = Me.imports.effects.noise_effect.NoiseEffect;
 
 var PanelBlur = class PanelBlur {
     constructor(connections, prefs) {
+        this._actorSignalIds = new Map();
+        this._windowSignalIds = new Map();
         this.connections = connections;
         this.paint_signals = new PaintSignals.PaintSignals(connections);
         this.prefs = prefs;
@@ -76,7 +78,7 @@ var PanelBlur = class PanelBlur {
         panel_box.insert_child_at_index(this.background_parent, 0);
 
         // remove panel background colour
-        Main.panel.add_style_class_name('transparent-panel');
+        this.connect_to_fullscreen();
 
         // perform updates
         this.change_blur_type();
@@ -276,6 +278,51 @@ var PanelBlur = class PanelBlur {
         }
     }
 
+    connect_to_fullscreen() {
+        if (
+            this.prefs.panel.BLUR &&
+            this.prefs.panel.UNBLUR_IN_FULLSCREEN
+        ) {
+            this._actorSignalIds = new Map();
+            this._windowSignalIds = new Map();
+            this._actorSignalIds.set(Main.overview, [
+                Main.overview.connect('showing', this._updateTransparent.bind(this)),
+                Main.overview.connect('hiding', this._updateTransparent.bind(this))
+            ]);
+
+            this._actorSignalIds.set(Main.sessionMode, [
+                Main.sessionMode.connect('updated', this._updateTransparent.bind(this))
+            ]);
+
+            for (const metaWindowActor of global.get_window_actors()) {
+                this._onWindowActorAdded(metaWindowActor.get_parent(), metaWindowActor);
+            }
+
+            this._actorSignalIds.set(global.window_group, [
+                global.window_group.connect('actor-added', this._onWindowActorAdded.bind(this)),
+                global.window_group.connect('actor-removed', this._onWindowActorRemoved.bind(this))
+            ]);
+
+            this._actorSignalIds.set(global.window_manager, [
+                global.window_manager.connect('switch-workspace', this._updateTransparent.bind(this))
+            ]);
+
+            this._updateTransparent();
+        } else {
+            for (const actorSignalIds of [this._actorSignalIds, this._windowSignalIds]) {
+                for (const [actor, signalIds] of actorSignalIds) {
+                    for (const signalId of signalIds) {
+                        actor.disconnect(signalId);
+                    }
+                }
+            }
+            this._actorSignalIds = new Map();
+            this._windowSignalIds = new Map();
+
+            Main.panel.add_style_class_name('transparent-panel');
+        }
+    }
+
     /// Fixes a bug where the blur is washed away when changing the sigma, or
     /// enabling/disabling other effects.
     invalidate_blur() {
@@ -307,6 +354,16 @@ var PanelBlur = class PanelBlur {
 
     disable() {
         this._log("removing blur from top panel");
+        for (const actorSignalIds of [this._actorSignalIds, this._windowSignalIds]) {
+            for (const [actor, signalIds] of actorSignalIds) {
+                for (const signalId of signalIds) {
+                    actor.disconnect(signalId);
+                }
+            }
+        }
+        this._actorSignalIds = new Map();
+        this._windowSignalIds = new Map();
+
         Main.panel.remove_style_class_name('transparent-panel');
 
         try {
@@ -324,6 +381,61 @@ var PanelBlur = class PanelBlur {
 
     hide() {
         this.background_parent.hide();
+    }
+
+    _onWindowActorAdded(container, metaWindowActor) {
+        this._windowSignalIds.set(metaWindowActor, [
+            metaWindowActor.connect('notify::allocation', this._updateTransparent.bind(this)),
+            metaWindowActor.connect('notify::visible', this._updateTransparent.bind(this))
+        ]);
+    }
+
+    _onWindowActorRemoved(container, metaWindowActor) {
+        for (const signalId of this._windowSignalIds.get(metaWindowActor)) {
+            metaWindowActor.disconnect(signalId);
+        }
+        this._windowSignalIds.delete(metaWindowActor);
+        this._updateTransparent();
+    }
+
+    _updateTransparent() {
+        if (Main.panel.has_style_pseudo_class('overview') || !Main.sessionMode.hasWindows) {
+            this._setTransparent(true);
+            return;
+        }
+
+        if (!Main.layoutManager.primaryMonitor) {
+            return;
+        }
+
+        // Get all the windows in the active workspace that are in the primary monitor and visible.
+        const workspaceManager = global.workspace_manager;
+        const activeWorkspace = workspaceManager.get_active_workspace();
+        const windows = activeWorkspace.list_windows().filter(metaWindow => {
+            return metaWindow.is_on_primary_monitor()
+                    && metaWindow.showing_on_its_workspace()
+                    && !metaWindow.is_hidden()
+                    && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
+        });
+
+        // Check if at least one window is near enough to the panel.
+        const panelTop = Main.panel.get_transformed_position()[1];
+        const panelBottom = panelTop + Main.panel.get_height();
+        const scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+        const isNearEnough = windows.some(metaWindow => {
+            const verticalPosition = metaWindow.get_frame_rect().y;
+            return verticalPosition < panelBottom + 5 * scale;
+        });
+
+        this._setTransparent(!isNearEnough);
+    }
+
+    _setTransparent(transparent) {
+        if (transparent) {
+            Main.panel.add_style_class_name('transparent-panel');
+        } else {
+            Main.panel.remove_style_class_name('transparent-panel');
+        }
     }
 
     _log(str) {

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -278,6 +278,7 @@ var PanelBlur = class PanelBlur {
         }
     }
 
+    /// Connect to windows disable transparency when a window is too close
     connect_to_fullscreen() {
         if (
             this.prefs.panel.BLUR &&

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -55,6 +55,7 @@ var Keys = [
             { type: Type.S, name: "background-color" },
             { type: Type.B, name: "static-blur" },
             { type: Type.B, name: "unblur-in-overview" },
+            { type: Type.B, name: "unblur-in-fullscreen" },
         ]
     },
     {

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -55,7 +55,7 @@ var Keys = [
             { type: Type.S, name: "background-color" },
             { type: Type.B, name: "static-blur" },
             { type: Type.B, name: "unblur-in-overview" },
-            { type: Type.B, name: "unblur-in-fullscreen" },
+            { type: Type.B, name: "unblur-dynamically" },
         ]
     },
     {

--- a/src/extension.js
+++ b/src/extension.js
@@ -281,9 +281,10 @@ class Extension {
             this._panel_blur.connect_to_overview();
         });
 
-        // panel blur's overview connection toggled on/off
-        this._prefs.panel.UNBLUR_IN_FULLSCREEN_changed(() => {
-            this._panel_blur.connect_to_fullscreen();
+        // panel blur's dynamic unblurring toggled on/off
+        this._prefs.panel.UNBLUR_DYNAMICALLY_changed(() => {
+            if (this._prefs.panel.BLUR)
+                this._panel_blur.connect_to_windows();
         });
 
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -281,6 +281,11 @@ class Extension {
             this._panel_blur.connect_to_overview();
         });
 
+        // panel blur's overview connection toggled on/off
+        this._prefs.panel.UNBLUR_IN_FULLSCREEN_changed(() => {
+            this._panel_blur.connect_to_fullscreen();
+        });
+
 
         // ---------- DASH TO DOCK ----------
 

--- a/src/preferences/panel.js
+++ b/src/preferences/panel.js
@@ -18,7 +18,7 @@ var Panel = GObject.registerClass({
         'customize',
         'static_blur',
         'unblur_in_overview',
-        'unblur_in_fullscreen',
+        'unblur_dynamically',
         'hidetopbar_compatibility'
     ],
 }, class Panel extends Adw.PreferencesPage {
@@ -30,7 +30,7 @@ var Panel = GObject.registerClass({
         prefs_panel.bind('blur', this._blur, 'state', Gio.SettingsBindFlags.DEFAULT);
         prefs_panel.bind('static-blur', this._static_blur, 'state', Gio.SettingsBindFlags.DEFAULT);
         prefs_panel.bind('unblur-in-overview', this._unblur_in_overview, 'state', Gio.SettingsBindFlags.DEFAULT);
-        prefs_panel.bind('unblur-in-fullscreen', this._unblur_in_fullscreen, 'state', Gio.SettingsBindFlags.DEFAULT);
+        prefs_panel.bind('unblur-dynamically', this._unblur_dynamically, 'state', Gio.SettingsBindFlags.DEFAULT);
         this._customize.connect_to(Preferences.panel, this._static_blur);
 
         const prefs_hidetopbar = Preferences.hidetopbar.settings;

--- a/src/preferences/panel.js
+++ b/src/preferences/panel.js
@@ -18,6 +18,7 @@ var Panel = GObject.registerClass({
         'customize',
         'static_blur',
         'unblur_in_overview',
+        'unblur_in_fullscreen',
         'hidetopbar_compatibility'
     ],
 }, class Panel extends Adw.PreferencesPage {
@@ -29,6 +30,7 @@ var Panel = GObject.registerClass({
         prefs_panel.bind('blur', this._blur, 'state', Gio.SettingsBindFlags.DEFAULT);
         prefs_panel.bind('static-blur', this._static_blur, 'state', Gio.SettingsBindFlags.DEFAULT);
         prefs_panel.bind('unblur-in-overview', this._unblur_in_overview, 'state', Gio.SettingsBindFlags.DEFAULT);
+        prefs_panel.bind('unblur-in-fullscreen', this._unblur_in_fullscreen, 'state', Gio.SettingsBindFlags.DEFAULT);
         this._customize.connect_to(Preferences.panel, this._static_blur);
 
         const prefs_hidetopbar = Preferences.hidetopbar.settings;


### PR DESCRIPTION
Closes #239

This feature tracks all windows and whenever one of them is near the panel, the transparency is removed.

Thanks for your great work, love the project!
If there is anything that needs change, feel free to let me know.