### PR TITLE
Fix blurring of original panel when using DTP

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -77,6 +77,10 @@ export const PanelBlur = class PanelBlur {
             // blur already existing ones
             if (global.dashToPanel.panels)
                 this.blur_dtp_panels();
+
+            // blur main panel if requested in settings
+            if (this.settings.dash_to_panel.BLUR_ORIGINAL_PANEL)
+                this.maybe_blur_panel(Main.panel);
         } else {
             // if no dash-to-panel, blur the main and only panel
             this.maybe_blur_panel(Main.panel);
@@ -95,21 +99,12 @@ export const PanelBlur = class PanelBlur {
     
             this._log("Blurring Dash to Panel panels after idle.");
     
-            // blur every panel found
+            // blur every panel, except Main.panel (this is handled in blur_existing_panels() method above)
             global.dashToPanel.panels.forEach(p => {
-                this.maybe_blur_panel(p.panel);
+                if (p.panel != Main.panel)
+                    this.maybe_blur_panel(p.panel);
             });
-    
-            // if main panel is not included in the previous panels, blur it
-            if (
-                !global.dashToPanel.panels
-                    .map(p => p.panel)
-                    .includes(Main.panel)
-                &&
-                this.settings.dash_to_panel.BLUR_ORIGINAL_PANEL
-            )
-                this.maybe_blur_panel(Main.panel);
-    
+
             return GLib.SOURCE_REMOVE;
         });
     };


### PR DESCRIPTION
Hello,

without Dash to Panel (DTP) extension the blurring of the original Gnome panel is done outside of the `GLib.idle_add()` context, which works without any issues. With the current implementation and enabled DTP #785 occurs.

I think the blurring of the DTP panels works just fine in the `GLib.idle_add()` context but not for the original panel. Therefore, I moved the code which blurs the original panel out of this context. It is now handled in the `blur_existing_panels()` method like it is done if the DTP extension is not present.

This fixes the above issue for me.