### PR TITLE
Enable blur for floating panel (static blur) and fix for panel_box dynamic blur

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -237,16 +237,14 @@ export const PanelBlur = class PanelBlur {
             // sometimes yields NaN (probably when the actor is not fully
             // positionned yet)
             let [p_x, p_y] = panel_box.get_position();
-            let [p_p_x, p_p_y] = panel_box.get_parent().get_position();
-            let x = p_x + p_p_x - monitor.x;
-            let y = p_y + p_p_y - monitor.y;
-
-            background.set_clip(x, y, width, height);
-            background.x = -x;
-            background.y = -y;
+            let x = p_x +  (width - panel.width)/2;
+            let y = p_y +  (height - panel.height)/2;
+            background.set_clip(x, y, panel.width, panel.height);
+            background.x = (width - panel.width)/2 - x;
+            background.y = (height - panel.height)/2 - y;
         } else {
-            background.x = panel.x;
-            background.y = panel.y;
+            background.x = panel_box.x;
+            background.y = panel_box.y;
             background.width = width;
             background.height = height;
         }


### PR DESCRIPTION
Hello Aurélien,

I tried BMS for floating panel since BMS now supports rounded corners (static) but faced an issue. This is a small PR to fix it. Let me explain the scenario below so you can see if you would like to go this way.

**Current state for floating panel with Static blur**:

Blur is applied to panel-box and so goes beyond the panel -
![current_static](https://github.com/aunetx/blur-my-shell/assets/4656768/8cbe0de7-6af2-4116-962c-8232f8162bd3)


Current state for floating panel with Dynamic blur:
Code uses x, y for the Panel but Width, Height for the Panel-Box causing this mismatch -
![current_dynamic](https://github.com/aunetx/blur-my-shell/assets/4656768/255dab3b-3866-4e4f-80a9-5493e8d4a452)


**How it would look with the PR**:

Floating panel with Static blur (blur applied to Panel):
![new_static](https://github.com/aunetx/blur-my-shell/assets/4656768/e13ef2a1-6416-4884-8561-4cdbd43da49b)

Floating panel with Dynamic blur (blur applied to Panel-Box since rounded corners not supported in Dynamic):
Not floating anymore since blur applied to Panel-Box. We can apply it to Panel instead but it will be a floating rectangle without the rounded corners. So instead this could be treated like no-support for floating with Dynamic (yet).
![new_dynamic](https://github.com/aunetx/blur-my-shell/assets/4656768/6b8678bf-d218-4d40-97cf-38deab939ee7)


Some more variations:
Regular panel:
![v1](https://github.com/aunetx/blur-my-shell/assets/4656768/563ab8f0-d9e8-4c16-ba72-82bba650a37e)

Regular with colored button islands:
![v2](https://github.com/aunetx/blur-my-shell/assets/4656768/69e133b3-f921-491d-a377-6255ea9588b4)

Floating with colored button islands:
![v3](https://github.com/aunetx/blur-my-shell/assets/4656768/4c214b6f-e590-480e-a51c-b5e17d60cb9f)


Note: The panel effects for Floating or Colors are added using [Open Bar](https://github.com/neuromorph/openbar) extension.


