### PR TITLE
Added missing German translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -71,7 +71,7 @@ msgstr ""
 
 #: src/effects/effects.js:86
 msgid "Gaussian blur (advanced effect)"
-msgstr ""
+msgstr "Gaußscher Weichzeichner (fortgeschrittener Effekt)"
 
 #: src/effects/effects.js:87
 msgid ""
@@ -158,7 +158,7 @@ msgstr "Ein Effekt, der das Bild verpixelt."
 #: src/effects/effects.js:177 src/effects/effects.js:204
 #: src/effects/effects.js:231
 msgid "Factor"
-msgstr ""
+msgstr "Faktor"
 
 #: src/effects/effects.js:178 src/effects/effects.js:205
 msgid "How much to scale down the image."
@@ -166,71 +166,71 @@ msgstr "Wie stark das Bild verkleinert werden soll."
 
 #: src/effects/effects.js:185 src/effects/effects.js:212
 msgid "Downsampling mode"
-msgstr ""
+msgstr "Downsampling-Modus"
 
 #: src/effects/effects.js:186 src/effects/effects.js:213
 msgid "The downsampling method that is used."
-msgstr ""
+msgstr "Die verwendete Downsampling-Methode."
 
 #: src/effects/effects.js:189 src/effects/effects.js:216
 msgid "Boxcar"
-msgstr ""
+msgstr "Boxcar"
 
 #: src/effects/effects.js:190 src/effects/effects.js:217
 msgid "Triangular"
-msgstr ""
+msgstr "Triangular"
 
 #: src/effects/effects.js:191 src/effects/effects.js:218
 msgid "Dirac"
-msgstr ""
+msgstr "Dirac"
 
 #: src/effects/effects.js:199
 msgid "Downscale (advanced effect)"
-msgstr ""
+msgstr "Herunterskalieren (fortgeschrittener Effekt)"
 
 #: src/effects/effects.js:200
 msgid "An effect that downscales the image and put it on the top-left corner."
-msgstr ""
+msgstr "Ein Effekt, der das Bild verkleinert und in die obere linke Ecke setzt."
 
 #: src/effects/effects.js:226
 msgid "Upscale (advanced effect)"
-msgstr ""
+msgstr "Hochskalieren (fortgeschrittener Effekt)"
 
 #: src/effects/effects.js:227
 msgid "An effect that upscales the image from the top-left corner."
-msgstr ""
+msgstr "Ein Effekt, der das Bild von der oberen linken Ecke aus hochskaliert."
 
 #: src/effects/effects.js:232
 msgid "How much to scale up the image."
-msgstr ""
+msgstr "Wie stark das Bild vergrößert werden soll."
 
 #: src/effects/effects.js:243
 msgid "Derivative"
-msgstr ""
+msgstr "Ableitung"
 
 #: src/effects/effects.js:244
 msgid "Apply a spatial derivative, or a laplacian."
-msgstr ""
+msgstr "Wende eine räumliche Ableitung oder einen Laplace-Operator an."
 
 #: src/effects/effects.js:248
 msgid "Operation"
-msgstr ""
+msgstr "Operation"
 
 #: src/effects/effects.js:249
 msgid "The mathematical operation to apply."
-msgstr ""
+msgstr "Die mathematische Operation, welche angewendet werden soll."
 
 #: src/effects/effects.js:252
 msgid "1-step derivative"
-msgstr ""
+msgstr "Erste Ableitung"
 
 #: src/effects/effects.js:253
 msgid "2-step derivative"
-msgstr ""
+msgstr "Zweite Ableitung"
 
 #: src/effects/effects.js:254
 msgid "Laplacian"
-msgstr ""
+msgstr "Laplace-Operator"
 
 #: src/effects/effects.js:262 src/effects/effects.js:267
 msgid "Noise"
@@ -262,19 +262,19 @@ msgstr ""
 
 #: src/effects/effects.js:291
 msgid "RGB to HSL (advanced effect)"
-msgstr ""
+msgstr "RGB zu HSL (fortgeschrittener Effekt)"
 
 #: src/effects/effects.js:292
 msgid "Converts the image from RGBA colorspace to HSLA."
-msgstr ""
+msgstr "Konvertiert das Bild von RGBA-Farbraum zu HSLA."
 
 #: src/effects/effects.js:299
 msgid "HSL to RGB (advanced effect)"
-msgstr ""
+msgstr "HSL zu RGB (fortgeschrittener Effekt)"
 
 #: src/effects/effects.js:300
 msgid "Converts the image from HSLA colorspace to RGBA."
-msgstr ""
+msgstr "Konvertiert das Bild von HSLA-Farbraum zu RGBA."
 
 #: src/effects/effects.js:307
 msgid "Corner"
@@ -505,7 +505,7 @@ msgstr "Effekt hinzufügen"
 
 #: resources/ui/effects-dialog.ui:72
 msgid "Include advanced effects"
-msgstr ""
+msgstr "Fortgeschrittene Effekte einschließen"
 
 #: resources/ui/menu.ui:6
 msgid "Project page"
@@ -559,11 +559,12 @@ msgstr ""
 
 #: resources/ui/other.ui:100
 msgid "Coverflow Alt-Tab extension blur"
-msgstr ""
+msgstr "Coverflow Alt-Tab Erweiterung Unschärfe"
 
 #: resources/ui/other.ui:101
 msgid "Make the coverflow alt-tab extension blurred, if it is used."
-msgstr ""
+msgstr "Unschärfeeffekt auf die Coverflow Alt-Tab Erweiterungen anwenden wenn "
+"diese verwendet wird."
 
 #: resources/ui/other.ui:118
 msgid "Performance"


### PR DESCRIPTION
I added all the missing German translations.

German words tend to be longer than English words, so the `Gaußscher Weichzeichner (fortgeschrittener Effekt)` might be too long for the line it's supposed to be in.

If that's the case, I can change `(fortgeschrittener Effekt)` to `(fortgeschritten)`  in all translations that use this phrase to ensure the text fits and remains consistent.

The rest of the translations should be fine in terms of length.