### PR TITLE
Update the panel font when updating its background

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -54,9 +54,6 @@ export const PanelBlur = class PanelBlur {
         // the blur when a window is near a panel
         this.connect_to_windows_and_overview();
 
-        // update the classname if the panel to have or have not light text
-        this.update_light_text_classname();
-
         // connect to workareas change
         this.connections.connect(global.display, 'workareas-changed',
             _ => this.reset()
@@ -468,10 +465,14 @@ export const PanelBlur = class PanelBlur {
             this.settings.panel.OVERRIDE_BACKGROUND
             &&
             should_override
-        )
+        ) {
             panel.add_style_class_name(
                 PANEL_STYLES[this.settings.panel.STYLE_PANEL]
             );
+        }
+
+        // update the classname if the panel to have or have not light text
+        this.update_light_text_classname(!should_override);
     }
 
     update_pipeline() {


### PR DESCRIPTION
When the gnome color-scheme is set to 'prefer-light', and the options 'force-light-text' and 'Disable when window is near' are enabled, the text of the panel would appear white on white and thus be unreadable if a window is near the panel. This commit fixes this issue by updating the text color of the panel whenever the panel background is updated, and by forcing light text only when the panel's background is blured/overrided (and the same settings as above are applied).