### PR TITLE
Use meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,17 @@
+project('blur-my-shell')
+
+gnome = import('gnome')
+i18n = import('i18n')
+
+uuid = 'blur-my-shell@aunetx'
+rdnn = 'org.gnome.shell.extensions.blur-my-shell'
+
+datadir = get_option('datadir')
+extension_dir = datadir / 'gnome-shell' / 'extensions' / uuid
+
+subdir('src')
+subdir('resources')
+subdir('schemas')
+subdir('po')
+
+install_data('metadata.json', install_dir : extension_dir)

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,1 @@
+i18n.gettext(uuid, preset : 'glib')

--- a/resources/meson.build
+++ b/resources/meson.build
@@ -1,0 +1,2 @@
+install_subdir('icons', install_dir : extension_dir)
+install_subdir('ui', install_dir : extension_dir)

--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -1,0 +1,6 @@
+schema = rdnn + '.gschema.xml'
+schema_dir = datadir / 'glib-2.0' / 'schemas'
+
+install_data(schema, install_dir : schema_dir)
+
+gnome.post_install(glib_compile_schemas : true)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,14 @@
+install_data(
+  [
+    'extension.js',
+    'prefs.js',
+    'stylesheet.css',
+  ],
+  install_dir : extension_dir,
+)
+
+install_subdir('components', install_dir : extension_dir)
+install_subdir('conveniences', install_dir : extension_dir)
+install_subdir('dbus', install_dir : extension_dir)
+install_subdir('effects', install_dir : extension_dir)
+install_subdir('preferences', install_dir : extension_dir)


### PR DESCRIPTION
This standardizes a system-wide installation, which is useful for distros who create native system packages of this extension.