### PR TITLE
Add -y flag to dnf install command

### DIFF
--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -110,7 +110,7 @@ install_dep(){
 		echo "--------------------------------------------------------"
 		echo "Installing dependency"
 		echo "--------------------------------------------------------"
-		sudo dnf install git glib2-devel @c-development meson mutter-devel gobject-introspection
+		sudo dnf -y install git glib2-devel @c-development meson mutter-devel gobject-introspection
 	else
 		echo "--------------------------------------------------------"
 		echo "Please manually install the equivalent of libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson on your computer"


### PR DESCRIPTION
This change is small but important.

If attempting to install `gnome-rounded-blur` via the script on Fedora causes this:

<img width="1675" height="1282" alt="image" src="https://github.com/user-attachments/assets/b93918b9-75a4-4d99-ad9a-5dcd92f14796" />

It will abort without fail. this is because `dnf` wants to confirm that you actually want these changes but running `dnf` in a script will auto-abort unless it has the `--assumeyes` /  `-y` flag.