### PR TITLE
Update shell versions to support Gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "description": "Adds a blur look to different parts of the GNOME Shell, including the top panel, dash and overview.\n\nYou can support my work by sponsoring me on:\n- github: https://github.com/sponsors/aunetx\n- ko-fi: https://ko-fi.com/aunetx\n\nNote: if the extension shows an error after updating, please make sure to restart your session to see if it persists. This is due to a bug in gnome shell, which I can't fix by myself.",
     "name": "Blur my Shell",
     "shell-version": [
-        "42"
+        "42",
+        "43"
     ],
     "url": "https://github.com/aunetx/gnome-shell-extension-blur-my-shell",
     "uuid": "blur-my-shell@aunetx",


### PR DESCRIPTION
Basically I'm just bumping the metadata.json to support the Gnome 43. I'm currently using the extension on Fedora 37 Beta and it is working just fine for a few days, so I thought that it was stable enough to be on master. Even more now that Gnome 43 was officially released.

Image 1: Running on Fedora 37 Beta with Gnome 43
![Screenshot from 2022-09-22 09-35-30](https://user-images.githubusercontent.com/51462138/191748441-558027e1-f2fa-4bb7-8077-c28c4ecece36.png)

