### PR TITLE
Fix: blacklisted windows disappear during workspace gesture switch

### DIFF
--- a/src/components/overview.js
+++ b/src/components/overview.js
@@ -104,7 +104,14 @@ export const OverviewBlur = class OverviewBlur {
                 // this hides windows that are not on the current workspace
                 if (
                     outer_this.settings.applications.BLUR
-                )
+                ) {
+                    // compile blacklist patterns once for this switch
+                    const blacklist = outer_this.settings.applications.BLACKLIST || [];
+                    const blacklist_regexes = blacklist.map(pattern => {
+                        const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+                        return new RegExp('^' + escaped.replace(/\*/g, '.*').replace(/\?/g, '.') + '$', 'i');
+                    });
+
                     for (let i = 0; i < w_m.get_n_workspaces(); i++) {
                         if (i != w_m.get_active_workspace_index())
                             w_m.get_workspace_by_index(i)?.list_windows().forEach(
@@ -113,10 +120,23 @@ export const OverviewBlur = class OverviewBlur {
                                     // monitor windows under `workspaces-only-on-primary`);
                                     // hiding them on any inactive workspace hides them globally
                                     if (window.is_on_all_workspaces()) return;
+
+                                    // skip desktop-type windows (e.g. DING, Nautilus desktop):
+                                    // they should always remain visible
+                                    if (window.get_window_type() === Meta.WindowType.DESKTOP)
+                                        return;
+
+                                    // skip blacklisted windows:
+                                    // they are not blurred and should always remain visible
+                                    const wm_class = window.get_wm_class();
+                                    if (wm_class && blacklist_regexes.some(re => re.test(wm_class)))
+                                        return;
+
                                     window.get_compositor_private().hide();
                                 }
                             );
                     }
+                }
 
                 Main.uiGroup.remove_child(outer_this.animation_background_group);
             };


### PR DESCRIPTION
**Problem**
When switching workspaces using touchpad gestures, windows that are in the application blur blacklist (e.g. DING desktop icons, Conky, Plank) temporarily disappear and do not reappear after the transition completes.
This does not happen when switching workspaces via keyboard shortcuts.

**Root cause**
In `_finishWorkspaceSwitch` (patched in `src/components/overview.js`), all window actors that do not belong to the active workspace are hidden with `.hide()`. The intent is to restore the normal GNOME behaviour of hiding off-workspace windows after the blur extension showed them during the animation.
However, the code hid every off-workspace window unconditionally, including windows that are in the user's blacklist. Blacklisted windows are never given a blur actor, so the extension never calls `.show()` on them again — leaving them permanently hidden until the next login.

```
// before: hides everything indiscriminately
window.get_compositor_private().hide();
```

**Fix**
Before hiding a window actor, skip it if its `wm_class` matches any pattern in the user's blacklist. These windows are not blurred by the extension and must always remain visible.
The same wildcard-to-regex logic already used in `applications.js` is applied here, compiled once per workspace switch for efficiency.

```
// after: respects the blacklist
const wm_class = window.get_wm_class();
if (wm_class && blacklist_regexes.some(re => re.test(wm_class))) return;
window.get_compositor_private().hide();
```

**Files changed**
·	src/components/overview.js — _finishWorkspaceSwitch only

**Testing**
Tested on:
·	Ubuntu 26.04, GNOME 50.1, Wayland
·	[DING](https://gitlab.com/rastersoft/desktop-icons-ng) added to blacklist
·	Switching workspaces via 3-finger swipe gesture: icons remain visible ✓
·	Switching workspaces via Super+PageDown: no regression ✓
·	Blacklisted apps (Conky, Plank, browser) unaffected ✓
