### PR TITLE
gnome-rounded-blur script update

### DIFF
--- a/scripts/GUIDE.md
+++ b/scripts/GUIDE.md
@@ -28,11 +28,11 @@ You can get this library by getting it on [the AUR](https://aur.archlinux.org/pa
 
 - For `paru` users
 ```
-$ paru -S gnome-rounded-blur
+paru -S gnome-rounded-blur
 ```
 - For `yay` users
 ```
-$ yay -S gnome-rounded-blur
+yay -S gnome-rounded-blur
 ```
 
 ### Build it yourself

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -106,9 +106,9 @@ uninstall_lib(){
 		echo "Uninstalling"
 		echo "--------------------------------------------------------"
 		sudo rm -rf /usr/include/blur-effect-1.0
-		if [ ! -f /usr/lib/libblur-effect-1.0.so ]; then
+		if [ -e /usr/lib64/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		elif [ ! -f /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
+		elif [ -f /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib/x86_64-linux-gnu/girepository-1.0/Blur-1.0.typelib /usr/lib/x86_64-linux-gnu/pkgconfig/blur-effect-1.0.pc /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1 /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		else
 			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -216,7 +216,7 @@ while true; do
             break
             ;;
 		-h|--help)
-			k=y
+			h=y
             help_doc
             shift
             break

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -108,7 +108,7 @@ uninstall_lib(){
 		sudo rm -rf /usr/include/blur-effect-1.0
 		if [ -e /usr/lib64/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		elif [ -f /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
+		elif [ -e /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib/x86_64-linux-gnu/girepository-1.0/Blur-1.0.typelib /usr/lib/x86_64-linux-gnu/pkgconfig/blur-effect-1.0.pc /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1 /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		else
 			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -110,7 +110,7 @@ uninstall_lib(){
 			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		elif [ -e /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib/x86_64-linux-gnu/girepository-1.0/Blur-1.0.typelib /usr/lib/x86_64-linux-gnu/pkgconfig/blur-effect-1.0.pc /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1 /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		elif [ -e /usr/lib/libblur-effect-1.0.so ];
+		elif [ -e /usr/lib/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		else
 			echo "--------------------------------------------------------"

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -80,8 +80,8 @@ install_lib(){
 	echo "Installing the library"
 	echo "--------------------------------------------------------"
 	meson install -C build --destdir "$dest_dir"
-	sudo install -D -m 655 -o root -t /usr/ ./build/binary/usr/local/* 
-
+	sudo cp -rf ./build/binary/usr/local/* /usr/
+	
 	echo "--------------------------------------------------------"
 	echo "For the changes to apply, please log out and then log back in."
 	echo "--------------------------------------------------------"

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -110,8 +110,12 @@ uninstall_lib(){
 			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		elif [ -e /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib/x86_64-linux-gnu/girepository-1.0/Blur-1.0.typelib /usr/lib/x86_64-linux-gnu/pkgconfig/blur-effect-1.0.pc /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1 /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		else
+		elif [ -e /usr/lib/libblur-effect-1.0.so ];
 			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
+		else
+			echo "--------------------------------------------------------"
+			echo "No library found, skipping"
+			echo "--------------------------------------------------------"
 		fi
 		echo "--------------------------------------------------------"
 		echo "For the changes to apply, please log out and then log back in."

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -95,7 +95,11 @@ uninstall_lib(){
 		echo "Uninstalling"
 		echo "--------------------------------------------------------"
 		sudo rm -rf /usr/include/blur-effect-1.0
-		sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+		if [ ! -f /usr/lib/libblur-effect-1.0.so ]; then
+			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+		else
+			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+		fi
 		echo "--------------------------------------------------------"
 		echo "For the changes to apply, please log out and then log back in."
 		echo "--------------------------------------------------------"

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -30,7 +30,7 @@ install_git(){
 			echo "--------------------------------------------------------"
 			echo "Installing git"
 			echo "--------------------------------------------------------"
-			sudo apt install git 
+			sudo apt -y install git 
 		elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
 			echo "--------------------------------------------------------"
 			echo "Installing git"
@@ -44,6 +44,17 @@ install_git(){
 			exit 1
 		fi
 	fi
+
+	# Ubuntu doesn't have this installed for some reason.
+	if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then	
+		if ! command -v mutter >/dev/null 2>&1
+		then
+			echo "--------------------------------------------------------"
+			echo "Installing mutter"
+			echo "--------------------------------------------------------"
+			sudo apt -y install mutter
+		fi
+	fi
 }
 
 install_dep(){
@@ -51,7 +62,7 @@ install_dep(){
 		echo "--------------------------------------------------------"
 		echo "Installing dependency"
 		echo "--------------------------------------------------------"
-		sudo apt install libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
+		sudo apt -y install libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
 	elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
 		echo "--------------------------------------------------------"
 		echo "Installing dependency"

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -96,9 +96,9 @@ uninstall_lib(){
 		echo "--------------------------------------------------------"
 		sudo rm -rf /usr/include/blur-effect-1.0
 		if [ ! -f /usr/lib/libblur-effect-1.0.so ]; then
-			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
-		else
 			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+		else
+			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
 		fi
 		echo "--------------------------------------------------------"
 		echo "For the changes to apply, please log out and then log back in."

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -33,12 +33,12 @@ check_env(){
 install_git(){
 	if ! command -v git >/dev/null 2>&1
 	then
-		if [[ "$OS_TYPE"="debian" ]]; then
+		if [[ $OS_TYPE="debian" ]]; then
 			echo "--------------------------------------------------------"
 			echo "Installing git"
 			echo "--------------------------------------------------------"
 			sudo apt install git 
-		elif [[ "$OS_TYPE"="fedora" ]]; then
+		elif [[ $OS_TYPE="fedora" ]]; then
 			echo "--------------------------------------------------------"
 			echo "Installing git"
 			echo "--------------------------------------------------------"
@@ -195,14 +195,14 @@ while true; do
             shift
             break
             ;;
-				-u|--uninstall)
-						u=y
+		-u|--uninstall)
+			u=y
             uninstall_lib
             shift
             break
             ;;
-				-h|--help)
-						k=y
+		-h|--help)
+			k=y
             help_doc
             shift
             break

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -1,9 +1,124 @@
 #!/bin/bash
 
+check_env(){
+	OS_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID=).*')
+	OS_LIKE_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID_LIKE=).*' || true)
+
+	if [[ "$OS_ID_TYPE" = "arch" ]] || [[ "$OS_LIKE_ID_TYPE" = "arch" ]]; then
+		if [[ $i = "y" ]] && [[ $u = "n" ]]; then		
+			echo "--------------------------------------------------------"
+			echo "Please do not use this script to install gnome-rounded-blur on Arch Linux"
+			echo "To install this library on Arch, please do so via the AUR"
+			echo "https://aur.archlinux.org/packages/gnome-rounded-blur"
+			echo "--------------------------------------------------------"
+		elif [[ $i = "n" ]] && [[ $u = "y" ]]; then	
+			echo "--------------------------------------------------------"
+			echo "Please do not use this script to uninstall gnome-rounded-blur on Arch Linux"
+			echo "To uninstall this library on Arch, please use the following command"
+			echo "< sudo pacman -R gnome-rounded-blur >"
+			echo "--------------------------------------------------------"
+		fi
+		OS_TYPE="arch"
+		sleep 5
+		exit 1
+	elif [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
+		OS_TYPE="debian"
+	elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
+		OS_TYPE="fedora"
+	else
+		OS_TYPE="unknown"
+	fi
+}
+
+install_git(){
+	if ! command -v git >/dev/null 2>&1
+	then
+		if [[ "$OS_TYPE"="debian" ]]; then
+			echo "--------------------------------------------------------"
+			echo "Installing git"
+			echo "--------------------------------------------------------"
+			sudo apt install git 
+		elif [[ "$OS_TYPE"="fedora" ]]; then
+			echo "--------------------------------------------------------"
+			echo "Installing git"
+			echo "--------------------------------------------------------"
+			sudo dnf -y install git
+		else
+			echo "--------------------------------------------------------"
+			echo "Please manually install git using your distro's package manager"
+			echo "--------------------------------------------------------"
+			sleep 5
+			exit 1
+		fi
+	fi
+}
+
+install_dep(){
+	if [[ "$OS_TYPE"="debian" ]]; then
+		echo "--------------------------------------------------------"
+		echo "Installing dependency"
+		echo "--------------------------------------------------------"
+		sudo apt install libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
+	elif [[ "$OS_TYPE"="fedora" ]]; then
+		echo "--------------------------------------------------------"
+		echo "Installing dependency"
+		echo "--------------------------------------------------------"
+		sudo dnf -y install glib2-devel @c-development meson mutter-devel gobject-introspection
+	else
+		echo "--------------------------------------------------------"
+		echo "Please manually install the equivalent of libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson on your computer"
+		echo "The setup will still proceed and fail if you don't have those installed"
+		echo "--------------------------------------------------------"
+		sleep 5
+	fi
+}
+
 install_lib(){
+	prep_stage
+		
+	echo "--------------------------------------------------------"
+	echo "Building the library"
+	echo "--------------------------------------------------------"
+	meson setup build;
+	meson compile -C build;
+	
+	# meson install the library in the wrong directory, we'll do that ourselves
+	echo "--------------------------------------------------------"
+	echo "Installing the library"
+	echo "--------------------------------------------------------"
+	meson install -C build --destdir "$dest_dir"
+	sudo install -D -m 655 -o root -t /usr/ ./build/binary/usr/local/* 
+	
+	echo "--------------------------------------------------------"
+	echo "For the changes to apply, please log out and then log back in."
+	echo "--------------------------------------------------------"
+}
+
+uninstall_lib(){
+	check_env
+	
+	if [[ "$OS_TYPE" = "debian" ]] || [[ "$OS_TYPE" = "fedora" ]]; then
+		echo "--------------------------------------------------------"
+		echo "Uninstalling"
+		echo "--------------------------------------------------------"
+		sudo rm -rf /usr/include/blur-effect-1.0
+		sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+		echo "--------------------------------------------------------"
+		echo "For the changes to apply, please log out and then log back in."
+		echo "--------------------------------------------------------"
+	fi
+}
+
+prep_stage(){
 	REPO="https://github.com/kancko/gnome-rounded-blur"
 	dest_dir="./binary"
 	build_dir="/tmp"
+	
+	# Check for current environment before doing anything
+	check_env
+	
+	# Install git first before doing anything else
+	install_git
 	
 	echo "--------------------------------------------------------"
 	echo "Cloning repo"
@@ -37,87 +152,6 @@ install_lib(){
 	fi
 	
 	install_dep;
-	
-	echo "--------------------------------------------------------"
-	echo "Building the library"
-	echo "--------------------------------------------------------"
-	meson setup build;
-	meson compile -C build;
-	
-	# meson install the library in the wrong directory, we'll do that ourselves
-	echo "--------------------------------------------------------"
-	echo "Installing the library"
-	echo "--------------------------------------------------------"
-	meson install -C build --destdir "$dest_dir"
-	sudo cp -rf ./build/binary/usr/local/* /usr/
-	
-	echo "--------------------------------------------------------"
-	echo "For the changes to apply, please log out and then log back in."
-	echo "--------------------------------------------------------"
-}
-
-uninstall_lib(){
-	OS_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID=).*')
-	OS_LIKE_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID_LIKE=).*' || true)
-	
-	if [[ "$OS_ID_TYPE" = "arch" ]] || [[ "$OS_LIKE_ID_TYPE" = "arch" ]]; then
-	 	echo "--------------------------------------------------------"
-		echo "Please do not use this script to uninstall the library if you installed it via the AUR,"
-		echo "use pacman -R gnome-rounded-blur instead"
-		echo "--------------------------------------------------------"
-		sleep 5
-		exit 1
-	else
-		echo "--------------------------------------------------------"
-		echo "Uninstalling"
-		echo "--------------------------------------------------------"
-		sudo rm -rf /usr/include/blur-effect-1.0
-		sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
-	fi
-
-	echo "--------------------------------------------------------"
-	echo "For the changes to apply, please log out and then log back in."
-	echo "--------------------------------------------------------"
-}
-
-# More safety, by turning some bugs into errors.
-set -o errexit -o pipefail -o noclobber -o nounset
-
-# ignore errexit with `&& true`
-getopt --test > /dev/null && true
-if [[ $? -ne 4 ]]; then
-    echo 'I’m sorry, `getopt --test` failed in this environment.'
-    exit 1
-fi
-
-install_dep(){
-	OS_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID=).*')
-	OS_LIKE_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID_LIKE=).*' || true)
-
-	if [[ "$OS_ID_TYPE" = "arch" ]] || [[ "$OS_LIKE_ID_TYPE" = "arch" ]]; then
-	 	echo "--------------------------------------------------------"
-		echo "Please install this library via the AUR"
-		echo "https://aur.archlinux.org/packages/gnome-rounded-blur"
-		echo "--------------------------------------------------------"
-		sleep 5
-		exit 1
-	elif [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
-		echo "--------------------------------------------------------"
-		echo "Installing dependency"
-		echo "--------------------------------------------------------"
-		sudo apt install git libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
-	elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
-		echo "--------------------------------------------------------"
-		echo "Installing dependency"
-		echo "--------------------------------------------------------"
-		sudo dnf -y install git glib2-devel @c-development meson mutter-devel gobject-introspection
-	else
-		echo "--------------------------------------------------------"
-		echo "Please manually install the equivalent of libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson on your computer"
-		echo "The setup will still proceed and fail if you don't have those installed"
-		echo "--------------------------------------------------------"
-		sleep 5
-	fi
 }
 
 help_doc(){
@@ -128,6 +162,17 @@ help_doc(){
 	echo "-u			Uninstall the library"
 	echo "-h			Help"
 }
+
+
+# More safety, by turning some bugs into errors.
+set -o errexit -o pipefail -o noclobber -o nounset
+
+# ignore errexit with `&& true`
+getopt --test > /dev/null && true
+if [[ $? -ne 4 ]]; then
+    echo 'I’m sorry, `getopt --test` failed in this environment.'
+    exit 1
+fi
 
 LONGOPTS=install,uninstall,help
 OPTIONS=iuh
@@ -151,7 +196,7 @@ while true; do
             break
             ;;
 				-u|--uninstall)
-						k=y
+						u=y
             uninstall_lib
             shift
             break

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -88,7 +88,7 @@ install_lib(){
 	echo "--------------------------------------------------------"
 	meson install -C build --destdir "$dest_dir"
 	sudo install -D -m 655 -o root -t /usr/ ./build/binary/usr/local/* 
-	
+
 	echo "--------------------------------------------------------"
 	echo "For the changes to apply, please log out and then log back in."
 	echo "--------------------------------------------------------"
@@ -221,6 +221,7 @@ done
 # handle non-option arguments
 if [[ $# -ne 1 ]]; then
     echo "$0: A single input file is required."
+	help_doc
     exit 4
 fi
 

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -108,6 +108,8 @@ uninstall_lib(){
 		sudo rm -rf /usr/include/blur-effect-1.0
 		if [ ! -f /usr/lib/libblur-effect-1.0.so ]; then
 			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
+		elif [ ! -f /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
+			sudo rm /usr/lib/x86_64-linux-gnu/girepository-1.0/Blur-1.0.typelib /usr/lib/x86_64-linux-gnu/pkgconfig/blur-effect-1.0.pc /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1 /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		else
 			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		fi

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -96,9 +96,9 @@ uninstall_lib(){
 		echo "--------------------------------------------------------"
 		sudo rm -rf /usr/include/blur-effect-1.0
 		if [ ! -f /usr/lib/libblur-effect-1.0.so ]; then
-			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		else
-			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir
+			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
 		fi
 		echo "--------------------------------------------------------"
 		echo "For the changes to apply, please log out and then log back in."

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -18,27 +18,20 @@ check_env(){
 			echo "< sudo pacman -R gnome-rounded-blur >"
 			echo "--------------------------------------------------------"
 		fi
-		OS_TYPE="arch"
 		sleep 5
 		exit 1
-	elif [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
-		OS_TYPE="debian"
-	elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
-		OS_TYPE="fedora"
-	else
-		OS_TYPE="unknown"
 	fi
 }
 
 install_git(){
 	if ! command -v git >/dev/null 2>&1
 	then
-		if [[ $OS_TYPE="debian" ]]; then
+		if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
 			echo "--------------------------------------------------------"
 			echo "Installing git"
 			echo "--------------------------------------------------------"
 			sudo apt install git 
-		elif [[ $OS_TYPE="fedora" ]]; then
+		elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
 			echo "--------------------------------------------------------"
 			echo "Installing git"
 			echo "--------------------------------------------------------"
@@ -54,12 +47,12 @@ install_git(){
 }
 
 install_dep(){
-	if [[ "$OS_TYPE"="debian" ]]; then
+	if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
 		echo "--------------------------------------------------------"
 		echo "Installing dependency"
 		echo "--------------------------------------------------------"
 		sudo apt install libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
-	elif [[ "$OS_TYPE"="fedora" ]]; then
+	elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
 		echo "--------------------------------------------------------"
 		echo "Installing dependency"
 		echo "--------------------------------------------------------"
@@ -97,7 +90,7 @@ install_lib(){
 uninstall_lib(){
 	check_env
 	
-	if [[ "$OS_TYPE" = "debian" ]] || [[ "$OS_TYPE" = "fedora" ]]; then
+	if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]] || [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
 		echo "--------------------------------------------------------"
 		echo "Uninstalling"
 		echo "--------------------------------------------------------"


### PR DESCRIPTION
- Fixed uninstallation on Fedora and Ubuntu because they both install the library on two different directory (`/usr/lib64` on Fedora and `/usr/lib/x86_64-linux-gnu` on Ubuntu)
- Now check for enviroment and install `git` if not installed (and `mutter` on ubuntu because they don't have that installed for some reason) before doing anything else.
- `-y` arg for `apt` as well