### PR TITLE
Support for GNOME 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "shell-version": [
         "46",
         "47",
-        "48"
+        "48",
+        "49"
     ],
     "url": "https://github.com/aunetx/blur-my-shell",
     "uuid": "blur-my-shell@aunetx",


### PR DESCRIPTION
I've been testing Blur My Shell with GNOME 49.alpha, 49.beta and 49.rc, without any issues so far. With GNOME 49 being [released next week](https://release.gnome.org/calendar/), I think it's safe to assume there won't be any issues enabling GNOME 49 support.

If want to be sure, here are the changes since the last pre-release: [49.rc...main](https://gitlab.gnome.org/GNOME/gnome-shell/-/compare/49.rc...main). You can see it's mostly translations and minor code fixes, nothing that will break the API.