### PR TITLE
Fix: Secondary-monitor windows hidden after workspace switch when applications.BLUR is enabled

### DIFF
--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -108,7 +108,13 @@ export const OverviewBlur = class OverviewBlur {
                     for (let i = 0; i < w_m.get_n_workspaces(); i++) {
                         if (i != w_m.get_active_workspace_index())
                             w_m.get_workspace_by_index(i)?.list_windows().forEach(
-                                window => window.get_compositor_private().hide()
+                                window => {
+                                    // skip windows on all workspaces (e.g. secondary
+                                    // monitor windows under `workspaces-only-on-primary`);
+                                    // hiding them on any inactive workspace hides them globally
+                                    if (window.is_on_all_workspaces()) return;
+                                    window.get_compositor_private().hide();
+                                }
                             );
                     }
 


### PR DESCRIPTION
Fixes #866.

When `applications.BLUR` is enabled, the patched `_finishWorkspaceSwitch` iterates inactive workspaces and calls `.hide()` on every window returned by `list_windows()`. Windows on all workspaces — including secondary-monitor windows under `workspaces-only-on-primary = true` — appear in every workspace's list, so the loop hid them globally.

Skip them with `is_on_all_workspaces()`.

Tested on GNOME Shell 50 / Wayland with the repro from #866 — the bug is gone with the patch and reproducible without it.