### PR TITLE
Fixed transparency logic for just perfection bottom panels

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -438,11 +438,15 @@ export const PanelBlur = class PanelBlur {
                     let same_monitor = actors.monitor.index == window_monitor_i;
 
                     let window_vertical_pos = meta_window.get_frame_rect().y;
+                    let window_vertical_bottom = window_vertical_pos + meta_window.get_frame_rect().height;
 
                     // if so, and if in the same monitor, then it overlaps
                     if (same_monitor
                         &&
-                        window_vertical_pos < panel_bottom + 5 * scale
+                        // check if panel is on top
+                        ((panel_top === 0 && window_vertical_pos < panel_bottom + 5 * scale) ||
+                        // check if panel is at the bottom
+                        (panel_top > 0 && window_vertical_bottom > panel_top - 5 * scale))
                     )
                         window_overlap_panel = true;
                 });


### PR DESCRIPTION
### Summary
Fixes an issue with the _"disable when a window is near"_ logic for users using Just Perfections bottom panel setting.

### Changes

- Detects whether the panel is at the top or bottom of the screen
- Adjusts window overlap logic to account for bottom-aligned panels
- Keeps the original **5 * scale** margin

### Testing

- Gnome 48 (Wayland)
- Just Perfection: Tested top and bottom panel alignments.
