### PR TITLE
Handle dock blur recovery after layout invalidation

### DIFF
--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -1,3 +1,4 @@
+import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
@@ -33,6 +34,7 @@ class DashInfos {
         this.bg_manager = bg_manager;
         this.settings = dash_blur.settings;
         this.old_style = this.dash._background.style;
+        this._update_retry_id = 0;
 
         this.dash_destroy_id = dash.connect('destroy', () => this.remove_dash_blur(false));
         this.dash_blur_connections_ids = [];
@@ -62,6 +64,9 @@ class DashInfos {
         // disconnect everything
         this.dash_blur_connections_ids.forEach(id => { if (id) this.dash_blur.disconnect(id); });
         this.dash_blur_connections_ids = [];
+        if (this._update_retry_id)
+            GLib.source_remove(this._update_retry_id);
+        this._update_retry_id = 0;
         if (this.dash_destroy_id)
             this.dash.disconnect(this.dash_destroy_id);
         this.dash_destroy_id = null;
@@ -117,48 +122,134 @@ class DashInfos {
         );
     }
 
-    update_size() {
+    update_size(attempt = 0) {
+        if (!this.geometry_ready()) {
+            this.background_group.hide();
+            this.schedule_update_retry(attempt);
+            return;
+        }
+
+        this.cancel_update_retry();
         if (this.dash_blur.is_static) {
-            let [x, y] = this.get_dash_position(this.dash_container, this.dash_background);
+            let position = this.get_dash_position(this.dash_container, this.dash_background);
+            if (!position) {
+                this.background_group.hide();
+                this.schedule_update_retry(attempt);
+                return;
+            }
+
+            let [x, y] = position;
+            if (![x, y].every(Number.isFinite)) {
+                this.background_group.hide();
+                this.schedule_update_retry(attempt);
+                return;
+            }
 
             this.background.x = -x;
             this.background.y = -y;
 
-            if (this.dash_container.get_style_class_name().includes("top"))
-                this.background.set_clip(
-                    x,
-                    y + this.dash.y + this.dash_background.y,
-                    this.dash_background.width,
-                    this.dash_background.height
-                );
-            else if (this.dash_container.get_style_class_name().includes("bottom"))
-                this.background.set_clip(
-                    x,
-                    y + this.dash.y + this.dash_background.y,
-                    this.dash_background.width,
-                    this.dash_background.height
-                );
-            else if (this.dash_container.get_style_class_name().includes("left"))
-                this.background.set_clip(
-                    x + this.dash.x + this.dash_background.x,
-                    y + this.dash.y + this.dash_background.y,
-                    this.dash_background.width,
-                    this.dash_background.height
-                );
-            else if (this.dash_container.get_style_class_name().includes("right"))
-                this.background.set_clip(
-                    x + this.dash.x + this.dash_background.x,
-                    y + this.dash.y + this.dash_background.y,
-                    this.dash_background.width,
-                    this.dash_background.height
-                );
+            let clip_x = null;
+            let clip_y = null;
+            let clip_width = this.dash_background.width;
+            let clip_height = this.dash_background.height;
+
+            if (this.dash_container.get_style_class_name().includes("top")) {
+                clip_x = x;
+                clip_y = y + this.dash.y + this.dash_background.y;
+            } else if (this.dash_container.get_style_class_name().includes("bottom")) {
+                clip_x = x;
+                clip_y = y + this.dash.y + this.dash_background.y;
+            } else if (this.dash_container.get_style_class_name().includes("left")) {
+                clip_x = x + this.dash.x + this.dash_background.x;
+                clip_y = y + this.dash.y + this.dash_background.y;
+            } else if (this.dash_container.get_style_class_name().includes("right")) {
+                clip_x = x + this.dash.x + this.dash_background.x;
+                clip_y = y + this.dash.y + this.dash_background.y;
+            }
+
+            if (![clip_x, clip_y, clip_width, clip_height].every(Number.isFinite) ||
+                clip_width <= 0 || clip_height <= 0) {
+                this.background_group.hide();
+                this.schedule_update_retry(attempt);
+                return;
+            }
+
+            this.background.set_clip(
+                clip_x,
+                clip_y,
+                clip_width,
+                clip_height
+            );
         } else {
+            if (![this.dash_background.width, this.dash_background.height,
+                this.dash_background.x, this.dash_background.y,
+                this.dash.y].every(Number.isFinite) ||
+                this.dash_background.width <= 0 ||
+                this.dash_background.height <= 0) {
+                this.background_group.hide();
+                this.schedule_update_retry(attempt);
+                return;
+            }
             this.background.width = this.dash_background.width;
             this.background.height = this.dash_background.height;
 
             this.background.x = this.dash_background.x;
             this.background.y = this.dash_background.y + this.dash.y;
         }
+
+        if (!(this.settings.dash_to_dock.UNBLUR_IN_OVERVIEW && Main.overview.visible))
+            this.background_group.show();
+    }
+
+    geometry_ready() {
+        const monitor = Main.layoutManager.findMonitorForActor(this.dash_container);
+        const dash_box = this.dash_container?._slider?.get_child();
+
+        return !!(
+            this.dash &&
+            this.dash_container &&
+            this.dash_background &&
+            dash_box &&
+            monitor &&
+            Number.isFinite(this.dash_container.width) &&
+            Number.isFinite(this.dash_container.height) &&
+            Number.isFinite(this.dash.width) &&
+            Number.isFinite(this.dash.height) &&
+            Number.isFinite(this.dash_background.width) &&
+            Number.isFinite(this.dash_background.height) &&
+            this.dash_container.width > 0 &&
+            this.dash_container.height > 0 &&
+            this.dash.width > 0 &&
+            this.dash.height > 0 &&
+            this.dash_background.width > 0 &&
+            this.dash_background.height > 0
+        );
+    }
+
+    schedule_update_retry(attempt = 0, delay_ms = 120) {
+        if (this._update_retry_id || !this.dash_blur.enabled)
+            return;
+
+        this._update_retry_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay_ms, () => {
+            this._update_retry_id = 0;
+
+            if (!this.dash_blur.enabled)
+                return GLib.SOURCE_REMOVE;
+
+            if (attempt >= 14)
+                return GLib.SOURCE_REMOVE;
+
+            this.update_size(attempt + 1);
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    cancel_update_retry() {
+        if (!this._update_retry_id)
+            return;
+
+        GLib.source_remove(this._update_retry_id);
+        this._update_retry_id = 0;
     }
 
     get_dash_position(dash_container, dash_background) {
@@ -166,6 +257,9 @@ class DashInfos {
 
         let monitor = Main.layoutManager.findMonitorForActor(dash_container);
         let dash_box = dash_container._slider.get_child();
+
+        if (!monitor || !dash_box)
+            return null;
 
         if (dash_container.get_style_class_name().includes("top")) {
             x = (monitor.width - dash_background.width) / 2;
@@ -180,6 +274,8 @@ class DashInfos {
             x = monitor.width - dash_container.width;
             y = dash_container.y + (dash_container.height - dash_background.height) / 2 - dash_background.y;
         }
+        if (![x, y].every(Number.isFinite))
+            return null;
 
         return [x, y];
     }
@@ -203,23 +299,26 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
         this.paint_signals = new PaintSignals(connections);
         this.is_static = this.settings.dash_to_dock.STATIC_BLUR;
         this.enabled = false;
+        this._pending_retries = new Map();
+        this._refresh_all_id = 0;
     }
 
     enable() {
+        this.enabled = true;
         this.connections.connect(Main.uiGroup, 'child-added', (_, actor) => {
             if (
                 (actor.get_name() === "dashtodockContainer") &&
                 (actor.constructor.name === 'DashToDock')
             )
-                this.try_blur(actor);
+                this.schedule_try_blur(actor);
         });
 
         this.blur_existing_dashes();
         this.connect_to_overview();
+        this.connections.connect(Main.layoutManager, 'monitors-changed', () => this.queue_refresh_all());
+        this.connections.connect(global.display, 'workareas-changed', () => this.queue_refresh_all());
 
         this.update_size();
-
-        this.enabled = true;
     }
 
     // Finds all existing dashes on every monitor, and call `try_blur` on them
@@ -231,12 +330,16 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
         Main.uiGroup.get_children().filter((child) => {
             return (child.get_name() === "dashtodockContainer") &&
                 (child.constructor.name === 'DashToDock');
-        }).forEach(dash_container => this.try_blur(dash_container));
+        }).forEach(dash_container => this.schedule_try_blur(dash_container));
     }
 
     // Tries to blur the dash contained in the given actor
-    try_blur(dash_container) {
-        let dash_box = dash_container._slider.get_child();
+    try_blur(dash_container, attempt = 0) {
+        let { dash_box, dash, dash_background } =
+            this.get_dash_parts(dash_container);
+
+        if (!dash_box || !dash)
+            return;
 
         // verify that we did not already blur that dash
         if (!dash_box.get_children().some(child =>
@@ -244,18 +347,52 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
         )) {
             this._log("dash to dock found, blurring it");
 
-            // finally blur the dash
-            let dash = dash_box.get_children().find(child => {
-                return child.get_name() === 'dash';
-            });
+            // Wait until the dock has a real allocation before creating the blur
+            // background, otherwise the background actor gets inserted too early
+            // and GNOME logs allocation warnings instead of showing the blur.
+            if (!this.dash_actor_ready(dash, dash_container, dash_background)) {
+                this.schedule_try_blur(dash_container, 700, attempt + 1);
+                return;
+            }
 
-            this.dashes.push(this.blur_dash_from(dash, dash_container));
+            this.cancel_retry(dash_container);
+            GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                if (!this.enabled)
+                    return GLib.SOURCE_REMOVE;
+
+                let {
+                    dash_box: idle_dash_box,
+                    dash: idle_dash,
+                    dash_background: idle_dash_background
+                } = this.get_dash_parts(dash_container);
+
+                if (!idle_dash_box || !idle_dash)
+                    return GLib.SOURCE_REMOVE;
+
+                if (idle_dash_box.get_children().some(child =>
+                    child.get_name() === "bms-dash-backgroundgroup"
+                )) {
+                    return GLib.SOURCE_REMOVE;
+                }
+
+                if (!this.dash_actor_ready(
+                    idle_dash, dash_container, idle_dash_background
+                )) {
+                    this.schedule_try_blur(dash_container, 700, attempt + 1);
+                    return GLib.SOURCE_REMOVE;
+                }
+
+                this.dashes.push(this.blur_dash_from(idle_dash, dash_container));
+                return GLib.SOURCE_REMOVE;
+            });
         }
     }
 
     // Blurs the dash and returns a `DashInfos` containing its information
     blur_dash_from(dash, dash_container) {
         let [background, background_group, bg_manager, paint_signals] = this.add_blur(dash);
+
+        background_group.hide();
 
         // insert the background group to the right element
         dash.get_parent().insert_child_at_index(background_group, 0);
@@ -287,9 +424,19 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
             bg_manager,
             paint_signals
         );
+        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+            if (!this.enabled)
+                return GLib.SOURCE_REMOVE;
 
-        this.update_size();
-        this.update_background();
+            if (!this.dashes.includes(infos))
+                return GLib.SOURCE_REMOVE;
+
+            this.update_size();
+            this.update_background();
+            if (!(this.settings.dash_to_dock.UNBLUR_IN_OVERVIEW && Main.overview.visible))
+                infos.background_group.show();
+            return GLib.SOURCE_REMOVE;
+        });
 
         // returns infos
         return infos;
@@ -353,6 +500,86 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
         return [background, background_group, bg_manager, paint_signals];
     }
 
+    dash_actor_ready(dash, dash_container, dash_background) {
+        return !!(
+            dash &&
+            dash_background &&
+            Main.layoutManager.findMonitorForActor(dash) &&
+            dash_container.width > 0 &&
+            dash_container.height > 0 &&
+            dash.width > 0 &&
+            dash.height > 0 &&
+            dash_background.width > 0 &&
+            dash_background.height > 0
+        );
+    }
+    get_dash_parts(dash_container) {
+        let dash_box = dash_container?._slider?.get_child();
+        let dash = dash_box?.get_children().find(child => {
+            return child.get_name() === 'dash';
+        });
+        let dash_background = dash?.get_children().find(child => {
+            return child.get_style_class_name() === 'dash-background';
+        });
+
+        return { dash_box, dash, dash_background };
+    }
+
+    schedule_try_blur(dash_container, delay_ms = 1600, attempt = 0) {
+        if (!this.enabled)
+            return;
+        this.cancel_retry(dash_container);
+
+        this._log(`scheduling dock blur in ${delay_ms}ms (attempt ${attempt + 1})`);
+        const retry_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay_ms, () => {
+            this._pending_retries.delete(dash_container);
+
+            if (!this.enabled)
+                return GLib.SOURCE_REMOVE;
+
+            if (attempt >= 19) {
+                let { dash, dash_background } = this.get_dash_parts(dash_container);
+                this._warn(
+                    `dash initialization exhausted attempts=${attempt + 1}, ` +
+                    `container=${dash_container.width}x${dash_container.height}, ` +
+                    `dash=${dash?.width ?? 0}x${dash?.height ?? 0}, ` +
+                    `background=${dash_background?.width ?? 0}x${dash_background?.height ?? 0})`
+                );
+                return GLib.SOURCE_REMOVE;
+            }
+            this.try_blur(dash_container, attempt);
+            return GLib.SOURCE_REMOVE;
+        });
+
+        this._pending_retries.set(dash_container, retry_id);
+    }
+
+    cancel_retry(dash_container) {
+        const retry_id = this._pending_retries.get(dash_container);
+        if (!retry_id)
+            return;
+
+        GLib.source_remove(retry_id);
+        this._pending_retries.delete(dash_container);
+    }
+
+    queue_refresh_all(delay_ms = 180) {
+        if (!this.enabled || this._refresh_all_id)
+            return;
+
+        this._refresh_all_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay_ms, () => {
+            this._refresh_all_id = 0;
+
+            if (!this.enabled)
+                return GLib.SOURCE_REMOVE;
+
+            this.blur_existing_dashes();
+            this.update_size();
+            this.update_background();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
     change_blur_type() {
         this.is_static = this.settings.dash_to_dock.STATIC_BLUR;
         this.emit('change-blur-type');
@@ -405,6 +632,11 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
         this.emit('remove-dashes');
 
         this.dashes = [];
+        if (this._refresh_all_id)
+            GLib.source_remove(this._refresh_all_id);
+        this._refresh_all_id = 0;
+        this._pending_retries.forEach(retry_id => GLib.source_remove(retry_id));
+        this._pending_retries.clear();
         this.connections.disconnect_all();
 
         this.enabled = false;


### PR DESCRIPTION
## Summary
This fixes dock blur breakage when Blur my Shell is used together with Ubuntu Dock and Hanabi.

## What changed
- guard dock blur geometry updates until the dock has a valid allocation
- avoid applying invalid clip values during transient layout resets
- retry dock blur updates after temporary invalid geometry states
- refresh dash blur after `monitors-changed` and `workareas-changed`

## Why
On GNOME Shell startup and after wallpaper/layout refreshes triggered by Hanabi, the dock can temporarily report incomplete geometry. Blur my Shell was still updating the dash blur state during that window, which could lead to invalid clip values and leave the dock blur visually broken until the extension was toggled.

## Notes
Related debugging conversation: {conversation_link}

Co-Authored-By: Oz <oz-agent@warp.dev>
