### PR TITLE
Implement Monte Carlo blur

### DIFF
--- a/src/conveniences/blur_creator.js
+++ b/src/conveniences/blur_creator.js
@@ -3,6 +3,9 @@ import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Background from 'resource:///org/gnome/shell/ui/background.js';
 
+import { BlurEffect } from '../effects/blur_effect.js';
+import { MonteCarloBlurEffect } from '../effects/monte_carlo_blur.js';
+
 export const create_background = function (
     monitor_index,
     background_managers,
@@ -21,7 +24,7 @@ export const create_background = function (
         height: monitor.height
     });
 
-    let blur_effect = new Shell.BlurEffect({
+    /*let blur_effect = new BlurEffect({
         name: 'blur',
         brightness: local_settings.CUSTOMIZE
             ? local_settings.BRIGHTNESS
@@ -29,7 +32,20 @@ export const create_background = function (
         radius: (local_settings.CUSTOMIZE
             ? local_settings.SIGMA
             : global_settings.SIGMA) * 2 * monitor.geometry_scale,
-        mode: Shell.BlurMode.ACTOR
+        width: monitor.width,
+        height: monitor.height,
+        corner_radius: 0
+    });*/
+    let blur_effect = new MonteCarloBlurEffect({
+        name: 'blur',
+        brightness: local_settings.CUSTOMIZE
+            ? local_settings.BRIGHTNESS
+            : global_settings.BRIGHTNESS,
+        iterations: 5,
+        radius: 2.,
+        width: monitor.width,
+        height: monitor.height,
+        use_base_pixel: false
     });
 
     // store the scale in the effect in order to retrieve it in set_sigma

--- a/src/effects/monte_carlo_blur.glsl
+++ b/src/effects/monte_carlo_blur.glsl
@@ -1,0 +1,44 @@
+uniform sampler2D tex;
+uniform float radius;
+uniform int iterations;
+uniform float brightness;
+uniform float width;
+uniform float height;
+uniform bool use_base_pixel;
+
+float srand(vec2 a) {
+    return sin(dot(a, vec2(1233.224, 1743.335)));
+}
+
+float rand(inout float r) {
+    r = fract(3712.65 * r + 0.61432);
+    return (r - 0.5) * 2.0;
+}
+
+void main() {
+    vec2 uv = cogl_tex_coord0_in.st;
+    vec2 p = 16 * radius / vec2(width, height);
+    float r = srand(uv);
+    vec2 rv;
+
+    int count = 0;
+    vec4 c = vec4(0.);
+
+    for (int i = 0; i < iterations; i++) {
+        rv.x = rand(r);
+        rv.y = rand(r);
+        vec2 new_uv = uv + rv * p;
+        if (new_uv.x >= 0.005 && new_uv.y >= 0.005 && new_uv.x <= .995 && new_uv.y <= .995) {
+            c += texture2D(tex, new_uv);
+            count += 1;
+        }
+    }
+
+    if (count == 0 || use_base_pixel) {
+        c += texture2D(tex, uv);
+        count += 1;
+    }
+
+    c.xyz *= brightness;
+    cogl_color_out = c / count;
+}

--- a/src/effects/monte_carlo_blur.js
+++ b/src/effects/monte_carlo_blur.js
@@ -1,0 +1,184 @@
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Clutter from 'gi://Clutter';
+import Shell from 'gi://Shell';
+
+const SHADER_PATH = GLib.filename_from_uri(GLib.uri_resolve_relative(import.meta.url, 'monte_carlo_blur.glsl', GLib.UriFlags.NONE))[0];
+
+
+const get_shader_source = _ => {
+    try {
+        return Shell.get_file_contents_utf8_sync(SHADER_PATH);
+    } catch (e) {
+        console.warn(`[Blur my Shell] error loading shader from ${SHADER_PATH}: ${e}`);
+        return null;
+    }
+};
+
+export const MonteCarloBlurEffect = new GObject.registerClass({
+    GTypeName: "MonteCarloBlurEffect",
+    Properties: {
+        'radius': GObject.ParamSpec.double(
+            `radius`,
+            `Radius`,
+            `Blur radius`,
+            GObject.ParamFlags.READWRITE,
+            0.0, 2000.0,
+            200.0,
+        ),
+        'iterations': GObject.ParamSpec.int(
+            `iterations`,
+            `Iterations`,
+            `Blur iterations`,
+            GObject.ParamFlags.READWRITE,
+            0, 64,
+            16,
+        ),
+        'brightness': GObject.ParamSpec.double(
+            `brightness`,
+            `Brightness`,
+            `Blur brightness`,
+            GObject.ParamFlags.READWRITE,
+            0.0, 1.0,
+            0.6,
+        ),
+        'width': GObject.ParamSpec.double(
+            `width`,
+            `Width`,
+            `Width`,
+            GObject.ParamFlags.READWRITE,
+            0.0, Number.MAX_SAFE_INTEGER,
+            0.0,
+        ),
+        'height': GObject.ParamSpec.double(
+            `height`,
+            `Height`,
+            `Height`,
+            GObject.ParamFlags.READWRITE,
+            0.0, Number.MAX_SAFE_INTEGER,
+            0.0,
+        ),
+        'use_base_pixel': GObject.ParamSpec.boolean(
+            `use_base_pixel`,
+            `Use base pixel`,
+            `Use base pixel`,
+            GObject.ParamFlags.READWRITE,
+            false,
+        ),
+    }
+}, class MonteCarloBlurEffect extends Clutter.ShaderEffect {
+    constructor(params, settings) {
+        super(params);
+
+        this._sigma = null;
+        this._iterations = null;
+        this._brightness = null;
+        this._width = null;
+        this._height = null;
+        this._use_base_pixel = null;
+
+        this._settings = settings;
+
+        if (params.sigma)
+            this.sigma = params.sigma;
+        if (params.iterations)
+            this.iterations = params.iterations;
+        if (params.brightness)
+            this.brightness = params.brightness;
+        if (params.width)
+            this.width = params.width;
+        if (params.height)
+            this.height = params.height;
+        if (params.use_base_pixel)
+            this.use_base_pixel = params.use_base_pixel;
+
+        // set shader source
+        this._source = get_shader_source();
+        if (this._source)
+            this.set_shader_source(this._source);
+    }
+
+    get radius() {
+        return this._radius;
+    }
+
+    set radius(value) {
+        if (this._radius !== value) {
+            this._radius = value;
+
+            this.set_uniform_value('radius', parseFloat(this._radius - 1e-6));
+        }
+    }
+
+    get iterations() {
+        return this._iterations;
+    }
+
+    set iterations(value) {
+        if (this._iterations !== value) {
+            this._iterations = value;
+
+            this.set_uniform_value('iterations', this._iterations);
+        }
+    }
+
+    get brightness() {
+        return this._brightness;
+    }
+
+    set brightness(value) {
+        if (this._brightness !== value) {
+            this._brightness = value;
+
+            this.set_uniform_value('brightness', parseFloat(this._brightness - 1e-6));
+        }
+    }
+
+    get width() {
+        return this._width;
+    }
+
+    set width(value) {
+        if (this._width !== value) {
+            this._width = value;
+
+            this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
+        }
+    }
+
+    get height() {
+        return this._height;
+    }
+
+    set height(value) {
+        if (this._height !== value) {
+            this._height = value;
+
+            this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
+        }
+    }
+
+    get use_base_pixel() {
+        return this._use_base_pixel;
+    }
+
+    set use_base_pixel(value) {
+        if (this._use_base_pixel !== value) {
+            this._use_base_pixel = value;
+
+            this.set_uniform_value('use_base_pixel', this._use_base_pixel ? 1 : 0);
+        }
+    }
+
+    vfunc_paint_target(paint_node = null, paint_context = null) {
+        this.set_uniform_value("tex", 0);
+        log("repainted");
+
+        if (paint_node && paint_context)
+            super.vfunc_paint_target(paint_node, paint_context);
+        else if (paint_node)
+            super.vfunc_paint_target(paint_node);
+        else
+            super.vfunc_paint_target();
+    }
+});


### PR DESCRIPTION
Just a proof-of-concept for the moment, there is no way to change the parameters other than in the code for example! Based on https://www.shadertoy.com/view/MdXXWr#

This probably won't be merged, because I intend to really beef up the extension before that:
- adding "pipelines" which would permit the users to combine different effects together
- permitting the user to choose which pipeline to use for which component
- implementing different effects (this one, the gaussian blur effect, etc)
- PROFIT hehe

However, I first need to fix a big performance issue, because the effects are currently being redrawn very often, which causes low FPS (especially when using big effects, for example augmenting the iterations for the Monte Carlo blur or the radius for the gaussian blur). So I need to find a way to redraw the effect way less often, and then I may do it!

PS you may play with the parameters in `src/conveniences/blur_creator.js`, lines 41 to 49. More iterations is slower and converges towards a gaussian blur, more radius is not slower but is not very pretty when there are not enough iterations, and `use_base_pixel` makes an interesting variation when using low iterations!

With 5 iterations, radius of 2 and `use_base_pixel` to `false`:
![image](https://github.com/aunetx/blur-my-shell/assets/31563930/b5a487bb-186f-4214-9886-212a9bb5c3c0)

With 15 iterations, radius of 15 and `use_base_pixel` to `false`:
![Capture d’écran du 2024-03-27 22-44-31](https://github.com/aunetx/blur-my-shell/assets/31563930/cafc47dc-4623-4ac9-a64b-3645a6b6593a)

With 7 iterations, radius of 5 and `use_base_pixel` to `true`:
![image](https://github.com/aunetx/blur-my-shell/assets/31563930/a7ec2fa5-c252-473e-a34e-82020fa99c9a)