### PR TITLE
Fixed application blur with fractional scaling on wayland

### DIFF
--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -416,25 +416,15 @@ export const ApplicationsBlur = class ApplicationsBlur {
         });
     }
 
-    /// Compute the size and position for a blur actor.
-    /// On wayland, it seems like we need to divide by the scale to get the
-    /// correct result.
     compute_allocation(meta_window) {
-        const is_wayland = Meta.is_wayland_compositor();
-        const monitor_index = meta_window.get_monitor();
-        // check if the window is using wayland, or xwayland/xorg for rendering
-        const scale = is_wayland && meta_window.get_client_type() == 0
-            ? Main.layoutManager.monitors[monitor_index].geometry_scale
-            : 1;
-
         let frame = meta_window.get_frame_rect();
         let buffer = meta_window.get_buffer_rect();
 
         return {
-            x: (frame.x - buffer.x) / scale,
-            y: (frame.y - buffer.y) / scale,
-            width: frame.width / scale,
-            height: frame.height / scale
+            x: (frame.x - buffer.x),
+            y: (frame.y - buffer.y),
+            width: frame.width,
+            height: frame.height
         };
     }
 


### PR DESCRIPTION
Fixes #362 / #357 . Tested on GNOME 45 wayland session with scaling set to 150%