### PR TITLE
Add support for CoverflowAltTab

### DIFF
--- a/resources/ui/other.ui
+++ b/resources/ui/other.ui
@@ -95,6 +95,23 @@
       </object>
     </child>
 
+    <child>
+      <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Coverflow Alt-Tab extension blur</property>
+        <property name="description" translatable="yes">Make the coverflow alt-tab extension blurred, if it is used.</property>
+        <property name="header-suffix">
+          <object class="GtkSwitch" id="coverflow_alt_tab_blur">
+            <property name="valign">center</property>
+          </object>
+        </property>
+
+        <child>
+          <object class="PipelineChooseRow" id="coverflow_alt_tab_pipeline_choose_row">
+            <property name="sensitive" bind-source="coverflow_alt_tab_blur" bind-property="state" bind-flags="sync-create" />
+          </object>
+        </child>
+      </object>
+    </child>
 
     <child>
       <object class="AdwPreferencesGroup">

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -98,6 +98,7 @@
         <child name='screenshot' schema='org.gnome.shell.extensions.blur-my-shell.screenshot'></child>
         <child name='lockscreen' schema='org.gnome.shell.extensions.blur-my-shell.lockscreen'></child>
         <child name='window-list' schema='org.gnome.shell.extensions.blur-my-shell.window-list'></child>
+        <child name='coverflow-alt-tab' schema='org.gnome.shell.extensions.blur-my-shell.coverflow-alt-tab'></child>
         <child name='hidetopbar' schema='org.gnome.shell.extensions.blur-my-shell.hidetopbar'></child>
         <child name='dash-to-panel' schema='org.gnome.shell.extensions.blur-my-shell.dash-to-panel'></child>
     </schema>
@@ -544,6 +545,21 @@
         <key type="d" name="noise-lightness">
             <default>0.</default>
             <summary>Lightness of the noise added to the blur effect</summary>
+        </key>
+    </schema>
+
+    <!-- COVERFLOW ALT-TAB -->
+    <schema id="org.gnome.shell.extensions.blur-my-shell.coverflow-alt-tab"
+        path="/org/gnome/shell/extensions/blur-my-shell/coverflow-alt-tab/">
+        <!-- BLUR -->
+        <key type="b" name="blur">
+            <default>true</default>
+            <summary>Boolean, whether to blur activate the blur for this component or not</summary>
+        </key>
+        <!-- PIPELINE -->
+        <key type="s" name="pipeline">
+            <default>"pipeline_default"</default>
+            <summary>String, the name of the pipeline to use. It must exist, else "pipeline_default" will be used</summary>
         </key>
     </schema>
 

--- a/src/components/coverflow_alt_tab.js
+++ b/src/components/coverflow_alt_tab.js
@@ -1,0 +1,91 @@
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+
+import { PaintSignals } from "../conveniences/paint_signals.js";
+import { Pipeline } from "../conveniences/pipeline.js";
+
+export const CoverflowAltTabBlur = class CoverflowAltTabBlur {
+    constructor(connections, settings, effects_manager) {
+        this.connections = connections;
+        this.settings = settings;
+        this.paint_signals = new PaintSignals(connections);
+        this.effects_manager = effects_manager;
+        this.background_actors = [];
+        this.background_managers = [];
+    }
+
+    enable() {
+        this._log("blurring coverflow alt-tab");
+
+        this.update_backgrounds();
+
+        this.connections.connect(
+            Main.layoutManager.uiGroup,
+            "child-added",
+            (_, child) => this.try_blur(child)
+        );
+
+        this.connections.connect(Main.layoutManager, "monitors-changed", (_) => {
+            this.update_backgrounds();
+        });
+    }
+
+    update_backgrounds() {
+        this.remove_background_actors();
+
+        Main.layoutManager.uiGroup
+            .get_children()
+            .forEach((child) => this.try_blur(child));
+    }
+
+    try_blur(actor) {
+        if (
+            actor.constructor.name !== "Meta_BackgroundGroup" ||
+            actor.get_name() !== "coverflow-alt-tab-background-group"
+        ) {
+            return;
+        }
+
+        this._log("found coverflow alt-tab to blur");
+
+        for (let i = 0; i < Main.layoutManager.monitors.length; i++) {
+            const pipeline = new Pipeline(
+                this.effects_manager,
+                global.blur_my_shell._pipelines_manager,
+                this.settings.coverflow_alt_tab.PIPELINE
+            );
+
+            const background_actor = pipeline.create_background_with_effects(
+                i,
+                this.background_managers,
+                actor,
+                "bms-coverflow-alt-tab-blurred-widget"
+            );
+
+            this.background_actors.push(background_actor);
+        }
+    }
+
+    remove_background_actors() {
+        this.background_actors.forEach((actor) => actor.destroy);
+        this.background_actors = [];
+
+        this.background_managers.forEach((background_manager) => {
+            background_manager._bms_pipeline.destroy();
+            background_manager.destroy();
+        });
+        this.background_managers = [];
+    }
+
+    disable() {
+        this._log("removing blur from coverflow alt-tab");
+
+        this.remove_background_actors();
+        this.connections.disconnect_all();
+    }
+
+    _log(str) {
+        if (this.settings.DEBUG) {
+            console.log(`[Blur my Shell > coverflow alt-tab]  ${str}`);
+        }
+    }
+};

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -78,6 +78,12 @@ export const KEYS = [
         ]
     },
     {
+        component: "coverflow-alt-tab", schemas: [
+            { type: Type.B, name: "blur" },
+            { type: Type.S, name: "pipeline" },
+        ]
+    },
+    {
         component: "screenshot", schemas: [
             { type: Type.B, name: "blur" },
             { type: Type.S, name: "pipeline" },

--- a/src/conveniences/settings_updater.js
+++ b/src/conveniences/settings_updater.js
@@ -22,7 +22,7 @@ export function update_from_old_settings(gsettings) {
         preferences.dash_to_dock.STYLE_DASH_TO_DOCK = 0;
 
         // 'customize' has been removed: we merge the current used settings
-        ['appfolder', 'panel', 'dash_to_dock', 'applications', 'window_list'].forEach(
+        ['appfolder', 'panel', 'dash_to_dock', 'applications', 'window_list', 'coverflow_alt_tab'].forEach(
             component_name => {
                 const deprecated_component = deprecated_preferences[component_name];
                 const new_component = preferences[component_name];

--- a/src/extension.js
+++ b/src/extension.js
@@ -17,6 +17,7 @@ import { DashBlur } from './components/dash_to_dock.js';
 import { LockscreenBlur } from './components/lockscreen.js';
 import { AppFoldersBlur } from './components/appfolders.js';
 import { WindowListBlur } from './components/window_list.js';
+import { CoverflowAltTabBlur } from './components/coverflow_alt_tab.js';
 import { ApplicationsBlur } from './components/applications.js';
 import { ScreenshotBlur } from './components/screenshot.js';
 
@@ -67,6 +68,7 @@ export default class BlurMyShell extends Extension {
         this._lockscreen_blur = new LockscreenBlur(...init());
         this._appfolder_blur = new AppFoldersBlur(...init());
         this._window_list_blur = new WindowListBlur(...init());
+        this._coverflow_alt_tab_blur = new CoverflowAltTabBlur(...init());
         this._applications_blur = new ApplicationsBlur(...init());
         this._screenshot_blur = new ScreenshotBlur(...init());
 
@@ -167,6 +169,7 @@ export default class BlurMyShell extends Extension {
         this._appfolder_blur = null;
         this._lockscreen_blur = null;
         this._window_list_blur = null;
+        this._coverflow_alt_tab_blur = null;
         this._applications_blur = null;
         this._screenshot_blur = null;
 
@@ -200,6 +203,7 @@ export default class BlurMyShell extends Extension {
         this._overview_blur.disable();
         this._appfolder_blur.disable();
         this._window_list_blur.disable();
+        this._coverflow_alt_tab_blur.disable();
         this._applications_blur.disable();
         this._screenshot_blur.disable();
 
@@ -283,6 +287,9 @@ export default class BlurMyShell extends Extension {
 
         if (this._settings.window_list.BLUR)
             this._window_list_blur.enable();
+
+        if (this._settings.coverflow_alt_tab.BLUR)
+            this._coverflow_alt_tab_blur.enable();
 
         if (this._settings.screenshot.BLUR)
             this._screenshot_blur.enable();
@@ -526,6 +533,17 @@ export default class BlurMyShell extends Extension {
                 this._window_list_blur.enable();
             else
                 this._window_list_blur.disable();
+        });
+
+
+        // ---------- COVERFLOW ALT-TAB ----------
+
+        // toggled on/off
+        this._settings.coverflow_alt_tab.BLUR_changed(() => {
+            if (this._settings.coverflow_alt_tab.BLUR)
+                this._coverflow_alt_tab_blur.enable();
+            else
+                this._coverflow_alt_tab_blur.disable();
         });
 
 

--- a/src/preferences/other.js
+++ b/src/preferences/other.js
@@ -18,6 +18,9 @@ export const Other = GObject.registerClass({
         'window_list_sigma',
         'window_list_brightness',
 
+        'coverflow_alt_tab_blur',
+        'coverflow_alt_tab_pipeline_choose_row',
+
         'hack_level',
         'debug',
         'reset'
@@ -59,6 +62,14 @@ export const Other = GObject.registerClass({
         this.preferences.window_list.settings.bind(
             'brightness', this._window_list_brightness, 'value',
             Gio.SettingsBindFlags.DEFAULT
+        );
+
+        this.preferences.coverflow_alt_tab.settings.bind(
+            'blur', this._coverflow_alt_tab_blur, 'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this._coverflow_alt_tab_pipeline_choose_row.initialize(
+            this.preferences.coverflow_alt_tab, this.pipelines_manager, this.pipelines_page
         );
 
         this.preferences.settings.bind(


### PR DESCRIPTION
> NOTICE: This pull request depends on https://github.com/dsheeler/CoverflowAltTab/pull/240

Add basic support for [dsheeler/CoverflowAltTab](https://github.com/dsheeler/CoverflowAltTab). When enabled, blur-my-shell will blur the background of the Alt-Tab switcher.

Preference:
![Screenshot from 2024-08-11 22-34-35](https://github.com/user-attachments/assets/9862dc81-8e6f-45ab-9751-e5a62e8b6bed)

Before enabling:
[Screencast from 2024-08-11 22-38-32.webm](https://github.com/user-attachments/assets/e4c18fc7-daa6-475f-9f42-0b8da4d0b6db)

After enabling:
[Screencast from 2024-08-11 22-28-56.webm](https://github.com/user-attachments/assets/87507cb0-f146-4848-a5b3-58256fa760a7)
