### PR TITLE
Fix #377

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,5 +15,9 @@
         "github": "aunetx",
         "kofi": "aunetx"
     },
+    "session-modes": [
+        "user", 
+        "unlock-dialog"
+    ],
     "version": 55
 }


### PR DESCRIPTION
This pull request adds the appropriate session-modes to `metadata.json` to keep the extension working after the system wakes up from a suspended state.

Adding `unlock-dialog` to the session-modes [should not affect the behavior of the extension while the user is logged in](https://gjs.guide/extensions/overview/anatomy.html#session-modes) and should therefore be safe to add.