### PR TITLE
Use adw-external-link-symbolic instead of just external-link-symbolic

### DIFF
--- a/resources/ui/applications.ui
+++ b/resources/ui/applications.ui
@@ -118,7 +118,7 @@ To get the best results possible, although with reduced performances, you can ch
 
             <child type="suffix">
               <object class="GtkButton" id="open_gnome_rounded_blur">
-                <property name="icon-name">external-link-symbolic</property>
+                <property name="icon-name">adw-external-link-symbolic</property>
                 <property name="valign">center</property>
                 <property name="action-name">link.open-gnome-rounded-blur</property>
               </object>

--- a/resources/ui/dash.ui
+++ b/resources/ui/dash.ui
@@ -117,7 +117,7 @@
 
             <child type="suffix">
               <object class="GtkButton" id="open_gnome_rounded_blur">
-                <property name="icon-name">external-link-symbolic</property>
+                <property name="icon-name">adw-external-link-symbolic</property>
                 <property name="valign">center</property>
                 <property name="action-name">link.open-gnome-rounded-blur</property>
               </object>

--- a/resources/ui/panel.ui
+++ b/resources/ui/panel.ui
@@ -117,7 +117,7 @@
 
             <child type="suffix">
               <object class="GtkButton" id="open_gnome_rounded_blur">
-                <property name="icon-name">external-link-symbolic</property>
+                <property name="icon-name">adw-external-link-symbolic</property>
                 <property name="valign">center</property>
                 <property name="action-name">link.open-gnome-rounded-blur</property>
               </object>


### PR DESCRIPTION
This fix the external link icon for those who do not use Yaru 
<img width="601" height="116" alt="image" src="https://github.com/user-attachments/assets/990869b4-1b7c-468c-9547-9299e1e9db8b" />

and Yaru default this to their icon pack anyway so no problem there
