### PR TITLE
fix(applications): hide minimized windows to prevent ghost rendering

### DIFF
--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -97,7 +97,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
                         let window_actor = meta_window.get_compositor_private();
 
                         if (
-                            !meta_window.get_workspace().active
+                             (!meta_window.get_workspace().active) || meta_window.minimized
                         )
                             window_actor.hide();
                     });


### PR DESCRIPTION
Previously, the blur component only checked for the active workspace before hiding a window, ignoring its minimized state. This caused minimized windows to be erroneously rendered upon exiting Overview.

Now, we also check `meta_window.minimized` in the condition, ensuring these windows are properly hidden and cannot become non-interactable 'ghosts'.

Fixes: [#[799]](https://github.com/aunetx/blur-my-shell/issues/799)