### PR TITLE
Fix applications service error

### DIFF
--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -411,7 +411,7 @@ var ApplicationsBlur = class ApplicationsBlur {
     disable() {
         this._log("removing blur from applications...");
 
-        this.service.unexport();
+        this.service?.unexport();
 
         this.blur_actor_map.forEach(((_blur_actor, pid) => {
             this.remove_blur(pid);


### PR DESCRIPTION
The service will be undefined when user don't use application blur.

Since `?.` is supported in 40 and higher, we can use that to avoid calling undefined properties.

Related to #312 