### PR TITLE
Fix race condition with Dash to Panel on startup

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -1,4 +1,5 @@
 import St from 'gi://St';
+import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
@@ -83,23 +84,34 @@ export const PanelBlur = class PanelBlur {
     }
 
     blur_dtp_panels() {
-        // FIXME when Dash to Panel changes its size, it seems it creates new
-        // panels; but I can't get to delete old widgets
-
-        // blur every panel found
-        global.dashToPanel.panels.forEach(p => {
-            this.maybe_blur_panel(p.panel);
+        // Defer the blurring to the next idle cycle.
+        // This is crucial to ensure the panel actors have been allocated their
+        // final size and position by the compositor, avoiding race conditions
+        // during extension startup.
+        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+            if (!global.dashToPanel?.panels) {
+                return GLib.SOURCE_REMOVE;
+            }
+    
+            this._log("Blurring Dash to Panel panels after idle.");
+    
+            // blur every panel found
+            global.dashToPanel.panels.forEach(p => {
+                this.maybe_blur_panel(p.panel);
+            });
+    
+            // if main panel is not included in the previous panels, blur it
+            if (
+                !global.dashToPanel.panels
+                    .map(p => p.panel)
+                    .includes(Main.panel)
+                &&
+                this.settings.dash_to_panel.BLUR_ORIGINAL_PANEL
+            )
+                this.maybe_blur_panel(Main.panel);
+    
+            return GLib.SOURCE_REMOVE;
         });
-
-        // if main panel is not included in the previous panels, blur it
-        if (
-            !global.dashToPanel.panels
-                .map(p => p.panel)
-                .includes(Main.panel)
-            &&
-            this.settings.dash_to_panel.BLUR_ORIGINAL_PANEL
-        )
-            this.maybe_blur_panel(Main.panel);
     };
 
     /// Blur a panel only if it is not already blurred (contained in the list)


### PR DESCRIPTION
Hi, this PR fixes a long-standing race condition that occurs when enabling the extension while Dash to Panel (DTP) is already active.

The Problem:

On startup, blur_dtp_panels() is called before DTP's panel actors have been fully allocated and drawn by the compositor. This results in the blur effect being created with incorrect dimensions (e.g., zero height), leading to a broken visual appearance. The issue resolves itself if the panel blur is toggled manually later, as the UI is stable by then.

Repro:

* Install both dash to panel and blur my shell.

```bash
anduin@anduin-lunar:/usr/share/gnome-shell/extensions/blur-my-shell@aunetx$ gnome-extensions disable blur-my-shell@aunetx
anduin@anduin-lunar:/usr/share/gnome-shell/extensions/blur-my-shell@aunetx$ gnome-extensions enable blur-my-shell@aunetx
```

<img width="2018" height="646" alt="image" src="https://github.com/user-attachments/assets/176808f1-a710-4784-b834-cca873ee088c" />


Mitigation:

```bash
anduin@anduin-lunar:/usr/share/gnome-shell/extensions/blur-my-shell@aunetx$ dconf write  /org/gnome/shell/extensions/blur-my-shell/panel/blur false
anduin@anduin-lunar:/usr/share/gnome-shell/extensions/blur-my-shell@aunetx$ dconf write  /org/gnome/shell/extensions/blur-my-shell/panel/blur true
```

<img width="1835" height="1464" alt="image" src="https://github.com/user-attachments/assets/dc0fd103-bad6-474e-84b6-f801f302ef5b" />


The Solution:

This fix wraps the core logic of blur_dtp_panels() inside a GLib.idle_add() call. This defers the execution to the next idle cycle, giving the compositor enough time to calculate the final geometry of the panel actors.

This approach is minimally invasive as it doesn't change any of the calling logic in the enable() method, but ensures that the blurring operation always runs against a fully-rendered panel.

This should robustly fix the compatibility issue with Dash to Panel.