### PR TITLE
Gnome 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "description": "Adds a blur look to different parts of the GNOME Shell, including the top panel, dash and overview.\n\nYou can support my work by sponsoring me on:\n- github: https://github.com/sponsors/aunetx\n- ko-fi: https://ko-fi.com/aunetx\n\nNote: if the extension shows an error after updating, please make sure to restart your session to see if it persists. This is due to a bug in gnome shell, which I can't fix by myself.",
     "name": "Blur my Shell",
     "shell-version": [
-        "45"
+        "46"
     ],
     "url": "https://github.com/aunetx/gnome-shell-extension-blur-my-shell",
     "uuid": "blur-my-shell@aunetx",

--- a/src/components/appfolders.js
+++ b/src/components/appfolders.js
@@ -37,7 +37,7 @@ let _zoomAndFadeIn = function () {
 
     let blur_effect = this.get_effect("appfolder-blur");
 
-    blur_effect.sigma = 0;
+    blur_effect.radius = 0;
     blur_effect.brightness = 1.0;
     Tweener.addTween(blur_effect,
         {
@@ -165,7 +165,7 @@ export const AppFoldersBlur = class AppFoldersBlur {
 
             let blur_effect = new Shell.BlurEffect({
                 name: "appfolder-blur",
-                sigma: sigma,
+                radius: sigma * 2,
                 brightness: brightness,
                 mode: Shell.BlurMode.BACKGROUND
             });

--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -324,7 +324,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
     /// Add the blur effect to the window.
     create_blur_effect(pid, window_actor, meta_window, brightness, sigma) {
         let blur_effect = new Shell.BlurEffect({
-            sigma: sigma,
+            radius: sigma * 2,
             brightness: brightness,
             mode: Shell.BlurMode.BACKGROUND
         });
@@ -465,7 +465,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
     /// Updates the blur effect by overwriting its sigma and brightness values.
     update_blur_effect(blur_actor, brightness, sigma) {
         let effect = blur_actor.get_effect('blur-effect');
-        effect.sigma = sigma;
+        effect.radius = sigma * 2;
         effect.brightness = brightness;
     }
 

--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -59,9 +59,8 @@ class DashInfos {
         dash_blur.connections.connect(dash_blur, 'update-sigma', () => {
             if (this.dash_blur.is_static) {
                 this.dash_blur.update_size();
-                this.effect.radius = 2 * this.dash_blur.sigma * this.effect.scale;
-            } else
-                this.effect.sigma = this.dash_blur.sigma * this.effect.scale;
+            }
+            this.effect.radius = 2 * this.dash_blur.sigma * this.effect.scale;
         });
 
         dash_blur.connections.connect(dash_blur, 'update-brightness', () => {
@@ -92,14 +91,14 @@ class DashInfos {
             if (this.dash_blur.is_static)
                 this.background_parent.show();
             else
-                this.effect.sigma = this.dash_blur.sigma * this.effect.scale;
+                this.effect.radius = this.dash_blur.sigma * 2 * this.effect.scale;
         });
 
         dash_blur.connections.connect(dash_blur, 'hide', () => {
             if (this.dash_blur.is_static)
                 this.background_parent.hide();
             else
-                this.effect.sigma = 0;
+                this.effect.radius = 0;
         });
 
         dash_blur.connections.connect(dash_blur, 'update-wallpaper', () => {
@@ -221,7 +220,7 @@ export const DashBlur = class DashBlur {
     }
 
     enable() {
-        this.connections.connect(Main.uiGroup, 'actor-added', (_, actor) => {
+        this.connections.connect(Main.uiGroup, 'child-added', (_, actor) => {
             if (
                 (actor.get_name() === "dashtodockContainer") &&
                 (actor.constructor.name === 'DashToDock')
@@ -375,7 +374,7 @@ export const DashBlur = class DashBlur {
         } else {
             effect = new Shell.BlurEffect({
                 brightness: this.brightness,
-                sigma: this.sigma * monitor.geometry_scale,
+                radius: this.sigma * 2 * monitor.geometry_scale,
                 mode: Shell.BlurMode.BACKGROUND
             });
 

--- a/src/components/lockscreen.js
+++ b/src/components/lockscreen.js
@@ -67,7 +67,7 @@ export const LockscreenBlur = class LockscreenBlur {
 
         let blur_effect = new Shell.BlurEffect({
             name: 'blur',
-            sigma: sigma,
+            radius: sigma * 2,
             brightness: brightness
         });
 
@@ -121,7 +121,7 @@ export const LockscreenBlur = class LockscreenBlur {
             if (blur_effect) {
                 blur_effect.set({
                     brightness: brightness,
-                    sigma: sigma * blur_effect.scale,
+                    radius: sigma * 2 * blur_effect.scale,
                 });
             }
         }

--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -185,9 +185,9 @@ export const OverviewBlur = class OverviewBlur {
             brightness: this.settings.overview.CUSTOMIZE
                 ? this.settings.overview.BRIGHTNESS
                 : this.settings.BRIGHTNESS,
-            sigma: (this.settings.overview.CUSTOMIZE
+            radius: (this.settings.overview.CUSTOMIZE
                 ? this.settings.overview.SIGMA
-                : this.settings.SIGMA) * monitor.geometry_scale,
+                : this.settings.SIGMA) * 2 * monitor.geometry_scale,
             mode: Shell.BlurMode.ACTOR
         });
 
@@ -235,7 +235,7 @@ export const OverviewBlur = class OverviewBlur {
 
     set_sigma(s) {
         this.effects.forEach(effect => {
-            effect.blur_effect.sigma = s * effect.blur_effect.scale;
+            effect.blur_effect.radius = s * 2 * effect.blur_effect.scale;
         });
     }
 

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -170,9 +170,9 @@ export const PanelBlur = class PanelBlur {
             brightness: this.settings.panel.CUSTOMIZE
                 ? this.settings.panel.BRIGHTNESS
                 : this.settings.BRIGHTNESS,
-            sigma: (this.settings.panel.CUSTOMIZE
+            radius: (this.settings.panel.CUSTOMIZE
                 ? this.settings.panel.SIGMA
-                : this.settings.SIGMA) * monitor.geometry_scale,
+                : this.settings.SIGMA) * 2 * monitor.geometry_scale,
             mode: this.settings.panel.STATIC_BLUR
                 ? Shell.BlurMode.ACTOR
                 : Shell.BlurMode.BACKGROUND
@@ -438,10 +438,10 @@ export const PanelBlur = class PanelBlur {
             }
 
             // manage windows at their creation/removal
-            this.connections.connect(global.window_group, 'actor-added',
+            this.connections.connect(global.window_group, 'child-added',
                 this.on_window_actor_added.bind(this)
             );
-            this.connections.connect(global.window_group, 'actor-removed',
+            this.connections.connect(global.window_group, 'child-removed',
                 this.on_window_actor_removed.bind(this)
             );
 
@@ -610,7 +610,7 @@ export const PanelBlur = class PanelBlur {
 
     set_sigma(s) {
         this.actors_list.forEach(actors => {
-            actors.effects.blur.sigma = s * actors.effects.blur.scale;
+            actors.effects.blur.radius = s * 2 * actors.effects.blur.scale;
             this.invalidate_blur(actors);
         });
     }

--- a/src/components/screenshot.js
+++ b/src/components/screenshot.js
@@ -82,9 +82,9 @@ export const ScreenshotBlur = class ScreenshotBlur {
             brightness: this.settings.screenshot.CUSTOMIZE
                 ? this.settings.screenshot.BRIGHTNESS
                 : this.settings.BRIGHTNESS,
-            sigma: (this.settings.screenshot.CUSTOMIZE
+            radius: (this.settings.screenshot.CUSTOMIZE
                 ? this.settings.screenshot.SIGMA
-                : this.settings.SIGMA) * monitor.geometry_scale,
+                : this.settings.SIGMA) * 2 * monitor.geometry_scale,
             mode: Shell.BlurMode.ACTOR
         });
 
@@ -116,7 +116,7 @@ export const ScreenshotBlur = class ScreenshotBlur {
 
     set_sigma(s) {
         this.effects.forEach(effect => {
-            effect.blur_effect.sigma = s * effect.blur_effect;
+            effect.blur_effect.radius = s * 2 * effect.blur_effect;
         });
     }
 

--- a/src/components/window_list.js
+++ b/src/components/window_list.js
@@ -24,7 +24,7 @@ export const WindowListBlur = class WindowListBlur {
         // if is window-list
         this.connections.connect(
             Main.layoutManager.uiGroup,
-            'actor-added',
+            'child-added',
             (_, child) => this.try_blur(child)
         );
 
@@ -46,9 +46,9 @@ export const WindowListBlur = class WindowListBlur {
 
             let blur_effect = new Shell.BlurEffect({
                 name: 'window-list-blur',
-                sigma: this.settings.window_list.CUSTOMIZE
-                    ? this.settings.window_list.SIGMA
-                    : this.settings.SIGMA,
+                radius: (this.settings.window_list.CUSTOMIZE
+                        ? this.settings.window_list.SIGMA
+                        : this.settings.SIGMA) * 2,
                 brightness: this.settings.window_list.CUSTOMIZE
                     ? this.settings.window_list.BRIGHTNESS
                     : this.settings.BRIGHTNESS,
@@ -65,7 +65,7 @@ export const WindowListBlur = class WindowListBlur {
 
             this.connections.connect(
                 child._windowList,
-                'actor-added',
+                'child-added',
                 (_, window) => this.blur_window_button(window)
             );
 
@@ -117,7 +117,7 @@ export const WindowListBlur = class WindowListBlur {
 
     set_sigma(s) {
         this.effects.forEach(effect => {
-            effect.blur_effect.sigma = s;
+            effect.blur_effect.radius = s * 2;
         });
     }
 


### PR DESCRIPTION
This applies @DaPigGuy's 2 patches to current master and bumps the shell-version, so all credits to him!

![Screenshot from 2024-03-24 12-00-38](https://github.com/aunetx/blur-my-shell/assets/5265345/fadb8a0a-3eb7-4f46-ab6a-b53afdb1f99a)

Arch just upgrade Gnome to 46 and this broke (among other things)

EDIT: Just noticed app folders are not blurred, probably still something missing.