### PR TITLE
Fix `Main.panel` crash on log out

### DIFF
--- a/src/components/coverflow_alt_tab.js
+++ b/src/components/coverflow_alt_tab.js
@@ -66,7 +66,7 @@ export const CoverflowAltTabBlur = class CoverflowAltTabBlur {
     }
 
     remove_background_actors() {
-        this.background_actors.forEach((actor) => actor.destroy);
+        this.background_actors.forEach((actor) => actor.destroy());
         this.background_actors = [];
 
         this.background_managers.forEach((background_manager) => {

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -16,6 +16,9 @@ const PANEL_STYLES = [
     "contrasted-panel"
 ];
 
+// global listener, so we don't miss the panel destruction event
+let isMainPanelAlive = true;
+Main.panel.connect('destroy', () => isMainPanelAlive = false);
 
 export const PanelBlur = class PanelBlur {
     constructor(connections, settings, effects_manager) {
@@ -28,6 +31,11 @@ export const PanelBlur = class PanelBlur {
     }
 
     enable() {
+        if (this.enabled) {
+            this._log("blur already enabled");
+            return;
+        }
+
         this._log("blurring top panel");
 
         // check for panels when Dash to Panel is activated
@@ -64,6 +72,11 @@ export const PanelBlur = class PanelBlur {
     }
 
     reset() {
+        if (!this.enabled) {
+            this._log("reset called but blur is not enabled");
+            return;
+        }
+
         this._log("resetting...");
 
         this.disable();
@@ -77,7 +90,7 @@ export const PanelBlur = class PanelBlur {
             // blur already existing ones
             if (global.dashToPanel.panels)
                 this.blur_dtp_panels();
-        } else {
+        } else if (isMainPanelAlive) {
             // if no dash-to-panel, blur the main and only panel
             this.maybe_blur_panel(Main.panel);
         }
@@ -92,14 +105,14 @@ export const PanelBlur = class PanelBlur {
             if (!global.dashToPanel?.panels) {
                 return GLib.SOURCE_REMOVE;
             }
-    
+
             this._log("Blurring Dash to Panel panels after idle.");
-    
+
             // blur every panel found
             global.dashToPanel.panels.forEach(p => {
                 this.maybe_blur_panel(p.panel);
             });
-    
+
             // if main panel is not included in the previous panels, blur it
             if (
                 !global.dashToPanel.panels
@@ -107,9 +120,11 @@ export const PanelBlur = class PanelBlur {
                     .includes(Main.panel)
                 &&
                 this.settings.dash_to_panel.BLUR_ORIGINAL_PANEL
+                &&
+                isMainPanelAlive
             )
                 this.maybe_blur_panel(Main.panel);
-    
+
             return GLib.SOURCE_REMOVE;
         });
     };
@@ -377,6 +392,11 @@ export const PanelBlur = class PanelBlur {
 
     /// Update the css classname of the panel for light theme
     update_light_text_classname(disable = false) {
+        if (!isMainPanelAlive) {
+            this._log("cannot update light text classname, Main.panel is not alive");
+            return;
+        }
+
         if (this.settings.panel.FORCE_LIGHT_TEXT && !disable)
             Main.panel.add_style_class_name("panel-light-text");
         else
@@ -408,7 +428,7 @@ export const PanelBlur = class PanelBlur {
     /// Update the visibility of the blur effect
     update_visibility() {
         if (
-            Main.panel.has_style_pseudo_class('overview')
+            isMainPanelAlive && Main.panel.has_style_pseudo_class('overview')
             || !Main.sessionMode.hasWindows
         ) {
             this.actors_list.forEach(
@@ -533,6 +553,11 @@ export const PanelBlur = class PanelBlur {
     }
 
     disable() {
+        if (!this.enabled) {
+            this._log("blur already removed");
+            return;
+        }
+
         this._log("removing blur from top panel");
 
         this.disconnect_from_windows_and_overview();


### PR DESCRIPTION
- Added a listener for [`destroy`](https://mutter.gnome.org/clutter/signal.Actor.destroy.html), so that `Main.panel` is not called after that event.
- Added protections against reentrancy for `enable()`, `disable()` and `reset()` methods.
- Fixes #782.
- Ensure actors are destroyed in `CoverflowAltTabBlur`.

Here are the logs after this change:

<details>
  <summary><b>Debug Logs</b></summary>

```log
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > extension]    enabling extension...
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > lockscreen]   blurring lockscreen
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > extension]    changing mode to user session...
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > overview]     blurring overview
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > dash manager] searching for dash
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > panel]        blurring top panel
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > panel]        resetting...
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > panel]        removing blur from top panel
set 07 00:13:57 marmis-arch gnome-shell[39106]: [Blur my Shell > panel]        blurring top panel
set 07 00:13:58 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   blurring appfolders
set 07 00:13:58 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:13:58 marmis-arch gnome-shell[39106]: [Blur my Shell > window list]  blurring window list
set 07 00:13:58 marmis-arch gnome-shell[39106]: [Blur my Shell > coverflow alt-tab]  blurring coverflow alt-tab
set 07 00:13:58 marmis-arch gnome-shell[39106]: [Blur my Shell > screenshot]   blurring screenshot's window selector
set 07 00:13:58 marmis-arch gnome-shell[39106]: [Blur my Shell > extension]    all components enabled.
set 07 00:14:06 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:06 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:07 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:07 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:17 marmis-arch gnome-shell[39106]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:30 marmis-arch gnome-shell[39106]: [Blur my Shell > panel]        cannot update light text classname, Main.panel is not alive
set 07 00:14:41 marmis-arch gnome-shell[40963]: [Blur my Shell > extension]    enabling extension...
set 07 00:14:41 marmis-arch gnome-shell[40963]: [Blur my Shell > lockscreen]   blurring lockscreen
set 07 00:14:41 marmis-arch gnome-shell[40963]: [Blur my Shell > extension]    changing mode to user session...
set 07 00:14:41 marmis-arch gnome-shell[40963]: [Blur my Shell > overview]     blurring overview
set 07 00:14:41 marmis-arch gnome-shell[40963]: [Blur my Shell > dash manager] searching for dash
set 07 00:14:41 marmis-arch gnome-shell[40963]: [Blur my Shell > panel]        blurring top panel
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > panel]        resetting...
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > panel]        removing blur from top panel
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > panel]        blurring top panel
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > appfolders]   blurring appfolders
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > window list]  blurring window list
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > coverflow alt-tab]  blurring coverflow alt-tab
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > screenshot]   blurring screenshot's window selector
set 07 00:14:42 marmis-arch gnome-shell[40963]: [Blur my Shell > extension]    all components enabled.
set 07 00:14:50 marmis-arch gnome-shell[40963]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:50 marmis-arch gnome-shell[40963]: [Blur my Shell > appfolders]   appfolders hack level 1
set 07 00:14:51 marmis-arch gnome-shell[40963]: [Blur my Shell > appfolders]   appfolders hack level 1
```

</details>

You can see in the logs "cannot update light text classname, Main.panel is not alive", so it still tries to update the `Main.panel` style, but the flag protects against it.

I also tried to make `disable()` run before `Main.panel::destroy`, but I don't think it's possible, at least not on GNOME 49.rc. The order of events on log out seems to be `Main.panel::destroy` => `global.display::workareas-changed` => `Extension.disable`.