### PR TITLE
fix pipeline.js: prevent wallpaper swap flash on blurred surfaces

### DIFF
--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -69,7 +69,7 @@ export const Pipeline = class Pipeline {
         // sibling re-ordering.
         // Without it, new actors render on top while loading, causing a solid color flash through
         // on the surface.
-        this.actor.connect(
+        this._child_added_id = this.actor.connect(
             'child-added', (_container, child) => {
                 if (child instanceof Meta.BackgroundActor)
                     _container.set_child_below_sibling(child, null);
@@ -148,7 +148,10 @@ export const Pipeline = class Pipeline {
         this.remove_all_effects();
         if (this.actor && this.actor_destroy_id)
             this.actor.disconnect(this.actor_destroy_id);
+        if (this.actor && this._child_added_id)
+            this.actor.disconnect(this._child_added_id);
         this.actor_destroy_id = null;
+        this._child_added_id = null;
         this.actor = null;
     }
 

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -69,7 +69,7 @@ export const Pipeline = class Pipeline {
         // sibling re-ordering.
         // Without it, new actors render on top while loading, causing a solid color flash through
         // on the surface.
-        this._child_added_id = this.actor.connect(
+        this.child_added_id = this.actor.connect(
             'child-added', (_container, child) => {
                 if (child instanceof Meta.BackgroundActor)
                     _container.set_child_below_sibling(child, null);
@@ -148,10 +148,10 @@ export const Pipeline = class Pipeline {
         this.remove_all_effects();
         if (this.actor && this.actor_destroy_id)
             this.actor.disconnect(this.actor_destroy_id);
-        if (this.actor && this._child_added_id)
-            this.actor.disconnect(this._child_added_id);
+        if (this.actor && this.child_added_id)
+            this.actor.disconnect(this.child_added_id);
         this.actor_destroy_id = null;
-        this._child_added_id = null;
+        this.child_added_id = null;
         this.actor = null;
     }
 

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -1,4 +1,5 @@
 import St from 'gi://St';
+import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Background from 'resource:///org/gnome/shell/ui/background.js';
 
@@ -63,6 +64,22 @@ export const Pipeline = class Pipeline {
             controlPosition: false,
         });
         bg_manager._bms_pipeline = this;
+
+        // Since controlPosition is false, gnome-shell BackgroundManager skips its default layout pass,
+        // disabling sibling re-ordering.
+        // To prevent them from rendering on top of the existing background (while loading - leading
+        // to a dark flash), we force new background actors to the bottom of the container.
+        bg_manager._bms_child_added_id = this.actor.connect(
+            'child-added', (_container, child) => {
+                if (child instanceof Meta.BackgroundActor)
+                    _container.set_child_below_sibling(child, null);
+            }
+        );
+
+        // unregister signal handler on actor destruction
+        this.actor.connect('destroy', () => {
+            bg_manager._bms_child_added_id = 0;
+        });
 
         background_managers.push(bg_manager);
         background_group.insert_child_at_index(this.actor, 0);

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -65,21 +65,16 @@ export const Pipeline = class Pipeline {
         });
         bg_manager._bms_pipeline = this;
 
-        // Since controlPosition is false, gnome-shell BackgroundManager skips its default layout pass,
-        // disabling sibling re-ordering.
-        // To prevent them from rendering on top of the existing background (while loading - leading
-        // to a dark flash), we force new background actors to the bottom of the container.
-        bg_manager._bms_child_added_id = this.actor.connect(
+        // 'controlPosition: false' skips BackgroundManager's default layout pass, which also diables
+        // sibling re-ordering.
+        // Without it, new actors render on top while loading, causing a solid color flash through
+        // on the surface.
+        this.actor.connect(
             'child-added', (_container, child) => {
                 if (child instanceof Meta.BackgroundActor)
                     _container.set_child_below_sibling(child, null);
             }
         );
-
-        // unregister signal handler on actor destruction
-        this.actor.connect('destroy', () => {
-            bg_manager._bms_child_added_id = 0;
-        });
 
         background_managers.push(bg_manager);
         background_group.insert_child_at_index(this.actor, 0);

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -70,9 +70,9 @@ export const Pipeline = class Pipeline {
         // Without it, new actors render on top while loading, causing a solid color flash through
         // on the surface.
         this.child_added_id = this.actor.connect(
-            'child-added', (_container, child) => {
+            'child-added', (container, child) => {
                 if (child instanceof Meta.BackgroundActor)
-                    _container.set_child_below_sibling(child, null);
+                    container.set_child_below_sibling(child, null);
             }
         );
 


### PR DESCRIPTION
### Description of Issue
When the wallpaper changes (slideshow background change, might be other cases) static blur surfaces briefly show a solid background colour before the new wallpaper appears. The flash is consistently reproducible in the overview.

### Cause
[`BackgroundManager`](https://github.com/GNOME/gnome-shell/blob/7bc1a00733cab6d1da619a43fb4d4c3816ff7799/js/ui/background.js#L684) is constructed with `controlPosition: false`, disabling the sibling re-ordering that `BackgroundManager` normally performs in [`_createBackgroundActor()`](https://github.com/GNOME/gnome-shell/blob/7bc1a00733cab6d1da619a43fb4d4c3816ff7799/js/ui/background.js#L801-L805): when a new `MetaBackgroundActor` is created during a wallpaper swap, it lands on top of the existing actor rather than below it.

While the new actor's image is loading, `MetaBackgroundContent` displays `DEFAULT_BACKGROUND_COLOR`.

### Fix
Reinstate the sibling re-ordering in a `child-added` handler. New `MetaBackgroundActors` are moved down in the container, so their 'loading' frames are hidden behind the existing actor.
GNOME's 1s opacity fade of the old actor then produces a blurred crossfade with no visible artefacts.

```js
this.actor.connect(
    'child-added', (_container, child) => {
        if (child instanceof Meta.BackgroundActor)
            _container.set_child_below_sibling(child, null);
    }
);
```

### Testing
Tested on GNOME Shell 50, Wayland, with a slideshow cycling every 30s:
- Wallpaper change while on the desktop: smooth blurred crossfade → no flash
- Wallpaper change while in the overview: previously the most reliable reproduction → no flash

### Notes
A reliably reproducible flash in the overview's unblurred workspace background (not the Blur-My-Shell blur layer) is present with all extensions disabled. That is a separate upstream issue in `gnome-shell` itself and is out of scope here.
I'm currently working on a gnome-shell patch for that separately.