### PR TITLE
Add support for GNOME 49 (fixes #788, #789)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "shell-version": [
         "46",
         "47",
-        "48"
+        "48",
+        "49"
     ],
     "url": "https://github.com/aunetx/blur-my-shell",
     "uuid": "blur-my-shell@aunetx",


### PR DESCRIPTION
### Description
Add support for **GNOME 49**. Tested with `make install` and the extension loads-works correctly.

### Changes
- Updated `metadata.json` with GNOME 49 support.
- Verified functionality on GNOME 49 (see screenshot).

### Related Issues
Fixes #788, Fixes #789
<img width="1920" height="1080" alt="Captura desde 2025-09-25 10-31-31" src="https://github.com/user-attachments/assets/2190a984-6599-41cf-99cd-e7328e7fe468" />
