### PR TITLE
Filter MetaBackgroundActor

### DIFF
--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -168,7 +168,9 @@ var OverviewBlur = class OverviewBlur {
     create_background_actor(monitor) {
         let bg_actor = new Meta.BackgroundActor;
         let background = Main.layoutManager._backgroundGroup.get_child_at_index(
-            Main.layoutManager.monitors.length - monitor.index - 1
+            (Main.layoutManager.monitors.length - monitor.index - 1) *
+                (Main.layoutManager._backgroundGroup.get_children().length /
+                    Main.layoutManager.monitors.length)
         );
 
         if (!background) {

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -167,11 +167,13 @@ var OverviewBlur = class OverviewBlur {
 
     create_background_actor(monitor) {
         let bg_actor = new Meta.BackgroundActor;
-        let background = Main.layoutManager._backgroundGroup.get_child_at_index(
-            (Main.layoutManager.monitors.length - monitor.index - 1) *
-                (Main.layoutManager._backgroundGroup.get_children().length /
-                    Main.layoutManager.monitors.length)
-        );
+        let background_group = Main.layoutManager._backgroundGroup
+            .get_children()
+            .filter((child) => child instanceof Meta.BackgroundActor);
+        let background =
+            background_group[
+                Main.layoutManager.monitors.length - monitor.index - 1
+            ];
 
         if (!background) {
             this._log("could not get background for overview");


### PR DESCRIPTION
The extension is not blurring one of my monitor's overview when the "Draw On Your Screen 2" extension is active. The reason is that it is adding an element to ```Main.layoutManager._backgroundGroup``` for each monitor. 

When the "Draw On Your Screen 2" extension is not active.
```javascript
>>> Main.layoutManager._backgroundGroup.get_children()
r(0) = [0x5573703d46e0 MetaBackgroundActor],[0x5573703d43b0 MetaBackgroundActor]
```

When the "Draw On Your Screen 2" extension is active.
```javascript
>>> Main.layoutManager._backgroundGroup.get_children()
r(0) = [0x5573703d46e0 MetaBackgroundActor],[0x557371638fd0 draw-on-your-screen2_at_zhrexl_github_com-DrawingArea.draw-on-your-screen:insensitive "drawOnYourSreenArea1"],[0x5573703d43b0 MetaBackgroundActor],[0x557371608c20 draw-on-your-screen2_at_zhrexl_github_com-DrawingArea.draw-on-your-screen:insensitive "drawOnYourSreenArea0"]
```

I added a filter to filter out the "Draw On Your Screen 2" elements.