### PR TITLE
fix: don't restore patched prototypes when suspending

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -155,6 +155,7 @@ export default class BlurMyShell extends Extension {
         // disable every component from user session mode
         if (this._user_session_mode_enabled)
             this._disable_user_session();
+        this._overview_blur.restore_patched_proto();
 
         // disable lockscreen blur too
         this._lockscreen_blur.disable();


### PR DESCRIPTION
Patched prototypes should only be restored in the `disable()` method of the extension, since gnome enforces extension rebasing when disabling them. Restoring protos in any other place may lead to infinite recursion if a different extension is also patching the same function.

See https://gitlab.gnome.org/ewlsh/gjs-guide/-/issues/75, https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7629

Fixes: #585