### PR TITLE
add gnome shell version 44 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
     "name": "Blur my Shell",
     "shell-version": [
         "42",
-        "43"
+        "43",
+        "44"
     ],
     "url": "https://github.com/aunetx/gnome-shell-extension-blur-my-shell",
     "uuid": "blur-my-shell@aunetx",


### PR DESCRIPTION
Just a metadata change made it work for me.

## Screenshots
![Screenshot from 2023-03-22 15-02-43](https://user-images.githubusercontent.com/54083498/226826573-30bc3d91-1048-4766-ba61-95517fb36c2d.png)
![Screenshot from 2023-03-22 15-02-38](https://user-images.githubusercontent.com/54083498/226826594-d3457b16-b8d1-458a-bf69-6bcfb1efc685.png)
![Screenshot from 2023-03-22 15-03-26](https://user-images.githubusercontent.com/54083498/226826601-5b678a84-39b2-4917-9da7-16e5a9ff563c.png)
