### PR TITLE
Update extension.js

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -253,14 +253,14 @@ export default class BlurMyShell extends Extension {
 
     /// Add the Clutter debug flag.
     _disable_clipped_redraws() {
-        Meta.add_clutter_debug_flags(
+        Clutter.add_debug_flags(
             null, Clutter.DrawDebugFlag.DISABLE_CLIPPED_REDRAWS, null
         );
     }
 
     /// Remove the Clutter debug flag.
     _reenable_clipped_redraws() {
-        Meta.remove_clutter_debug_flags(
+        Clutter.remove_debug_flags(
             null, Clutter.DrawDebugFlag.DISABLE_CLIPPED_REDRAWS, null
         );
     }


### PR DESCRIPTION
fix for gnome 48

Old Meta functions (get_clutter_debug_flags, add_clutter_debug_flags, remove_clutter_debug_flags) removed, they now in Clutter.