### PR TITLE
Add Liquid Glass-style refraction effect

### DIFF
--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -401,7 +401,7 @@ export function get_supported_effects(_ = () => "") {
                     description: _("Blurs the sampled backdrop before the liquid-glass shader is applied."),
                     type: "float",
                     min: 0.,
-                    max: 80.,
+                    max: 48.,
                     increment: 1.,
                     big_increment: 10.,
                     digits: 0
@@ -415,6 +415,16 @@ export function get_supported_effects(_ = () => "") {
                     increment: 1.,
                     big_increment: 10.,
                     digits: 0
+                },
+                rim_width: {
+                    name: _("Rim spread"),
+                    description: _("How far the refraction eases inward from the glass edge."),
+                    type: "float",
+                    min: 1.,
+                    max: 6.5,
+                    increment: 0.1,
+                    big_increment: 0.5,
+                    digits: 2
                 },
                 falloff: {
                     name: _("Glass thickness"),

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -446,16 +446,6 @@ export function get_supported_effects(_ = () => "") {
                     big_increment: 0.1,
                     digits: 2
                 },
-                webcam_gloss: {
-                    name: _("Experimental webcam gloss"),
-                    description: _("Modulates gloss from live camera brightness. This may request camera access and is experimental."),
-                    type: "boolean"
-                },
-                webcam_device: {
-                    name: _("Experimental video selector"),
-                    description: _("Camera device used by experimental webcam gloss."),
-                    type: "video_device"
-                },
                 tint: {
                     name: _("Tint"),
                     description: _("Amount of subtle milky glass tint over the blurred texture."),

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -12,6 +12,7 @@ import { DerivativeEffect } from './derivative.js';
 import { RgbToHslEffect } from './rgb_to_hsl.js';
 import { HslToRgbEffect } from './hsl_to_rgb.js';
 import { LuminosityEffect } from './luminosity.js';
+import { RefractionEffect } from './refraction.js';
 
 // We do in this way because I've not found another way to store our preferences in a dictionnary
 // while calling `gettext` on it while in preferences. Not so pretty, but works.
@@ -31,6 +32,7 @@ export function get_effects_groups(_ = _ => "") {
                 "downscale",
                 "upscale",
                 "pixelize",
+                "refraction",
                 "derivative",
                 "noise",
                 "color",
@@ -374,6 +376,124 @@ export function get_supported_effects(_ = () => "") {
                     increment: 0.01,
                     big_increment: 0.1,
                     digits: 2
+                }
+            }
+        },
+
+        refraction: {
+            class: RefractionEffect,
+            name: _("Liquid Glass"),
+            description: _("A glossy translucent material with edge refraction, rim lighting, tint, and inner shadow."),
+            is_advanced: false,
+            editable_params: {
+                strength: {
+                    name: _("Refraction scale"),
+                    description: _("How strongly the glass bends the sampled blur texture."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.01,
+                    big_increment: 0.1,
+                    digits: 2
+                },
+                blur_radius: {
+                    name: _("Blur radius"),
+                    description: _("Blurs the sampled backdrop before the liquid-glass shader is applied."),
+                    type: "float",
+                    min: 0.,
+                    max: 80.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0
+                },
+                edge_size: {
+                    name: _("Bezel width"),
+                    description: _("How far the liquid-glass lens reaches inward from the edge."),
+                    type: "float",
+                    min: 1.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0
+                },
+                falloff: {
+                    name: _("Glass thickness"),
+                    description: _("Depth used by the Snell-style refraction profile."),
+                    type: "float",
+                    min: 0.25,
+                    max: 8.,
+                    increment: 0.05,
+                    big_increment: 0.5,
+                    digits: 2
+                },
+                corner_radius: {
+                    name: _("Corner radius"),
+                    description: _("The rounded shape used for the glass edge and highlight."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0
+                },
+                gloss: {
+                    name: _("Gloss"),
+                    description: _("Strength of the white rim and surface highlight."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.01,
+                    big_increment: 0.1,
+                    digits: 2
+                },
+                webcam_gloss: {
+                    name: _("Experimental webcam gloss"),
+                    description: _("Modulates gloss from live camera brightness. This may request camera access and is experimental."),
+                    type: "boolean"
+                },
+                webcam_device: {
+                    name: _("Experimental video selector"),
+                    description: _("Camera device used by experimental webcam gloss."),
+                    type: "video_device"
+                },
+                tint: {
+                    name: _("Tint"),
+                    description: _("Amount of subtle milky glass tint over the blurred texture."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.01,
+                    big_increment: 0.1,
+                    digits: 2
+                },
+                shadow: {
+                    name: _("Inner shadow"),
+                    description: _("Darkens the lower and inner edge for a deeper glass surface."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.01,
+                    big_increment: 0.1,
+                    digits: 2
+                },
+                rgb_fringing: {
+                    name: _("RGB fringing"),
+                    description: _("Adds subtle color separation to the bent texture."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.01,
+                    big_increment: 0.1,
+                    digits: 2
+                },
+                texture_repeat: {
+                    name: _("Edge behavior"),
+                    description: _("How texture coordinates outside the actor are sampled."),
+                    type: "dropdown",
+                    options: [
+                        _("Clamp"),
+                        _("Mirror")
+                    ]
                 }
             }
         },

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -1,6 +1,5 @@
-// Adapted from winaviation-tweaks/liquidass Shared/LGMetalShaderSource.m.
-// Blur my Shell gives us the current pipeline texture, so this GLSL version
-// applies LiquidAss' bezel/refraction/specular model to that texture.
+// GLSL port of winaviation-tweaks/liquidass Shared/LGMetalShaderSource.m.
+// The sampling and blur pass are adapted for Blur my Shell's Clutter pipeline.
 uniform sampler2D tex;
 uniform float width;
 uniform float height;
@@ -9,6 +8,7 @@ uniform float blur_radius;
 uniform float edge_size;
 uniform float falloff;
 uniform float corner_radius;
+uniform float rim_width;
 uniform float rgb_fringing;
 uniform float gloss;
 uniform float tint;
@@ -21,6 +21,9 @@ uniform float clip_x0;
 uniform float clip_y0;
 uniform float clip_width;
 uniform float clip_height;
+
+const float PI = 3.14159265;
+const float REFRACTIVE_INDEX = 1.52;
 
 float surfaceConvexSquircle(float x) {
     return pow(1.0 - pow(1.0 - x, 4.0), 0.25);
@@ -139,16 +142,12 @@ float luminance(vec3 color) {
     return dot(color, vec3(0.2126, 0.7152, 0.0722));
 }
 
-float nearPeak(float value, float peak, float band) {
-    return 1.0 - smoothstep(band * 0.35, band, peak - value);
-}
-
 vec2 clampUV(vec2 uv) {
     vec2 px = vec2(1.5 / width, 1.5 / height);
     return clamp(uv, px, vec2(1.0) - px);
 }
 
-vec2 sampleUV(vec2 uv) {
+vec2 resolveUV(vec2 uv) {
     if (texture_repeat == 1) {
         vec2 mirrored = abs(fract(uv * 0.5) * 2.0 - 1.0);
         return clampUV(mirrored);
@@ -157,26 +156,29 @@ vec2 sampleUV(vec2 uv) {
     return clampUV(uv);
 }
 
+vec4 sampleBackdrop(vec2 uv) {
+    return texture2D(tex, resolveUV(uv));
+}
+
 vec4 sampleGlassBackdrop(vec2 uv) {
     if (blur_radius <= 0.01)
-        return texture2D(tex, sampleUV(uv));
+        return sampleBackdrop(uv);
 
     float sigma = max(0.1, blur_radius * 0.5);
     float pixelStep = blur_direction == 1 ? 1.0 / width : 1.0 / height;
     vec2 direction = vec2(float(blur_direction), 1.0 - float(blur_direction));
 
     vec3 gauss;
-    gauss.x = 1.0 / (sqrt(2.0 * 3.14159265) * sigma);
+    gauss.x = 1.0 / (sqrt(2.0 * PI) * sigma);
     gauss.y = exp(-0.5 / (sigma * sigma));
     gauss.z = gauss.y * gauss.y;
 
-    vec4 accum = texture2D(tex, sampleUV(uv)) * gauss.x;
+    vec4 accum = sampleBackdrop(uv) * gauss.x;
     float weightSum = gauss.x;
 
     gauss.xy *= gauss.yz;
 
     int radius = int(ceil(1.5 * sigma)) * 2;
-
     for (int i = 1; i <= radius; i += 2) {
         float subtotal = gauss.x;
 
@@ -184,12 +186,11 @@ vec4 sampleGlassBackdrop(vec2 uv) {
         subtotal += gauss.x;
 
         float gaussRatio = gauss.x / subtotal;
-        float foffset = float(i) + gaussRatio;
-        vec2 offset = direction * foffset * pixelStep;
+        float offset = float(i) + gaussRatio;
+        vec2 uvOffset = direction * offset * pixelStep;
 
-        accum += texture2D(tex, sampleUV(uv + offset)) * subtotal;
-        accum += texture2D(tex, sampleUV(uv - offset)) * subtotal;
-
+        accum += sampleBackdrop(uv + uvOffset) * subtotal;
+        accum += sampleBackdrop(uv - uvOffset) * subtotal;
         weightSum += subtotal * 2.0;
 
         gauss.xy *= gauss.yz;
@@ -198,105 +199,60 @@ vec4 sampleGlassBackdrop(vec2 uv) {
     return accum / weightSum;
 }
 
-float roundedRectDist(vec2 p, vec2 halfSize, float radius) {
+float roundedRectDistance(vec2 p, vec2 halfSize, float radius) {
     radius = min(radius, min(halfSize.x, halfSize.y));
     vec2 q = abs(p) - halfSize + vec2(radius);
     return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - radius;
 }
 
+float roundedRectAlpha(float signedDistance, float feather) {
+    return 1.0 - smoothstep(-feather, feather, signedDistance);
+}
+
 vec2 roundedRectNormal(vec2 p, vec2 halfSize, float radius) {
     float h = 1.0;
     vec2 grad = vec2(
-        roundedRectDist(p + vec2(h, 0.0), halfSize, radius) -
-        roundedRectDist(p - vec2(h, 0.0), halfSize, radius),
-        roundedRectDist(p + vec2(0.0, h), halfSize, radius) -
-        roundedRectDist(p - vec2(0.0, h), halfSize, radius)
+        roundedRectDistance(p + vec2(h, 0.0), halfSize, radius) -
+        roundedRectDistance(p - vec2(h, 0.0), halfSize, radius),
+        roundedRectDistance(p + vec2(0.0, h), halfSize, radius) -
+        roundedRectDistance(p - vec2(0.0, h), halfSize, radius)
     );
+
     return length(grad) > 0.0001 ? normalize(grad) : vec2(0.0, -1.0);
 }
 
-vec4 sampleDispersed(vec2 uv, vec2 prismOffset, float dispersion) {
-    vec4 base = sampleGlassBackdrop(sampleUV(uv));
-    if (dispersion <= 0.0001)
-        return base;
+struct EdgeInfo {
+    float distance;
+    float alpha;
+    vec2 dir;
+};
 
-    vec2 redUV = sampleUV(uv - prismOffset * (0.75 + dispersion * 7.0));
-    vec2 blueUV = sampleUV(uv + prismOffset * (0.75 + dispersion * 7.0));
-    vec3 dispersed = vec3(
-        sampleGlassBackdrop(redUV).r,
-        base.g,
-        sampleGlassBackdrop(blueUV).b
-    );
+EdgeInfo estimateAnalyticEdge(vec2 px, vec2 halfSize, float radius, float feather) {
+    vec2 centered = px - halfSize;
+    float signedDistance = roundedRectDistance(centered, halfSize, radius);
 
-    base.rgb = mix(base.rgb, dispersed, clamp(dispersion, 0.0, 1.0));
-    return base;
+    EdgeInfo info;
+    info.distance = max(0.0, -signedDistance);
+    info.alpha = roundedRectAlpha(signedDistance, feather);
+    info.dir = roundedRectNormal(centered, halfSize, radius);
+    return info;
 }
 
-vec4 wallpaperGloss(vec2 uv, vec2 fallbackDir) {
-    vec2 px = 1.0 / vec2(width, height);
-    vec2 radius = px * max(12.0, min(min(width, height) * 0.04, blur_radius * 1.6 + 10.0));
+vec4 sampleDispersed(vec2 sampleUV, vec2 prismOffset, float dispersion) {
+    vec4 bgColor = sampleGlassBackdrop(sampleUV);
+    if (dispersion <= 0.0001)
+        return bgColor;
 
-    float center = luminance(sampleGlassBackdrop(uv).rgb);
-    float left = luminance(sampleGlassBackdrop(uv - vec2(radius.x, 0.0)).rgb);
-    float right = luminance(sampleGlassBackdrop(uv + vec2(radius.x, 0.0)).rgb);
-    float top = luminance(sampleGlassBackdrop(uv - vec2(0.0, radius.y)).rgb);
-    float bottom = luminance(sampleGlassBackdrop(uv + vec2(0.0, radius.y)).rgb);
-    float topLeft = luminance(sampleGlassBackdrop(uv - radius).rgb);
-    float topRight = luminance(sampleGlassBackdrop(uv + vec2(radius.x, -radius.y)).rgb);
-    float bottomLeft = luminance(sampleGlassBackdrop(uv + vec2(-radius.x, radius.y)).rgb);
-    float bottomRight = luminance(sampleGlassBackdrop(uv + radius).rgb);
-
-    float peak = max(
-        center,
-        max(
-            max(left, right),
-            max(
-                max(top, bottom),
-                max(max(topLeft, topRight), max(bottomLeft, bottomRight))
-            )
-        )
-    );
-    float low = min(
-        center,
-        min(
-            min(left, right),
-            min(
-                min(top, bottom),
-                min(min(topLeft, topRight), min(bottomLeft, bottomRight))
-            )
-        )
-    );
-    float band = max(0.08, peak * 0.28);
-    float localPeak = nearPeak(center, peak, band);
-    float coverage = (
-        localPeak +
-        nearPeak(left, peak, band) +
-        nearPeak(right, peak, band) +
-        nearPeak(top, peak, band) +
-        nearPeak(bottom, peak, band) +
-        nearPeak(topLeft, peak, band) +
-        nearPeak(topRight, peak, band) +
-        nearPeak(bottomLeft, peak, band) +
-        nearPeak(bottomRight, peak, band)
-    ) / 9.0;
-    float brightness = smoothstep(0.36, 0.86, peak);
-    float spotSize = smoothstep(0.28, 0.78, coverage) * brightness;
-    float contrastMask = mix(0.55, 1.0, smoothstep(0.025, 0.22, peak - low));
-    float spotMask = brightness * contrastMask * pow(
-        localPeak,
-        mix(3.0, 1.05, spotSize)
+    vec2 redUV = resolveUV(sampleUV - prismOffset * 0.55);
+    vec2 blueUV = resolveUV(sampleUV + prismOffset * 0.55);
+    vec3 dispersed = vec3(
+        sampleGlassBackdrop(mix(sampleUV, redUV, dispersion * 80.0)).r,
+        bgColor.g,
+        sampleGlassBackdrop(mix(sampleUV, blueUV, dispersion * 80.0)).b
     );
 
-    vec2 gradient = vec2(right - left, bottom - top);
-    float contrast = length(gradient);
-    vec2 glossDir = fallbackDir;
-
-    if (contrast >= 0.015) {
-        vec2 backdropDir = normalize(vec2(-gradient.x, gradient.y));
-        glossDir = normalize(mix(fallbackDir, backdropDir, smoothstep(0.015, 0.13, contrast)));
-    }
-
-    return vec4(glossDir, spotMask, spotSize);
+    bgColor.rgb = mix(bgColor.rgb, dispersed, dispersion * 0.65);
+    return bgColor;
 }
 
 void main() {
@@ -309,87 +265,106 @@ void main() {
     }
 
     vec2 actorPx = actorUV * actorSize;
-
     vec4 bounds = clip_width < 0.0 || clip_height < 0.0
         ? vec4(0.0, 0.0, width, height)
         : vec4(clip_x0, clip_y0, clip_x0 + clip_width, clip_y0 + clip_height);
 
     vec2 glassSize = max(bounds.zw - bounds.xy, vec2(1.0));
     vec2 glassPx = actorPx - bounds.xy;
-    vec2 localUV = glassPx / glassSize;
     vec2 halfSize = glassSize * 0.5;
+    vec2 localUV = glassPx / glassSize;
+
     float W = glassSize.x;
     float H = glassSize.y;
-    float R = min(corner_radius, min(W, H) * 0.5);
-    float bezel = max(1.0, min(edge_size, min(W, H) * 0.5));
+    float shortestSide = min(W, H);
+    float R = min(corner_radius, shortestSide * 0.5);
+    float bezel = max(1.0, min(edge_size, shortestSide * 0.5));
     float glassThickness = max(0.5, edge_size * 0.55 * falloff);
-    float eta = 1.0 / 1.52;
-
-    vec2 centered = glassPx - halfSize;
-    float signedDist = roundedRectDist(centered, halfSize, R);
+    float eta = 1.0 / REFRACTIVE_INDEX;
     float feather = max(1.25, min(bezel * 0.08, 4.0));
-    float edgeOpacity = 1.0 - smoothstep(-feather, feather, signedDist);
-    if (edgeOpacity <= 0.0) {
+
+    EdgeInfo edge = estimateAnalyticEdge(glassPx, halfSize, R, feather);
+    if (edge.alpha <= 0.0) {
         cogl_color_out = vec4(0.0);
         return;
     }
 
-    float distFromSide = max(0.0, -signedDist);
-    vec2 dir = roundedRectNormal(centered, halfSize, R);
+    bool nearlySquare = abs(W - H) < max(4.0, shortestSide * 0.035);
+    bool useCircularSurface = nearlySquare && R >= shortestSide * 0.34;
+    float distFromSide = edge.distance;
+    float edgeOpacity = edge.alpha;
+    float edgeBand = 1.0;
+    float lensBezel = bezel;
+    vec2 dir = edge.dir;
 
-    float bezelRatio = clamp(distFromSide / bezel, 0.0, 1.0);
-    float normDisp = distFromSide < bezel
-        ? displacementAtRatio(bezelRatio, glassThickness, bezel, eta)
+    if (useCircularSurface) {
+        float circleRadius = shortestSide * 0.5;
+        vec2 circleCenter = glassSize * 0.5;
+        vec2 fromCenter = glassPx - circleCenter;
+        float circleDistance = length(fromCenter);
+
+        if (circleDistance > circleRadius + feather) {
+            cogl_color_out = vec4(0.0);
+            return;
+        }
+
+        distFromSide = max(0.0, circleRadius - circleDistance);
+        dir = circleDistance > 0.001 ? normalize(fromCenter) : vec2(0.0, -1.0);
+        edgeOpacity = clamp(1.0 - max(0.0, circleDistance - circleRadius), 0.0, 1.0);
+        lensBezel = max(bezel, circleRadius);
+
+        float rimRadius = max(1.0, bezel * 0.35);
+        edgeBand = clamp(1.0 - (distFromSide / rimRadius), 0.0, 1.0);
+    } else {
+        float rimRadius = max(1.0, bezel * 0.35 * max(1.0, rim_width));
+        edgeBand = clamp(1.0 - (distFromSide / rimRadius), 0.0, 1.0);
+    }
+
+    float bezelRatio = useCircularSurface
+        ? clamp(distFromSide / lensBezel, 0.0, 1.0)
+        : clamp(distFromSide / max(1.0, bezel * 0.35 * max(1.0, rim_width)), 0.0, 1.0);
+    float normDisp = edgeBand > 0.001
+        ? displacementAtRatio(bezelRatio, glassThickness, lensBezel, eta)
         : 0.0;
-    float dispStrength = edgeOpacity * strength;
-    vec2 dispPx = -dir * normDisp * bezel * dispStrength;
-    vec2 sample = sampleUV((actorPx + dispPx) / actorSize);
+    float dispStrength = useCircularSurface ? edgeOpacity : edgeBand;
+    vec2 dispPx = -dir * normDisp * lensBezel * strength * dispStrength;
 
+    vec2 sampleUV = (actorPx + dispPx) / actorSize;
     vec2 prismOffset = dispPx / max(actorSize, vec2(1.0));
-    float dispersion = clamp(rgb_fringing * length(prismOffset) * 96.0, 0.0, 0.85);
-    vec4 bgColor = sampleDispersed(sample, prismOffset, dispersion);
+    float dispersion = clamp(rgb_fringing * length(prismOffset) * 24.0, 0.0, 0.012);
+    vec4 bgColor = sampleDispersed(resolveUV(sampleUV), prismOffset, dispersion);
 
     float specularAngle = -0.85;
-    vec2 fallbackLightDir = vec2(cos(specularAngle), -sin(specularAngle));
-    vec4 glossSample = wallpaperGloss(actorUV, fallbackLightDir);
-    vec2 lightDir = glossSample.xy;
-    float wallpaperSpot = glossSample.z;
-    float specDot = dot(dir, lightDir);
-    float spotSize = glossSample.w;
-    float strokePx = mix(1.35, 3.25, spotSize);
-    float strokeMask = clamp(1.0 - (distFromSide / strokePx), 0.0, 1.0);
-    float lobeStart = mix(0.84, 0.58, spotSize);
-    float lobeWidth = mix(0.08, 0.26, spotSize);
+    vec2 lightDir = vec2(cos(specularAngle), -sin(specularAngle));
+    vec2 specDir = dir;
+    if (!useCircularSurface) {
+        vec2 centerVec = (glassPx - halfSize) / max(glassSize, vec2(1.0));
+        specDir = length(centerVec) > 0.001 ? normalize(centerVec) : dir;
+    }
+
+    float specDot = dot(specDir, lightDir);
+    float roundedStrokePx = clamp(shortestSide * 0.018, 2.0, 5.5);
+    float strokePx = useCircularSurface ? max(2.25, shortestSide * 0.040) : roundedStrokePx;
+    float circularStrokeMask = clamp(1.0 - (distFromSide / strokePx), 0.0, 1.0);
+    float strokeMask = useCircularSurface ? max(edgeBand, circularStrokeMask) : edgeBand;
+    float lobeStart = 0.66;
+    float lobeWidth = 0.20;
     float primary = smoothstep(lobeStart, lobeStart + lobeWidth, specDot);
     float secondary = smoothstep(lobeStart, lobeStart + lobeWidth, -specDot);
-    float roundSpec = smoothstep(0.46, 0.90, abs(specDot));
-    float cornerWeight = 1.0 - smoothstep(
-        R * 0.45,
-        R,
-        min(min(glassPx.x, W - glassPx.x), min(glassPx.y, H - glassPx.y))
-    );
-    float specLobe = mix(primary + secondary, roundSpec, cornerWeight);
-    float fresnel = pow(clamp(1.0 - bezelRatio, 0.0, 1.0), 2.2) * edgeOpacity;
-    float specular = specLobe *
-        strokeMask *
-        mix(0.18, 1.15, wallpaperSpot) *
-        gloss *
-        2.15 *
-        edgeOpacity;
-    float highlight = specular + fresnel * 0.34;
+    float cornerSpec = smoothstep(0.46, 0.90, abs(specDot));
+    float specLobe = useCircularSurface ? cornerSpec : max(primary, secondary);
+    float fresnel = pow(clamp(1.0 - bezelRatio, 0.0, 1.0), 2.2) * edgeBand;
+    float specular = specLobe * strokeMask * gloss * 1.15 * edgeOpacity;
+    float highlight = specular + fresnel * 0.28;
 
     vec3 lch = srgbToLch(clamp(bgColor.rgb, 0.0, 1.0));
-    lch.x = clamp(lch.x + highlight * 36.0, 0.0, 100.0);
-    lch.y = max(0.0, lch.y - highlight * 9.0);
-    vec3 shapedHighlight = lchToSrgb(lch);
-    bgColor.rgb = mix(bgColor.rgb, shapedHighlight, clamp(highlight * 0.70, 0.0, 1.0));
+    lch.x = clamp(lch.x + highlight * 18.0, 0.0, 100.0);
+    lch.y = max(0.0, lch.y - highlight * 4.0);
 
-    float bodyMix = (1.0 - smoothstep(0.0, bezel, distFromSide)) * 0.10;
-    bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22 + bodyMix);
+    vec3 shapedHighlight = lchToSrgb(lch);
+    bgColor.rgb = mix(bgColor.rgb, shapedHighlight, clamp(highlight * 0.48, 0.0, 1.0));
+    bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22);
     bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
 
-    cogl_color_out = vec4(
-        clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity,
-        min(bgColor.a, edgeOpacity)
-    );
+    cogl_color_out = vec4(clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity, edgeOpacity);
 }

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -330,7 +330,7 @@ void main() {
     float feather = max(1.25, min(bezel * 0.08, 4.0));
     float edgeOpacity = 1.0 - smoothstep(-feather, feather, signedDist);
     if (edgeOpacity <= 0.0) {
-        cogl_color_out = mix(texture2D(tex, actorUV), vec4(0.0), opacity_factor);
+        cogl_color_out = vec4(0.0);
         return;
     }
 
@@ -388,11 +388,8 @@ void main() {
     bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22 + bodyMix);
     bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
 
-    vec4 sourceColor = texture2D(tex, actorUV);
-    vec4 effectColor = vec4(
+    cogl_color_out = vec4(
         clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity,
         min(bgColor.a, edgeOpacity)
     );
-
-    cogl_color_out = mix(sourceColor, effectColor, opacity_factor);
 }

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -1,0 +1,275 @@
+// Adapted from winaviation-tweaks/liquidass Shared/LGMetalShaderSource.m.
+// Blur my Shell gives us the current pipeline texture, so this GLSL version
+// applies LiquidAss' bezel/refraction/specular model to that texture.
+uniform sampler2D tex;
+uniform float width;
+uniform float height;
+uniform float strength;
+uniform float blur_radius;
+uniform float edge_size;
+uniform float falloff;
+uniform float corner_radius;
+uniform float rgb_fringing;
+uniform float gloss;
+uniform float tint;
+uniform float shadow;
+uniform int texture_repeat;
+uniform float clip_x0;
+uniform float clip_y0;
+uniform float clip_width;
+uniform float clip_height;
+
+float surfaceConvexSquircle(float x) {
+    return pow(1.0 - pow(1.0 - x, 4.0), 0.25);
+}
+
+vec2 refractRay(vec2 normal, float eta) {
+    float cosI = -normal.y;
+    float k = 1.0 - eta * eta * (1.0 - cosI * cosI);
+    if (k < 0.0)
+        return vec2(0.0);
+
+    float kSqrt = sqrt(k);
+    return vec2(
+        -(eta * cosI + kSqrt) * normal.x,
+        eta - (eta * cosI + kSqrt) * normal.y
+    );
+}
+
+float rawRefraction(float bezelRatio, float glassThickness, float bezelWidth, float eta) {
+    float x = clamp(bezelRatio, 0.05, 0.95);
+    float y = surfaceConvexSquircle(x);
+    float y2 = surfaceConvexSquircle(x + 0.001);
+    float deriv = (y2 - y) / 0.001;
+    float mag = sqrt(deriv * deriv + 1.0);
+    vec2 n = vec2(-deriv / mag, -1.0 / mag);
+    vec2 r = refractRay(n, eta);
+    if (length(r) < 0.0001 || abs(r.y) < 0.0001)
+        return 0.0;
+
+    float remaining = y * bezelWidth + glassThickness;
+    return r.x * (remaining / r.y);
+}
+
+float displacementAtRatio(float bezelRatio, float glassThickness, float bezelWidth, float eta) {
+    float peak = rawRefraction(0.05, glassThickness, bezelWidth, eta);
+    if (abs(peak) < 0.0001)
+        return 0.0;
+
+    float raw = rawRefraction(bezelRatio, glassThickness, bezelWidth, eta);
+    float norm = raw / peak;
+    float profileFalloff = 1.0 - smoothstep(0.0, 1.0, bezelRatio);
+    return norm * profileFalloff;
+}
+
+float linearizeSRGB(float c) {
+    return c > 0.04045 ? pow((c + 0.055) / 1.055, 2.4) : c / 12.92;
+}
+
+float gammaCorrectSRGB(float c) {
+    return c <= 0.0031308 ? 12.92 * c : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+vec3 srgbToXyz(vec3 rgb) {
+    vec3 lin = vec3(linearizeSRGB(rgb.r), linearizeSRGB(rgb.g), linearizeSRGB(rgb.b));
+    return vec3(
+        dot(lin, vec3(0.4124, 0.3576, 0.1805)),
+        dot(lin, vec3(0.2126, 0.7152, 0.0722)),
+        dot(lin, vec3(0.0193, 0.1192, 0.9505))
+    );
+}
+
+vec3 xyzToSrgb(vec3 xyz) {
+    vec3 lin = vec3(
+        dot(xyz, vec3( 3.2406, -1.5372, -0.4986)),
+        dot(xyz, vec3(-0.9689,  1.8758,  0.0415)),
+        dot(xyz, vec3( 0.0557, -0.2040,  1.0570))
+    );
+    return clamp(vec3(gammaCorrectSRGB(lin.r), gammaCorrectSRGB(lin.g), gammaCorrectSRGB(lin.b)), 0.0, 1.0);
+}
+
+float labF(float t) {
+    return t > 0.00885645167 ? pow(t, 1.0 / 3.0) : (7.787037 * t + 16.0 / 116.0);
+}
+
+float labInvF(float t) {
+    float t3 = t * t * t;
+    return t3 > 0.00885645167 ? t3 : (t - 16.0 / 116.0) / 7.787037;
+}
+
+vec3 xyzToLab(vec3 xyz) {
+    vec3 n = xyz / vec3(0.95047, 1.0, 1.08883);
+    float fx = labF(n.x);
+    float fy = labF(n.y);
+    float fz = labF(n.z);
+    return vec3(116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz));
+}
+
+vec3 labToXyz(vec3 lab) {
+    float fy = (lab.x + 16.0) / 116.0;
+    float fx = fy + lab.y / 500.0;
+    float fz = fy - lab.z / 200.0;
+    return vec3(0.95047 * labInvF(fx), labInvF(fy), 1.08883 * labInvF(fz));
+}
+
+vec3 srgbToLch(vec3 rgb) {
+    vec3 lab = xyzToLab(srgbToXyz(rgb));
+    return vec3(lab.x, length(lab.yz), atan(lab.z, lab.y));
+}
+
+vec3 lchToSrgb(vec3 lch) {
+    vec3 lab = vec3(lch.x, cos(lch.z) * lch.y, sin(lch.z) * lch.y);
+    return xyzToSrgb(labToXyz(lab));
+}
+
+vec2 clampUV(vec2 uv) {
+    vec2 px = vec2(1.5 / width, 1.5 / height);
+    return clamp(uv, px, vec2(1.0) - px);
+}
+
+vec2 sampleUV(vec2 uv) {
+    if (texture_repeat == 1) {
+        vec2 mirrored = abs(fract(uv * 0.5) * 2.0 - 1.0);
+        return clampUV(mirrored);
+    }
+
+    return clampUV(uv);
+}
+
+vec4 sampleGlassBackdrop(vec2 uv) {
+    if (blur_radius <= 0.01)
+        return texture2D(tex, sampleUV(uv));
+
+    float radius = min(blur_radius, min(width, height) * 0.18);
+    vec2 step = radius / vec2(width, height);
+    vec4 color = texture2D(tex, sampleUV(uv)) * 0.16;
+
+    color += texture2D(tex, sampleUV(uv + vec2( 0.40,  0.00) * step)) * 0.10;
+    color += texture2D(tex, sampleUV(uv + vec2(-0.40,  0.00) * step)) * 0.10;
+    color += texture2D(tex, sampleUV(uv + vec2( 0.00,  0.40) * step)) * 0.10;
+    color += texture2D(tex, sampleUV(uv + vec2( 0.00, -0.40) * step)) * 0.10;
+
+    color += texture2D(tex, sampleUV(uv + vec2( 0.46,  0.46) * step)) * 0.075;
+    color += texture2D(tex, sampleUV(uv + vec2(-0.46,  0.46) * step)) * 0.075;
+    color += texture2D(tex, sampleUV(uv + vec2( 0.46, -0.46) * step)) * 0.075;
+    color += texture2D(tex, sampleUV(uv + vec2(-0.46, -0.46) * step)) * 0.075;
+
+    color += texture2D(tex, sampleUV(uv + vec2( 0.92,  0.18) * step)) * 0.045;
+    color += texture2D(tex, sampleUV(uv + vec2(-0.92, -0.18) * step)) * 0.045;
+    color += texture2D(tex, sampleUV(uv + vec2( 0.18, -0.92) * step)) * 0.045;
+    color += texture2D(tex, sampleUV(uv + vec2(-0.18,  0.92) * step)) * 0.045;
+
+    color += texture2D(tex, sampleUV(uv + vec2( 1.20,  0.70) * step)) * 0.025;
+    color += texture2D(tex, sampleUV(uv + vec2(-1.20, -0.70) * step)) * 0.025;
+    color += texture2D(tex, sampleUV(uv + vec2( 0.70, -1.20) * step)) * 0.025;
+    color += texture2D(tex, sampleUV(uv + vec2(-0.70,  1.20) * step)) * 0.025;
+
+    return color / 1.14;
+}
+
+float roundedRectDist(vec2 p, vec2 halfSize, float radius) {
+    radius = min(radius, min(halfSize.x, halfSize.y));
+    vec2 q = abs(p) - halfSize + vec2(radius);
+    return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - radius;
+}
+
+vec2 roundedRectNormal(vec2 p, vec2 halfSize, float radius) {
+    float h = 1.0;
+    vec2 grad = vec2(
+        roundedRectDist(p + vec2(h, 0.0), halfSize, radius) -
+        roundedRectDist(p - vec2(h, 0.0), halfSize, radius),
+        roundedRectDist(p + vec2(0.0, h), halfSize, radius) -
+        roundedRectDist(p - vec2(0.0, h), halfSize, radius)
+    );
+    return length(grad) > 0.0001 ? normalize(grad) : vec2(0.0, -1.0);
+}
+
+vec4 sampleDispersed(vec2 uv, vec2 prismOffset, float dispersion) {
+    vec4 base = sampleGlassBackdrop(sampleUV(uv));
+    if (dispersion <= 0.0001)
+        return base;
+
+    vec2 redUV = sampleUV(uv - prismOffset * (0.75 + dispersion * 7.0));
+    vec2 blueUV = sampleUV(uv + prismOffset * (0.75 + dispersion * 7.0));
+    vec3 dispersed = vec3(
+        sampleGlassBackdrop(redUV).r,
+        base.g,
+        sampleGlassBackdrop(blueUV).b
+    );
+
+    base.rgb = mix(base.rgb, dispersed, clamp(dispersion, 0.0, 1.0));
+    return base;
+}
+
+void main() {
+    vec2 actorSize = vec2(width, height);
+    vec2 actorUV = cogl_tex_coord_in[0].xy;
+    vec2 actorPx = actorUV * actorSize;
+
+    vec4 bounds = clip_width < 0.0 || clip_height < 0.0
+        ? vec4(0.0, 0.0, width, height)
+        : vec4(clip_x0, clip_y0, clip_x0 + clip_width, clip_y0 + clip_height);
+
+    vec2 glassSize = max(bounds.zw - bounds.xy, vec2(1.0));
+    vec2 glassPx = actorPx - bounds.xy;
+    vec2 localUV = glassPx / glassSize;
+    vec2 halfSize = glassSize * 0.5;
+    float W = glassSize.x;
+    float H = glassSize.y;
+    float R = min(corner_radius, min(W, H) * 0.5);
+    float bezel = max(1.0, min(edge_size, min(W, H) * 0.5));
+    float glassThickness = max(0.5, edge_size * 0.55 * falloff);
+    float eta = 1.0 / 1.52;
+
+    vec2 centered = glassPx - halfSize;
+    float signedDist = roundedRectDist(centered, halfSize, R);
+    float feather = max(1.25, min(bezel * 0.08, 4.0));
+    float edgeOpacity = 1.0 - smoothstep(-feather, feather, signedDist);
+    if (edgeOpacity <= 0.0) {
+        cogl_color_out = vec4(0.0);
+        return;
+    }
+
+    float distFromSide = max(0.0, -signedDist);
+    vec2 dir = roundedRectNormal(centered, halfSize, R);
+
+    float bezelRatio = clamp(distFromSide / bezel, 0.0, 1.0);
+    float normDisp = distFromSide < bezel
+        ? displacementAtRatio(bezelRatio, glassThickness, bezel, eta)
+        : 0.0;
+    float dispStrength = edgeOpacity * strength;
+    vec2 dispPx = -dir * normDisp * bezel * dispStrength;
+    vec2 sample = sampleUV((actorPx + dispPx) / actorSize);
+
+    vec2 prismOffset = dispPx / max(actorSize, vec2(1.0));
+    float dispersion = clamp(rgb_fringing * length(prismOffset) * 96.0, 0.0, 0.85);
+    vec4 bgColor = sampleDispersed(sample, prismOffset, dispersion);
+
+    float specularAngle = -0.85;
+    vec2 lightDir = vec2(cos(specularAngle), -sin(specularAngle));
+    float specDot = dot(dir, lightDir);
+    float strokePx = 2.0;
+    float strokeMask = clamp(1.0 - (distFromSide / strokePx), 0.0, 1.0);
+    float lobeStart = 0.66;
+    float lobeWidth = 0.20;
+    float primary = smoothstep(lobeStart, lobeStart + lobeWidth, specDot);
+    float secondary = smoothstep(lobeStart, lobeStart + lobeWidth, -specDot);
+    float roundSpec = smoothstep(0.46, 0.90, abs(specDot));
+    float cornerWeight = 1.0 - smoothstep(R * 0.45, R, min(min(glassPx.x, W - glassPx.x), min(glassPx.y, H - glassPx.y)));
+    float specLobe = mix(primary + secondary, roundSpec, cornerWeight);
+    float fresnel = pow(clamp(1.0 - bezelRatio, 0.0, 1.0), 2.2) * edgeOpacity;
+    float specular = specLobe * strokeMask * gloss * 2.15 * edgeOpacity;
+    float highlight = specular + fresnel * 0.34;
+
+    vec3 lch = srgbToLch(clamp(bgColor.rgb, 0.0, 1.0));
+    lch.x = clamp(lch.x + highlight * 36.0, 0.0, 100.0);
+    lch.y = max(0.0, lch.y - highlight * 9.0);
+    vec3 shapedHighlight = lchToSrgb(lch);
+    bgColor.rgb = mix(bgColor.rgb, shapedHighlight, clamp(highlight * 0.70, 0.0, 1.0));
+
+    float bodyMix = (1.0 - smoothstep(0.0, bezel, distFromSide)) * 0.10;
+    bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22 + bodyMix);
+    bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
+
+    cogl_color_out = vec4(clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity, min(bgColor.a, edgeOpacity));
+}

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -73,7 +73,12 @@ float gammaCorrectSRGB(float c) {
 }
 
 vec3 srgbToXyz(vec3 rgb) {
-    vec3 lin = vec3(linearizeSRGB(rgb.r), linearizeSRGB(rgb.g), linearizeSRGB(rgb.b));
+    vec3 lin = vec3(
+        linearizeSRGB(rgb.r),
+        linearizeSRGB(rgb.g),
+        linearizeSRGB(rgb.b)
+    );
+
     return vec3(
         dot(lin, vec3(0.4124, 0.3576, 0.1805)),
         dot(lin, vec3(0.2126, 0.7152, 0.0722)),
@@ -87,7 +92,12 @@ vec3 xyzToSrgb(vec3 xyz) {
         dot(xyz, vec3(-0.9689,  1.8758,  0.0415)),
         dot(xyz, vec3( 0.0557, -0.2040,  1.0570))
     );
-    return clamp(vec3(gammaCorrectSRGB(lin.r), gammaCorrectSRGB(lin.g), gammaCorrectSRGB(lin.b)), 0.0, 1.0);
+
+    return clamp(vec3(
+        gammaCorrectSRGB(lin.r),
+        gammaCorrectSRGB(lin.g),
+        gammaCorrectSRGB(lin.b)
+    ), 0.0, 1.0);
 }
 
 float labF(float t) {
@@ -237,11 +247,23 @@ vec4 wallpaperGloss(vec2 uv, vec2 fallbackDir) {
 
     float peak = max(
         center,
-        max(max(left, right), max(max(top, bottom), max(max(topLeft, topRight), max(bottomLeft, bottomRight))))
+        max(
+            max(left, right),
+            max(
+                max(top, bottom),
+                max(max(topLeft, topRight), max(bottomLeft, bottomRight))
+            )
+        )
     );
     float low = min(
         center,
-        min(min(left, right), min(min(top, bottom), min(min(topLeft, topRight), min(bottomLeft, bottomRight))))
+        min(
+            min(left, right),
+            min(
+                min(top, bottom),
+                min(min(topLeft, topRight), min(bottomLeft, bottomRight))
+            )
+        )
     );
     float band = max(0.08, peak * 0.28);
     float localPeak = nearPeak(center, peak, band);
@@ -259,7 +281,10 @@ vec4 wallpaperGloss(vec2 uv, vec2 fallbackDir) {
     float brightness = smoothstep(0.36, 0.86, peak);
     float spotSize = smoothstep(0.28, 0.78, coverage) * brightness;
     float contrastMask = mix(0.55, 1.0, smoothstep(0.025, 0.22, peak - low));
-    float spotMask = brightness * contrastMask * pow(localPeak, mix(3.0, 1.05, spotSize));
+    float spotMask = brightness * contrastMask * pow(
+        localPeak,
+        mix(3.0, 1.05, spotSize)
+    );
 
     vec2 gradient = vec2(right - left, bottom - top);
     float contrast = length(gradient);
@@ -344,7 +369,12 @@ void main() {
     );
     float specLobe = mix(primary + secondary, roundSpec, cornerWeight);
     float fresnel = pow(clamp(1.0 - bezelRatio, 0.0, 1.0), 2.2) * edgeOpacity;
-    float specular = specLobe * strokeMask * mix(0.18, 1.15, wallpaperSpot) * gloss * 2.15 * edgeOpacity;
+    float specular = specLobe *
+        strokeMask *
+        mix(0.18, 1.15, wallpaperSpot) *
+        gloss *
+        2.15 *
+        edgeOpacity;
     float highlight = specular + fresnel * 0.34;
 
     vec3 lch = srgbToLch(clamp(bgColor.rgb, 0.0, 1.0));

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -13,7 +13,6 @@ uniform float rgb_fringing;
 uniform float gloss;
 uniform float tint;
 uniform float shadow;
-uniform float opacity_factor;
 uniform int texture_repeat;
 uniform int blur_direction;
 uniform int private_pass;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -14,6 +14,8 @@ uniform float gloss;
 uniform float tint;
 uniform float shadow;
 uniform int texture_repeat;
+uniform int blur_direction;
+uniform int private_pass;
 uniform float clip_x0;
 uniform float clip_y0;
 uniform float clip_width;
@@ -148,31 +150,41 @@ vec4 sampleGlassBackdrop(vec2 uv) {
     if (blur_radius <= 0.01)
         return texture2D(tex, sampleUV(uv));
 
-    float radius = min(blur_radius, min(width, height) * 0.18);
-    vec2 step = radius / vec2(width, height);
-    vec4 color = texture2D(tex, sampleUV(uv)) * 0.16;
+    float sigma = max(0.1, blur_radius * 0.5);
+    float pixelStep = blur_direction == 1 ? 1.0 / width : 1.0 / height;
+    vec2 direction = vec2(float(blur_direction), 1.0 - float(blur_direction));
 
-    color += texture2D(tex, sampleUV(uv + vec2( 0.40,  0.00) * step)) * 0.10;
-    color += texture2D(tex, sampleUV(uv + vec2(-0.40,  0.00) * step)) * 0.10;
-    color += texture2D(tex, sampleUV(uv + vec2( 0.00,  0.40) * step)) * 0.10;
-    color += texture2D(tex, sampleUV(uv + vec2( 0.00, -0.40) * step)) * 0.10;
+    vec3 gauss;
+    gauss.x = 1.0 / (sqrt(2.0 * 3.14159265) * sigma);
+    gauss.y = exp(-0.5 / (sigma * sigma));
+    gauss.z = gauss.y * gauss.y;
 
-    color += texture2D(tex, sampleUV(uv + vec2( 0.46,  0.46) * step)) * 0.075;
-    color += texture2D(tex, sampleUV(uv + vec2(-0.46,  0.46) * step)) * 0.075;
-    color += texture2D(tex, sampleUV(uv + vec2( 0.46, -0.46) * step)) * 0.075;
-    color += texture2D(tex, sampleUV(uv + vec2(-0.46, -0.46) * step)) * 0.075;
+    vec4 accum = texture2D(tex, sampleUV(uv)) * gauss.x;
+    float weightSum = gauss.x;
 
-    color += texture2D(tex, sampleUV(uv + vec2( 0.92,  0.18) * step)) * 0.045;
-    color += texture2D(tex, sampleUV(uv + vec2(-0.92, -0.18) * step)) * 0.045;
-    color += texture2D(tex, sampleUV(uv + vec2( 0.18, -0.92) * step)) * 0.045;
-    color += texture2D(tex, sampleUV(uv + vec2(-0.18,  0.92) * step)) * 0.045;
+    gauss.xy *= gauss.yz;
 
-    color += texture2D(tex, sampleUV(uv + vec2( 1.20,  0.70) * step)) * 0.025;
-    color += texture2D(tex, sampleUV(uv + vec2(-1.20, -0.70) * step)) * 0.025;
-    color += texture2D(tex, sampleUV(uv + vec2( 0.70, -1.20) * step)) * 0.025;
-    color += texture2D(tex, sampleUV(uv + vec2(-0.70,  1.20) * step)) * 0.025;
+    int radius = int(ceil(1.5 * sigma)) * 2;
 
-    return color / 1.14;
+    for (int i = 1; i <= radius; i += 2) {
+        float subtotal = gauss.x;
+
+        gauss.xy *= gauss.yz;
+        subtotal += gauss.x;
+
+        float gaussRatio = gauss.x / subtotal;
+        float foffset = float(i) + gaussRatio;
+        vec2 offset = direction * foffset * pixelStep;
+
+        accum += texture2D(tex, sampleUV(uv + offset)) * subtotal;
+        accum += texture2D(tex, sampleUV(uv - offset)) * subtotal;
+
+        weightSum += subtotal * 2.0;
+
+        gauss.xy *= gauss.yz;
+    }
+
+    return accum / weightSum;
 }
 
 float roundedRectDist(vec2 p, vec2 halfSize, float radius) {
@@ -223,8 +235,14 @@ vec4 wallpaperGloss(vec2 uv, vec2 fallbackDir) {
     float bottomLeft = luminance(sampleGlassBackdrop(uv + vec2(-radius.x, radius.y)).rgb);
     float bottomRight = luminance(sampleGlassBackdrop(uv + radius).rgb);
 
-    float peak = max(center, max(max(left, right), max(max(top, bottom), max(max(topLeft, topRight), max(bottomLeft, bottomRight)))));
-    float low = min(center, min(min(left, right), min(min(top, bottom), min(min(topLeft, topRight), min(bottomLeft, bottomRight)))));
+    float peak = max(
+        center,
+        max(max(left, right), max(max(top, bottom), max(max(topLeft, topRight), max(bottomLeft, bottomRight))))
+    );
+    float low = min(
+        center,
+        min(min(left, right), min(min(top, bottom), min(min(topLeft, topRight), min(bottomLeft, bottomRight))))
+    );
     float band = max(0.08, peak * 0.28);
     float localPeak = nearPeak(center, peak, band);
     float coverage = (
@@ -258,6 +276,12 @@ vec4 wallpaperGloss(vec2 uv, vec2 fallbackDir) {
 void main() {
     vec2 actorSize = vec2(width, height);
     vec2 actorUV = cogl_tex_coord_in[0].xy;
+
+    if (private_pass == 1) {
+        cogl_color_out = sampleGlassBackdrop(actorUV);
+        return;
+    }
+
     vec2 actorPx = actorUV * actorSize;
 
     vec4 bounds = clip_width < 0.0 || clip_height < 0.0
@@ -313,7 +337,11 @@ void main() {
     float primary = smoothstep(lobeStart, lobeStart + lobeWidth, specDot);
     float secondary = smoothstep(lobeStart, lobeStart + lobeWidth, -specDot);
     float roundSpec = smoothstep(0.46, 0.90, abs(specDot));
-    float cornerWeight = 1.0 - smoothstep(R * 0.45, R, min(min(glassPx.x, W - glassPx.x), min(glassPx.y, H - glassPx.y)));
+    float cornerWeight = 1.0 - smoothstep(
+        R * 0.45,
+        R,
+        min(min(glassPx.x, W - glassPx.x), min(glassPx.y, H - glassPx.y))
+    );
     float specLobe = mix(primary + secondary, roundSpec, cornerWeight);
     float fresnel = pow(clamp(1.0 - bezelRatio, 0.0, 1.0), 2.2) * edgeOpacity;
     float specular = specLobe * strokeMask * mix(0.18, 1.15, wallpaperSpot) * gloss * 2.15 * edgeOpacity;
@@ -329,5 +357,8 @@ void main() {
     bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22 + bodyMix);
     bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
 
-    cogl_color_out = vec4(clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity, min(bgColor.a, edgeOpacity));
+    cogl_color_out = vec4(
+        clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity,
+        min(bgColor.a, edgeOpacity)
+    );
 }

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -126,6 +126,10 @@ float luminance(vec3 color) {
     return dot(color, vec3(0.2126, 0.7152, 0.0722));
 }
 
+float nearPeak(float value, float peak, float band) {
+    return 1.0 - smoothstep(band * 0.35, band, peak - value);
+}
+
 vec2 clampUV(vec2 uv) {
     vec2 px = vec2(1.5 / width, 1.5 / height);
     return clamp(uv, px, vec2(1.0) - px);
@@ -205,22 +209,50 @@ vec4 sampleDispersed(vec2 uv, vec2 prismOffset, float dispersion) {
     return base;
 }
 
-vec2 wallpaperGlossDirection(vec2 uv, vec2 fallbackDir) {
+vec4 wallpaperGloss(vec2 uv, vec2 fallbackDir) {
     vec2 px = 1.0 / vec2(width, height);
     vec2 radius = px * max(12.0, min(min(width, height) * 0.04, blur_radius * 1.6 + 10.0));
 
+    float center = luminance(sampleGlassBackdrop(uv).rgb);
     float left = luminance(sampleGlassBackdrop(uv - vec2(radius.x, 0.0)).rgb);
     float right = luminance(sampleGlassBackdrop(uv + vec2(radius.x, 0.0)).rgb);
     float top = luminance(sampleGlassBackdrop(uv - vec2(0.0, radius.y)).rgb);
     float bottom = luminance(sampleGlassBackdrop(uv + vec2(0.0, radius.y)).rgb);
+    float topLeft = luminance(sampleGlassBackdrop(uv - radius).rgb);
+    float topRight = luminance(sampleGlassBackdrop(uv + vec2(radius.x, -radius.y)).rgb);
+    float bottomLeft = luminance(sampleGlassBackdrop(uv + vec2(-radius.x, radius.y)).rgb);
+    float bottomRight = luminance(sampleGlassBackdrop(uv + radius).rgb);
+
+    float peak = max(center, max(max(left, right), max(max(top, bottom), max(max(topLeft, topRight), max(bottomLeft, bottomRight)))));
+    float low = min(center, min(min(left, right), min(min(top, bottom), min(min(topLeft, topRight), min(bottomLeft, bottomRight)))));
+    float band = max(0.08, peak * 0.28);
+    float localPeak = nearPeak(center, peak, band);
+    float coverage = (
+        localPeak +
+        nearPeak(left, peak, band) +
+        nearPeak(right, peak, band) +
+        nearPeak(top, peak, band) +
+        nearPeak(bottom, peak, band) +
+        nearPeak(topLeft, peak, band) +
+        nearPeak(topRight, peak, band) +
+        nearPeak(bottomLeft, peak, band) +
+        nearPeak(bottomRight, peak, band)
+    ) / 9.0;
+    float brightness = smoothstep(0.36, 0.86, peak);
+    float spotSize = smoothstep(0.28, 0.78, coverage) * brightness;
+    float contrastMask = mix(0.55, 1.0, smoothstep(0.025, 0.22, peak - low));
+    float spotMask = brightness * contrastMask * pow(localPeak, mix(3.0, 1.05, spotSize));
+
     vec2 gradient = vec2(right - left, bottom - top);
     float contrast = length(gradient);
+    vec2 glossDir = fallbackDir;
 
-    if (contrast < 0.015)
-        return fallbackDir;
+    if (contrast >= 0.015) {
+        vec2 backdropDir = normalize(vec2(-gradient.x, gradient.y));
+        glossDir = normalize(mix(fallbackDir, backdropDir, smoothstep(0.015, 0.13, contrast)));
+    }
 
-    vec2 backdropDir = normalize(vec2(-gradient.x, gradient.y));
-    return normalize(mix(fallbackDir, backdropDir, smoothstep(0.015, 0.13, contrast)));
+    return vec4(glossDir, spotMask, spotSize);
 }
 
 void main() {
@@ -269,19 +301,22 @@ void main() {
 
     float specularAngle = -0.85;
     vec2 fallbackLightDir = vec2(cos(specularAngle), -sin(specularAngle));
-    vec2 lightDir = wallpaperGlossDirection(actorUV, fallbackLightDir);
+    vec4 glossSample = wallpaperGloss(actorUV, fallbackLightDir);
+    vec2 lightDir = glossSample.xy;
+    float wallpaperSpot = glossSample.z;
     float specDot = dot(dir, lightDir);
-    float strokePx = 2.0;
+    float spotSize = glossSample.w;
+    float strokePx = mix(1.35, 3.25, spotSize);
     float strokeMask = clamp(1.0 - (distFromSide / strokePx), 0.0, 1.0);
-    float lobeStart = 0.66;
-    float lobeWidth = 0.20;
+    float lobeStart = mix(0.84, 0.58, spotSize);
+    float lobeWidth = mix(0.08, 0.26, spotSize);
     float primary = smoothstep(lobeStart, lobeStart + lobeWidth, specDot);
     float secondary = smoothstep(lobeStart, lobeStart + lobeWidth, -specDot);
     float roundSpec = smoothstep(0.46, 0.90, abs(specDot));
     float cornerWeight = 1.0 - smoothstep(R * 0.45, R, min(min(glassPx.x, W - glassPx.x), min(glassPx.y, H - glassPx.y)));
     float specLobe = mix(primary + secondary, roundSpec, cornerWeight);
     float fresnel = pow(clamp(1.0 - bezelRatio, 0.0, 1.0), 2.2) * edgeOpacity;
-    float specular = specLobe * strokeMask * gloss * 2.15 * edgeOpacity;
+    float specular = specLobe * strokeMask * mix(0.18, 1.15, wallpaperSpot) * gloss * 2.15 * edgeOpacity;
     float highlight = specular + fresnel * 0.34;
 
     vec3 lch = srgbToLch(clamp(bgColor.rgb, 0.0, 1.0));

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -13,6 +13,7 @@ uniform float rgb_fringing;
 uniform float gloss;
 uniform float tint;
 uniform float shadow;
+uniform float opacity_factor;
 uniform int texture_repeat;
 uniform int blur_direction;
 uniform int private_pass;
@@ -329,7 +330,7 @@ void main() {
     float feather = max(1.25, min(bezel * 0.08, 4.0));
     float edgeOpacity = 1.0 - smoothstep(-feather, feather, signedDist);
     if (edgeOpacity <= 0.0) {
-        cogl_color_out = vec4(0.0);
+        cogl_color_out = mix(texture2D(tex, actorUV), vec4(0.0), opacity_factor);
         return;
     }
 
@@ -387,8 +388,11 @@ void main() {
     bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22 + bodyMix);
     bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
 
-    cogl_color_out = vec4(
+    vec4 sourceColor = texture2D(tex, actorUV);
+    vec4 effectColor = vec4(
         clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity,
         min(bgColor.a, edgeOpacity)
     );
+
+    cogl_color_out = mix(sourceColor, effectColor, opacity_factor);
 }

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -122,6 +122,10 @@ vec3 lchToSrgb(vec3 lch) {
     return xyzToSrgb(labToXyz(lab));
 }
 
+float luminance(vec3 color) {
+    return dot(color, vec3(0.2126, 0.7152, 0.0722));
+}
+
 vec2 clampUV(vec2 uv) {
     vec2 px = vec2(1.5 / width, 1.5 / height);
     return clamp(uv, px, vec2(1.0) - px);
@@ -201,6 +205,24 @@ vec4 sampleDispersed(vec2 uv, vec2 prismOffset, float dispersion) {
     return base;
 }
 
+vec2 wallpaperGlossDirection(vec2 uv, vec2 fallbackDir) {
+    vec2 px = 1.0 / vec2(width, height);
+    vec2 radius = px * max(12.0, min(min(width, height) * 0.04, blur_radius * 1.6 + 10.0));
+
+    float left = luminance(sampleGlassBackdrop(uv - vec2(radius.x, 0.0)).rgb);
+    float right = luminance(sampleGlassBackdrop(uv + vec2(radius.x, 0.0)).rgb);
+    float top = luminance(sampleGlassBackdrop(uv - vec2(0.0, radius.y)).rgb);
+    float bottom = luminance(sampleGlassBackdrop(uv + vec2(0.0, radius.y)).rgb);
+    vec2 gradient = vec2(right - left, bottom - top);
+    float contrast = length(gradient);
+
+    if (contrast < 0.015)
+        return fallbackDir;
+
+    vec2 backdropDir = normalize(vec2(-gradient.x, gradient.y));
+    return normalize(mix(fallbackDir, backdropDir, smoothstep(0.015, 0.13, contrast)));
+}
+
 void main() {
     vec2 actorSize = vec2(width, height);
     vec2 actorUV = cogl_tex_coord_in[0].xy;
@@ -246,7 +268,8 @@ void main() {
     vec4 bgColor = sampleDispersed(sample, prismOffset, dispersion);
 
     float specularAngle = -0.85;
-    vec2 lightDir = vec2(cos(specularAngle), -sin(specularAngle));
+    vec2 fallbackLightDir = vec2(cos(specularAngle), -sin(specularAngle));
+    vec2 lightDir = wallpaperGlossDirection(actorUV, fallbackLightDir);
     float specDot = dot(dir, lightDir);
     float strokePx = 2.0;
     float strokeMask = clamp(1.0 - (distFromSide / strokePx), 0.0, 1.0);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -6,6 +6,7 @@ const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 const Gst = await utils.import_in_shell_only('gi://Gst');
+const GstApp = await utils.import_in_shell_only('gi://GstApp');
 
 const SHADER_FILENAME = 'refraction.glsl';
 const DEFAULT_PARAMS = {
@@ -178,6 +179,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             this._webcam_pipeline = null;
             this._webcam_sink = null;
             this._webcam_poll_id = null;
+            this._webcam_pipeline_candidates = [];
+            this._webcam_pipeline_index = 0;
+            this._webcam_empty_polls = 0;
             this._manual_gloss = DEFAULT_PARAMS.gloss;
             this._live_gloss = DEFAULT_PARAMS.gloss;
 
@@ -371,20 +375,14 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
         }
 
         _start_webcam_gloss() {
-            if (!Gst || this._webcam_pipeline)
+            if (!Gst || !GstApp || this._webcam_pipeline)
                 return;
 
             try {
                 Gst.init(null);
-
-                const source = this.webcam_device?.startsWith('/dev/video')
-                    ? `v4l2src device=${this._quoted_gst_string(this.webcam_device)}`
-                    : 'autovideosrc';
-                const pipeline_description = `${source} ! videoconvert ! videoscale ! video/x-raw,format=RGBA,width=24,height=16,framerate=8/1 ! appsink name=sink emit-signals=false sync=false max-buffers=1 drop=true`;
-
-                this._webcam_pipeline = Gst.parse_launch(pipeline_description);
-                this._webcam_sink = this._webcam_pipeline.get_by_name('sink');
-                this._webcam_pipeline.set_state(Gst.State.PLAYING);
+                this._webcam_pipeline_candidates = this._webcam_pipeline_descriptions();
+                this._webcam_pipeline_index = 0;
+                this._start_next_webcam_pipeline();
 
                 this._webcam_poll_id = GLib.timeout_add(GLib.PRIORITY_LOW, 125, () => {
                     this._poll_webcam_gloss();
@@ -397,21 +395,87 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             }
         }
 
+        _webcam_pipeline_descriptions() {
+            const device = this.webcam_device?.startsWith('/dev/video')
+                ? this.webcam_device
+                : '/dev/video0';
+            const source = `v4l2src device=${this._quoted_gst_string(device)}`;
+            const sink = 'videoconvert ! videoscale ! video/x-raw,format=RGBA,width=24,height=16 ! appsink name=sink emit-signals=false sync=false max-buffers=1 drop=true';
+
+            return [
+                `${source} ! video/x-raw,format=YUY2,width=640,height=480,framerate=30/1 ! ${sink}`,
+                `${source} ! video/x-raw,width=640,height=480,framerate=30/1 ! ${sink}`,
+                `${source} ! image/jpeg,width=640,height=480,framerate=30/1 ! jpegdec ! ${sink}`,
+                `autovideosrc ! video/x-raw,width=640,height=480,framerate=30/1 ! ${sink}`,
+                `autovideosrc ! ${sink}`,
+            ];
+        }
+
+        _start_next_webcam_pipeline() {
+            this._stop_webcam_pipeline();
+            this._webcam_empty_polls = 0;
+
+            while (this._webcam_pipeline_index < this._webcam_pipeline_candidates.length) {
+                const description = this._webcam_pipeline_candidates[this._webcam_pipeline_index++];
+
+                try {
+                    this._webcam_pipeline = Gst.parse_launch(description);
+                    this._webcam_sink = this._webcam_pipeline.get_by_name('sink');
+                    this._webcam_pipeline.set_state(Gst.State.PLAYING);
+                    return true;
+                } catch (e) {
+                    console.warn(`[Blur my Shell > refraction]   webcam pipeline failed: ${e}`);
+                }
+            }
+
+            console.warn('[Blur my Shell > refraction]   webcam gloss unavailable: no camera pipeline could start');
+            this.set_uniform_value('gloss', parseFloat(this._manual_gloss - 1e-6));
+            return false;
+        }
+
+        _webcam_pipeline_has_error() {
+            const bus = this._webcam_pipeline?.get_bus();
+            if (!bus)
+                return false;
+
+            const message = bus.pop_filtered(Gst.MessageType.ERROR | Gst.MessageType.EOS);
+            if (!message)
+                return false;
+
+            if (message.type === Gst.MessageType.ERROR) {
+                const [error, debug] = message.parse_error();
+                console.warn(`[Blur my Shell > refraction]   webcam pipeline error: ${error.message}; ${debug}`);
+            }
+
+            return true;
+        }
+
         _poll_webcam_gloss() {
             if (!this._webcam_sink)
                 return;
 
-            let sample = null;
-            try {
-                sample = this._webcam_sink.emit('try-pull-sample', 0);
-            } catch (e) {
-                this._stop_webcam_gloss();
+            if (this._webcam_pipeline_has_error()) {
+                this._start_next_webcam_pipeline();
                 return;
             }
 
-            if (!sample)
+            let sample = null;
+            try {
+                sample = this._webcam_sink.try_pull_sample(0);
+            } catch (e) {
+                console.warn(`[Blur my Shell > refraction]   webcam sample failed: ${e}`);
+                this._start_next_webcam_pipeline();
                 return;
+            }
 
+            if (!sample) {
+                this._webcam_empty_polls++;
+                if (this._webcam_empty_polls > 24)
+                    this._start_next_webcam_pipeline();
+                return;
+            }
+
+            this._webcam_empty_polls = 0;
             const buffer = sample.get_buffer();
             const [success, map] = buffer.map(Gst.MapFlags.READ);
             if (!success)
@@ -439,6 +503,12 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._webcam_poll_id = null;
             }
 
+            this._stop_webcam_pipeline();
+            this._webcam_pipeline_candidates = [];
+            this._webcam_pipeline_index = 0;
+        }
+
+        _stop_webcam_pipeline() {
             if (this._webcam_pipeline) {
                 try {
                     this._webcam_pipeline.set_state(Gst.State.NULL);
@@ -449,6 +519,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
             this._webcam_pipeline = null;
             this._webcam_sink = null;
+            this._webcam_empty_polls = 0;
         }
 
         get width() {

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -8,6 +8,7 @@ const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
 const SHADER_FILENAME = 'refraction.glsl';
 const CLIP_STABILIZE_EPSILON = 1.0;
+
 const DEFAULT_PARAMS = {
     strength: 0.42,
     blur_radius: 10,
@@ -22,6 +23,9 @@ const DEFAULT_PARAMS = {
     shadow: 0.28,
     mode: 0,
     texture_repeat: 0,
+    blur_direction: 0,
+    private_pass: 0,
+    chained_effect: null,
     width: 0,
     height: 0,
     clip: [0, 0, -1, -1]
@@ -135,6 +139,29 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 0, 1,
                 0,
             ),
+            'blur_direction': GObject.ParamSpec.int(
+                `blur_direction`,
+                `Blur Direction`,
+                `Private Gaussian blur direction`,
+                GObject.ParamFlags.READWRITE,
+                0, 1,
+                0,
+            ),
+            'private_pass': GObject.ParamSpec.int(
+                `private_pass`,
+                `Private Pass`,
+                `Private Gaussian blur pass`,
+                GObject.ParamFlags.READWRITE,
+                0, 1,
+                0,
+            ),
+            'chained_effect': GObject.ParamSpec.object(
+                `chained_effect`,
+                `Chained Effect`,
+                `Private chained blur effect`,
+                GObject.ParamFlags.READWRITE,
+                GObject.Object,
+            ),
             'width': GObject.ParamSpec.double(
                 `width`,
                 `Width`,
@@ -218,6 +245,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._edge_size = value;
 
                 this.update_scaled_uniforms();
+
+                if (this.chained_effect)
+                    this.chained_effect.edge_size = value;
             }
         }
 
@@ -230,6 +260,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._blur_radius = value;
 
                 this.update_scaled_uniforms();
+
+                if (this.chained_effect)
+                    this.chained_effect.blur_radius = value;
             }
         }
 
@@ -242,6 +275,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._falloff = value;
 
                 this.set_uniform_value('falloff', parseFloat(this._falloff - 1e-6));
+
+                if (this.chained_effect)
+                    this.chained_effect.falloff = value;
             }
         }
 
@@ -254,6 +290,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._corner_radius = value;
 
                 this.update_scaled_uniforms();
+
+                if (this.chained_effect)
+                    this.chained_effect.corner_radius = value;
             }
         }
 
@@ -339,7 +378,44 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._texture_repeat = value;
 
                 this.set_uniform_value('texture_repeat', this._texture_repeat);
+
+                if (this.chained_effect)
+                    this.chained_effect.texture_repeat = value;
             }
+        }
+
+        get blur_direction() {
+            return this._blur_direction;
+        }
+
+        set blur_direction(value) {
+            if (this._blur_direction !== value) {
+                this._blur_direction = value;
+
+                this.set_uniform_value('blur_direction', this._blur_direction);
+            }
+        }
+
+        get private_pass() {
+            return this._private_pass;
+        }
+
+        set private_pass(value) {
+            if (this._private_pass !== value) {
+                this._private_pass = value;
+
+                this.set_uniform_value('private_pass', this._private_pass);
+                if (this._private_pass === 1)
+                    this.set_enabled(this.blur_radius > 0.01);
+            }
+        }
+
+        get chained_effect() {
+            return this._chained_effect;
+        }
+
+        set chained_effect(value) {
+            this._chained_effect = value;
         }
 
         set(params) {
@@ -356,6 +432,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
                 this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
                 this.update_scaled_uniforms();
+
+                if (this.chained_effect)
+                    this.chained_effect.width = value;
             }
         }
 
@@ -369,6 +448,9 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
                 this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
                 this.update_scaled_uniforms();
+
+                if (this.chained_effect)
+                    this.chained_effect.height = value;
             }
         }
 
@@ -462,7 +544,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
         }
 
         _stabilized_clip_axis(start, size, previous_start, previous_size, stable_start, stable_size, stabilizing) {
-            const size_changed = previous_size !== null &&
+            const size_changed =
+                previous_size !== null &&
                 previous_size >= 0 &&
                 Math.abs(size - previous_size) > CLIP_STABILIZE_EPSILON;
 
@@ -481,8 +564,10 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
         update_scaled_uniforms() {
             const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-            const rect_width = this._stable_clip_width ?? (this._clip_width >= 0 ? this._clip_width : this.width);
-            const rect_height = this._stable_clip_height ?? (this._clip_height >= 0 ? this._clip_height : this.height);
+            const rect_width =
+                this._stable_clip_width ?? (this._clip_width >= 0 ? this._clip_width : this.width);
+            const rect_height =
+                this._stable_clip_height ?? (this._clip_height >= 0 ? this._clip_height : this.height);
             const max_edge = Math.max(1, Math.min(rect_width, rect_height) / 2);
             const edge_size = Math.min(this.edge_size * scale_factor, max_edge);
             const corner_radius = Math.min(this.corner_radius * scale_factor, max_edge);
@@ -490,9 +575,14 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             this.set_uniform_value('edge_size', parseFloat(edge_size - 1e-6));
             this.set_uniform_value('corner_radius', parseFloat(corner_radius - 1e-6));
             this.set_uniform_value('blur_radius', parseFloat(this.blur_radius * scale_factor - 1e-6));
+            if (this.private_pass === 1)
+                this.set_enabled(this.blur_radius > 0.01);
         }
 
         vfunc_set_actor(actor) {
+            if (this.chained_effect)
+                this.chained_effect.get_actor()?.remove_effect(this.chained_effect);
+
             if (this._actor_connection_size_id) {
                 let old_actor = this.get_actor();
                 old_actor?.disconnect(this._actor_connection_size_id);
@@ -530,6 +620,41 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             }
 
             super.vfunc_set_actor(actor);
+
+            if (this.private_pass === 0) {
+                if (!this.chained_effect) {
+                    const chained_params = {
+                        strength: this.strength,
+                        blur_radius: this.blur_radius,
+                        edge_size: this.edge_size,
+                        falloff: this.falloff,
+                        corner_radius: this.corner_radius,
+                        rgb_fringing: this.rgb_fringing,
+                        gloss: this.gloss,
+                        tint: this.tint,
+                        shadow: this.shadow,
+                        mode: this.mode,
+                        texture_repeat: this.texture_repeat,
+                        width: this.width,
+                        height: this.height,
+                        clip: this.clip,
+                        blur_direction: 1,
+                        private_pass: 1
+                    };
+
+                    this.chained_effect = new RefractionEffect(chained_params);
+                }
+
+                if (actor !== null)
+                    actor.add_effect(this.chained_effect);
+            }
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            this.set_uniform_value('blur_direction', this.blur_direction);
+            this.set_uniform_value('private_pass', this.private_pass);
+
+            super.vfunc_paint_target(paint_node, paint_context);
         }
 
         vfunc_dispose() {

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -1,0 +1,589 @@
+import GObject from 'gi://GObject';
+import GLib from 'gi://GLib';
+
+import * as utils from '../conveniences/utils.js';
+const St = await utils.import_in_shell_only('gi://St');
+const Shell = await utils.import_in_shell_only('gi://Shell');
+const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Gst = await utils.import_in_shell_only('gi://Gst');
+
+const SHADER_FILENAME = 'refraction.glsl';
+const DEFAULT_PARAMS = {
+    strength: 0.42,
+    blur_radius: 10,
+    edge_size: 22,
+    falloff: 2.4,
+    corner_radius: 22,
+    rgb_fringing: 0.08,
+    gloss: 0.55,
+    webcam_gloss: false,
+    webcam_device: '',
+    tint: 0.18,
+    shadow: 0.28,
+    mode: 0,
+    texture_repeat: 0,
+    width: 0,
+    height: 0,
+    clip: [0, 0, -1, -1]
+};
+
+
+export const RefractionEffect = utils.IS_IN_PREFERENCES ?
+    { default_params: DEFAULT_PARAMS } :
+    new GObject.registerClass({
+        GTypeName: "RefractionEffect",
+        Properties: {
+            'strength': GObject.ParamSpec.double(
+                `strength`,
+                `Strength`,
+                `Refraction strength`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                0.42,
+            ),
+            'edge_size': GObject.ParamSpec.double(
+                `edge_size`,
+                `Edge Size`,
+                `Refraction edge size`,
+                GObject.ParamFlags.READWRITE,
+                1.0, 200.0,
+                22.0,
+            ),
+            'blur_radius': GObject.ParamSpec.double(
+                `blur_radius`,
+                `Blur Radius`,
+                `Internal glass blur radius`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 80.0,
+                10.0,
+            ),
+            'falloff': GObject.ParamSpec.double(
+                `falloff`,
+                `Falloff`,
+                `Refraction falloff`,
+                GObject.ParamFlags.READWRITE,
+                0.25, 8.0,
+                2.4,
+            ),
+            'corner_radius': GObject.ParamSpec.double(
+                `corner_radius`,
+                `Corner Radius`,
+                `Refraction corner radius`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 200.0,
+                22.0,
+            ),
+            'rgb_fringing': GObject.ParamSpec.double(
+                `rgb_fringing`,
+                `RGB Fringing`,
+                `Chromatic offset strength`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                0.08,
+            ),
+            'gloss': GObject.ParamSpec.double(
+                `gloss`,
+                `Gloss`,
+                `Specular highlight strength`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                0.55,
+            ),
+            'webcam_gloss': GObject.ParamSpec.boolean(
+                `webcam_gloss`,
+                `Experimental Webcam Gloss`,
+                `Use webcam luminance to modulate gloss`,
+                GObject.ParamFlags.READWRITE,
+                false,
+            ),
+            'webcam_device': GObject.ParamSpec.string(
+                `webcam_device`,
+                `Experimental Webcam Device`,
+                `Video device used for webcam gloss`,
+                GObject.ParamFlags.READWRITE,
+                '',
+            ),
+            'tint': GObject.ParamSpec.double(
+                `tint`,
+                `Tint`,
+                `Glass tint strength`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                0.18,
+            ),
+            'shadow': GObject.ParamSpec.double(
+                `shadow`,
+                `Shadow`,
+                `Inner shadow strength`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                0.28,
+            ),
+            'mode': GObject.ParamSpec.int(
+                `mode`,
+                `Mode`,
+                `Refraction mode`,
+                GObject.ParamFlags.READWRITE,
+                0, 1,
+                0,
+            ),
+            'texture_repeat': GObject.ParamSpec.int(
+                `texture_repeat`,
+                `Texture Repeat`,
+                `Texture repeat behavior`,
+                GObject.ParamFlags.READWRITE,
+                0, 1,
+                0,
+            ),
+            'width': GObject.ParamSpec.double(
+                `width`,
+                `Width`,
+                `Width`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+            'height': GObject.ParamSpec.double(
+                `height`,
+                `Height`,
+                `Height`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+            // See corner.js: this is backed by an array setter, but represented
+            // as a dummy property so pipeline parameter assignment can reach it.
+            'clip': GObject.ParamSpec.double(
+                `clip`,
+                `Clip`,
+                `Clip`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+        }
+    }, class RefractionEffect extends Clutter.ShaderEffect {
+        constructor(params) {
+            super(params);
+
+            this._clip_x0 = null;
+            this._clip_y0 = null;
+            this._clip_width = null;
+            this._clip_height = null;
+            this._stable_clip_x0 = null;
+            this._stable_clip_y0 = null;
+            this._stable_clip_width = null;
+            this._stable_clip_height = null;
+            this._clip_settle_timeout_id = null;
+            this._webcam_pipeline = null;
+            this._webcam_sink = null;
+            this._webcam_poll_id = null;
+            this._manual_gloss = DEFAULT_PARAMS.gloss;
+            this._live_gloss = DEFAULT_PARAMS.gloss;
+
+            utils.setup_params(this, params);
+
+            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
+            if (this._source)
+                this.set_shader_source(this._source);
+
+            const theme_context = St.ThemeContext.get_for_stage(global.stage);
+            theme_context.connectObject(
+                'notify::scale-factor', _ => this.update_scaled_uniforms(),
+                this
+            );
+        }
+
+        static get default_params() {
+            return DEFAULT_PARAMS;
+        }
+
+        get strength() {
+            return this._strength;
+        }
+
+        set strength(value) {
+            if (this._strength !== value) {
+                this._strength = value;
+
+                this.set_uniform_value('strength', parseFloat(this._strength - 1e-6));
+                this.set_enabled(this.strength > 0.);
+            }
+        }
+
+        get edge_size() {
+            return this._edge_size;
+        }
+
+        set edge_size(value) {
+            if (this._edge_size !== value) {
+                this._edge_size = value;
+
+                this.update_scaled_uniforms();
+            }
+        }
+
+        get blur_radius() {
+            return this._blur_radius;
+        }
+
+        set blur_radius(value) {
+            if (this._blur_radius !== value) {
+                this._blur_radius = value;
+
+                this.update_scaled_uniforms();
+            }
+        }
+
+        get falloff() {
+            return this._falloff;
+        }
+
+        set falloff(value) {
+            if (this._falloff !== value) {
+                this._falloff = value;
+
+                this.set_uniform_value('falloff', parseFloat(this._falloff - 1e-6));
+            }
+        }
+
+        get corner_radius() {
+            return this._corner_radius;
+        }
+
+        set corner_radius(value) {
+            if (this._corner_radius !== value) {
+                this._corner_radius = value;
+
+                this.update_scaled_uniforms();
+            }
+        }
+
+        get rgb_fringing() {
+            return this._rgb_fringing;
+        }
+
+        set rgb_fringing(value) {
+            if (this._rgb_fringing !== value) {
+                this._rgb_fringing = value;
+
+                this.set_uniform_value('rgb_fringing', parseFloat(this._rgb_fringing - 1e-6));
+            }
+        }
+
+        get mode() {
+            return this._mode;
+        }
+
+        set mode(value) {
+            if (this._mode !== value)
+                this._mode = value;
+        }
+
+        get gloss() {
+            return this._gloss;
+        }
+
+        set gloss(value) {
+            if (this._gloss !== value) {
+                this._gloss = value;
+                this._manual_gloss = value;
+
+                if (!this.webcam_gloss)
+                    this.set_uniform_value('gloss', parseFloat(this._gloss - 1e-6));
+            }
+        }
+
+        get webcam_gloss() {
+            return this._webcam_gloss;
+        }
+
+        set webcam_gloss(value) {
+            if (this._webcam_gloss !== value) {
+                this._webcam_gloss = value;
+
+                if (this._webcam_gloss)
+                    this._start_webcam_gloss();
+                else {
+                    this._stop_webcam_gloss();
+                    this.set_uniform_value('gloss', parseFloat(this._manual_gloss - 1e-6));
+                }
+            }
+        }
+
+        get webcam_device() {
+            return this._webcam_device;
+        }
+
+        set webcam_device(value) {
+            if (this._webcam_device !== value) {
+                this._webcam_device = value ?? '';
+
+                if (this.webcam_gloss) {
+                    this._stop_webcam_gloss();
+                    this._start_webcam_gloss();
+                }
+            }
+        }
+
+        get tint() {
+            return this._tint;
+        }
+
+        set tint(value) {
+            if (this._tint !== value) {
+                this._tint = value;
+
+                this.set_uniform_value('tint', parseFloat(this._tint - 1e-6));
+            }
+        }
+
+        get shadow() {
+            return this._shadow;
+        }
+
+        set shadow(value) {
+            if (this._shadow !== value) {
+                this._shadow = value;
+
+                this.set_uniform_value('shadow', parseFloat(this._shadow - 1e-6));
+            }
+        }
+
+        get texture_repeat() {
+            return this._texture_repeat;
+        }
+
+        set texture_repeat(value) {
+            if (this._texture_repeat !== value) {
+                this._texture_repeat = value;
+
+                this.set_uniform_value('texture_repeat', this._texture_repeat);
+            }
+        }
+
+        set(params) {
+            utils.setup_params(this, params);
+        }
+
+        _quoted_gst_string(value) {
+            return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+        }
+
+        _start_webcam_gloss() {
+            if (!Gst || this._webcam_pipeline)
+                return;
+
+            try {
+                Gst.init(null);
+
+                const source = this.webcam_device?.startsWith('/dev/video')
+                    ? `v4l2src device=${this._quoted_gst_string(this.webcam_device)}`
+                    : 'autovideosrc';
+                const pipeline_description = `${source} ! videoconvert ! videoscale ! video/x-raw,format=RGBA,width=24,height=16,framerate=8/1 ! appsink name=sink emit-signals=false sync=false max-buffers=1 drop=true`;
+
+                this._webcam_pipeline = Gst.parse_launch(pipeline_description);
+                this._webcam_sink = this._webcam_pipeline.get_by_name('sink');
+                this._webcam_pipeline.set_state(Gst.State.PLAYING);
+
+                this._webcam_poll_id = GLib.timeout_add(GLib.PRIORITY_LOW, 125, () => {
+                    this._poll_webcam_gloss();
+                    return GLib.SOURCE_CONTINUE;
+                });
+            } catch (e) {
+                console.warn(`[Blur my Shell > refraction]   webcam gloss unavailable: ${e}`);
+                this._stop_webcam_gloss();
+                this.set_uniform_value('gloss', parseFloat(this._manual_gloss - 1e-6));
+            }
+        }
+
+        _poll_webcam_gloss() {
+            if (!this._webcam_sink)
+                return;
+
+            let sample = null;
+            try {
+                sample = this._webcam_sink.emit('try-pull-sample', 0);
+            } catch (e) {
+                this._stop_webcam_gloss();
+                return;
+            }
+
+            if (!sample)
+                return;
+
+            const buffer = sample.get_buffer();
+            const [success, map] = buffer.map(Gst.MapFlags.READ);
+            if (!success)
+                return;
+
+            try {
+                let sum = 0;
+                const data = map.data;
+                for (let i = 0; i + 2 < data.length; i += 4)
+                    sum += data[i] * 0.2126 + data[i + 1] * 0.7152 + data[i + 2] * 0.0722;
+
+                const luma = data.length > 0 ? sum / (data.length / 4) / 255 : 0.5;
+                const target = Math.max(0.05, Math.min(1.0, this._manual_gloss * (0.45 + luma * 1.25)));
+                this._live_gloss += (target - this._live_gloss) * 0.22;
+                this.set_uniform_value('gloss', parseFloat(this._live_gloss - 1e-6));
+                this.queue_repaint();
+            } finally {
+                buffer.unmap(map);
+            }
+        }
+
+        _stop_webcam_gloss() {
+            if (this._webcam_poll_id) {
+                GLib.Source.remove(this._webcam_poll_id);
+                this._webcam_poll_id = null;
+            }
+
+            if (this._webcam_pipeline) {
+                try {
+                    this._webcam_pipeline.set_state(Gst.State.NULL);
+                } catch (e) {
+                    console.warn(`[Blur my Shell > refraction]   could not stop webcam gloss: ${e}`);
+                }
+            }
+
+            this._webcam_pipeline = null;
+            this._webcam_sink = null;
+        }
+
+        get width() {
+            return this._width;
+        }
+
+        set width(value) {
+            if (this._width !== value) {
+                this._width = value;
+
+                this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
+                this.update_scaled_uniforms();
+            }
+        }
+
+        get height() {
+            return this._height;
+        }
+
+        set height(value) {
+            if (this._height !== value) {
+                this._height = value;
+
+                this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
+                this.update_scaled_uniforms();
+            }
+        }
+
+        get clip() {
+            return [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
+        }
+
+        set clip(value) {
+            [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height] = value;
+
+            let shader_clip = this._stabilized_clip();
+
+            this.set_uniform_value('clip_x0', parseFloat(shader_clip[0] - 1e-6));
+            this.set_uniform_value('clip_y0', parseFloat(shader_clip[1] - 1e-6));
+            this.set_uniform_value('clip_width', parseFloat(shader_clip[2] + 3.0 - 1e-6));
+            this.set_uniform_value('clip_height', parseFloat(shader_clip[3] + 3.0 - 1e-6));
+            this.update_scaled_uniforms();
+        }
+
+        _stabilized_clip() {
+            if (this._clip_width < 0 || this._clip_height < 0)
+                return [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
+
+            const x1 = this._clip_x0 + this._clip_width;
+            const y1 = this._clip_y0 + this._clip_height;
+
+            this._stable_clip_x0 = Math.min(this._stable_clip_x0 ?? this._clip_x0, this._clip_x0);
+            this._stable_clip_y0 = Math.min(this._stable_clip_y0 ?? this._clip_y0, this._clip_y0);
+            const stable_x1 = Math.max((this._stable_clip_x0 ?? this._clip_x0) + (this._stable_clip_width ?? 0), x1);
+            const stable_y1 = Math.max((this._stable_clip_y0 ?? this._clip_y0) + (this._stable_clip_height ?? 0), y1);
+            this._stable_clip_width = stable_x1 - this._stable_clip_x0;
+            this._stable_clip_height = stable_y1 - this._stable_clip_y0;
+
+            if (this._clip_settle_timeout_id)
+                GLib.Source.remove(this._clip_settle_timeout_id);
+
+            this._clip_settle_timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 220, () => {
+                this._stable_clip_x0 = this._clip_x0;
+                this._stable_clip_y0 = this._clip_y0;
+                this._stable_clip_width = this._clip_width;
+                this._stable_clip_height = this._clip_height;
+                this._clip_settle_timeout_id = null;
+                this.clip = [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
+                this.queue_repaint();
+                return GLib.SOURCE_REMOVE;
+            });
+
+            return [
+                this._stable_clip_x0,
+                this._stable_clip_y0,
+                this._stable_clip_width,
+                this._stable_clip_height
+            ];
+        }
+
+        update_scaled_uniforms() {
+            const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+            const rect_width = this._stable_clip_width ?? (this._clip_width >= 0 ? this._clip_width : this.width);
+            const rect_height = this._stable_clip_height ?? (this._clip_height >= 0 ? this._clip_height : this.height);
+            const max_edge = Math.max(1, Math.min(rect_width, rect_height) / 2);
+            const edge_size = Math.min(this.edge_size * scale_factor, max_edge);
+            const corner_radius = Math.min(this.corner_radius * scale_factor, max_edge);
+
+            this.set_uniform_value('edge_size', parseFloat(edge_size - 1e-6));
+            this.set_uniform_value('corner_radius', parseFloat(corner_radius - 1e-6));
+            this.set_uniform_value('blur_radius', parseFloat(this.blur_radius * scale_factor - 1e-6));
+        }
+
+        vfunc_set_actor(actor) {
+            if (this._actor_connection_size_id) {
+                let old_actor = this.get_actor();
+                old_actor?.disconnect(this._actor_connection_size_id);
+            }
+            if (this._actor_connection_clip_rect_id) {
+                let old_actor = this.get_actor();
+                old_actor?.disconnect(this._actor_connection_clip_rect_id);
+            }
+            if (this._clip_settle_timeout_id) {
+                GLib.Source.remove(this._clip_settle_timeout_id);
+                this._clip_settle_timeout_id = null;
+            }
+            if (actor) {
+                this.width = actor.width;
+                this.height = actor.height;
+                this._actor_connection_size_id = actor.connect('notify::size', _ => {
+                    this.width = actor.width;
+                    this.height = actor.height;
+                });
+
+                this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
+                this._actor_connection_clip_rect_id = actor.connect('notify::clip-rect', _ => {
+                    this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
+                });
+            }
+            else {
+                this._actor_connection_size_id = null;
+                this._actor_connection_clip_rect_id = null;
+                this._stable_clip_x0 = null;
+                this._stable_clip_y0 = null;
+                this._stable_clip_width = null;
+                this._stable_clip_height = null;
+                this._stop_webcam_gloss();
+            }
+
+            super.vfunc_set_actor(actor);
+        }
+
+        vfunc_dispose() {
+            this._stop_webcam_gloss();
+            if (super.vfunc_dispose)
+                super.vfunc_dispose();
+        }
+    });

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -31,10 +31,9 @@ const DEFAULT_PARAMS = {
     clip: [0, 0, -1, -1]
 };
 
-
-export const RefractionEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+export const RefractionEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : new GObject.registerClass({
         GTypeName: "RefractionEffect",
         Properties: {
             'strength': GObject.ParamSpec.double(
@@ -214,7 +213,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
             theme_context.connectObject(
-                'notify::scale-factor', _ => this.update_scaled_uniforms(),
+                'notify::scale-factor',
+                _ => this.update_scaled_uniforms(),
                 this
             );
         }
@@ -483,7 +483,12 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                     GLib.Source.remove(this._clip_settle_timeout_id);
                     this._clip_settle_timeout_id = null;
                 }
-                return [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
+                return [
+                    this._clip_x0,
+                    this._clip_y0,
+                    this._clip_width,
+                    this._clip_height
+                ];
             }
 
             const [previous_x0, previous_y0, previous_width, previous_height] = previous_clip;
@@ -543,7 +548,15 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             ];
         }
 
-        _stabilized_clip_axis(start, size, previous_start, previous_size, stable_start, stable_size, stabilizing) {
+        _stabilized_clip_axis(
+            start,
+            size,
+            previous_start,
+            previous_size,
+            stable_start,
+            stable_size,
+            stabilizing
+        ) {
             const size_changed =
                 previous_size !== null &&
                 previous_size >= 0 &&

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -23,11 +23,9 @@ const DEFAULT_PARAMS = {
     webcam_device: '',
     tint: 0.18,
     shadow: 0.28,
-    mode: 0,
     texture_repeat: 0,
     blur_direction: 0,
     private_pass: 0,
-    opacity_factor: 1,
     chained_effect: null,
     width: 0,
     height: 0,
@@ -133,14 +131,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 0.0, 1.0,
                 0.28,
             ),
-            'mode': GObject.ParamSpec.int(
-                `mode`,
-                `Mode`,
-                `Refraction mode`,
-                GObject.ParamFlags.READWRITE,
-                0, 1,
-                0,
-            ),
             'texture_repeat': GObject.ParamSpec.int(
                 `texture_repeat`,
                 `Texture Repeat`,
@@ -164,14 +154,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 GObject.ParamFlags.READWRITE,
                 0, 1,
                 0,
-            ),
-            'opacity_factor': GObject.ParamSpec.double(
-                `opacity_factor`,
-                `Opacity factor`,
-                `Opacity factor`,
-                GObject.ParamFlags.READWRITE,
-                0.0, 1.0,
-                1.0,
             ),
             'chained_effect': GObject.ParamSpec.object(
                 `chained_effect`,
@@ -223,7 +205,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             this._stabilize_clip_x = false;
             this._stabilize_clip_y = false;
             this._clip_settle_timeout_id = null;
-            this._opacity_factor = null;
 
             utils.setup_params(this, params);
 
@@ -231,8 +212,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             if (this._source)
                 this.set_shader_source(this._source);
 
-            const theme_context = St.ThemeContext.get_for_stage(global.stage);
-            theme_context.connectObject(
+            this._theme_context = St.ThemeContext.get_for_stage(global.stage);
+            this._theme_context.connectObject(
                 'notify::scale-factor',
                 _ => this.update_scaled_uniforms(),
                 this
@@ -344,15 +325,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             }
         }
 
-        get mode() {
-            return this._mode;
-        }
-
-        set mode(value) {
-            if (this._mode !== value)
-                this._mode = value;
-        }
-
         get gloss() {
             return this._gloss;
         }
@@ -365,6 +337,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             }
         }
 
+        // Deprecated no-op compatibility properties for old saved pipelines.
         get webcam_gloss() {
             return this._webcam_gloss;
         }
@@ -443,18 +416,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 this.set_uniform_value('private_pass', this._private_pass);
                 if (this._private_pass === 1)
                     this.set_enabled(this.blur_radius > 0.01);
-            }
-        }
-
-        get opacity_factor() {
-            return this._opacity_factor;
-        }
-
-        set opacity_factor(value) {
-            if (this._opacity_factor !== value) {
-                this._opacity_factor = value;
-
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
             }
         }
 
@@ -696,9 +657,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                         gloss: this.gloss,
                         tint: this.tint,
                         shadow: this.shadow,
-                        mode: this.mode,
                         texture_repeat: this.texture_repeat,
-                        opacity_factor: this.opacity_factor,
                         width: this.width,
                         height: this.height,
                         clip: this.clip,
@@ -722,6 +681,19 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
         }
 
         vfunc_dispose() {
+            if (this._clip_settle_timeout_id) {
+                GLib.Source.remove(this._clip_settle_timeout_id);
+                this._clip_settle_timeout_id = null;
+            }
+
+            if (this.chained_effect) {
+                this.chained_effect.get_actor()?.remove_effect(this.chained_effect);
+                this.chained_effect = null;
+            }
+
+            this._theme_context?.disconnectObject(this);
+            this._theme_context = null;
+
             if (super.vfunc_dispose)
                 super.vfunc_dispose();
         }

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -15,6 +15,8 @@ const DEFAULT_PARAMS = {
     corner_radius: 22,
     rgb_fringing: 0.08,
     gloss: 0.55,
+    webcam_gloss: false,
+    webcam_device: '',
     tint: 0.18,
     shadow: 0.28,
     mode: 0,
@@ -86,6 +88,20 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 0.0, 1.0,
                 0.55,
             ),
+            'webcam_gloss': GObject.ParamSpec.boolean(
+                `webcam_gloss`,
+                `Deprecated Webcam Gloss`,
+                `Deprecated compatibility property`,
+                GObject.ParamFlags.READWRITE,
+                false,
+            ),
+            'webcam_device': GObject.ParamSpec.string(
+                `webcam_device`,
+                `Deprecated Webcam Device`,
+                `Deprecated compatibility property`,
+                GObject.ParamFlags.READWRITE,
+                '',
+            ),
             'tint': GObject.ParamSpec.double(
                 `tint`,
                 `Tint`,
@@ -147,7 +163,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class RefractionEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
+            const { webcam_gloss, webcam_device, ...parent_params } = params;
+            super(parent_params);
 
             this._clip_x0 = null;
             this._clip_y0 = null;
@@ -268,6 +285,22 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
                 this.set_uniform_value('gloss', parseFloat(this._gloss - 1e-6));
             }
+        }
+
+        get webcam_gloss() {
+            return this._webcam_gloss;
+        }
+
+        set webcam_gloss(value) {
+            this._webcam_gloss = value;
+        }
+
+        get webcam_device() {
+            return this._webcam_device;
+        }
+
+        set webcam_device(value) {
+            this._webcam_device = value ?? '';
         }
 
         get tint() {

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -7,6 +7,7 @@ const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
 const SHADER_FILENAME = 'refraction.glsl';
+const CLIP_STABILIZE_EPSILON = 1.0;
 const DEFAULT_PARAMS = {
     strength: 0.42,
     blur_radius: 10,
@@ -174,6 +175,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             this._stable_clip_y0 = null;
             this._stable_clip_width = null;
             this._stable_clip_height = null;
+            this._stabilize_clip_x = false;
+            this._stabilize_clip_y = false;
             this._clip_settle_timeout_id = null;
 
             utils.setup_params(this, params);
@@ -374,9 +377,10 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set clip(value) {
+            const previous_clip = this.clip;
             [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height] = value;
 
-            let shader_clip = this._stabilized_clip();
+            let shader_clip = this._stabilized_clip(previous_clip);
 
             this.set_uniform_value('clip_x0', parseFloat(shader_clip[0] - 1e-6));
             this.set_uniform_value('clip_y0', parseFloat(shader_clip[1] - 1e-6));
@@ -385,28 +389,64 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             this.update_scaled_uniforms();
         }
 
-        _stabilized_clip() {
-            if (this._clip_width < 0 || this._clip_height < 0)
+        _stabilized_clip(previous_clip) {
+            if (this._clip_width < 0 || this._clip_height < 0) {
+                this._stable_clip_x0 = null;
+                this._stable_clip_y0 = null;
+                this._stable_clip_width = null;
+                this._stable_clip_height = null;
+                this._stabilize_clip_x = false;
+                this._stabilize_clip_y = false;
+                if (this._clip_settle_timeout_id) {
+                    GLib.Source.remove(this._clip_settle_timeout_id);
+                    this._clip_settle_timeout_id = null;
+                }
                 return [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
+            }
 
-            const x1 = this._clip_x0 + this._clip_width;
-            const y1 = this._clip_y0 + this._clip_height;
+            const [previous_x0, previous_y0, previous_width, previous_height] = previous_clip;
 
-            this._stable_clip_x0 = Math.min(this._stable_clip_x0 ?? this._clip_x0, this._clip_x0);
-            this._stable_clip_y0 = Math.min(this._stable_clip_y0 ?? this._clip_y0, this._clip_y0);
-            const stable_x1 = Math.max((this._stable_clip_x0 ?? this._clip_x0) + (this._stable_clip_width ?? 0), x1);
-            const stable_y1 = Math.max((this._stable_clip_y0 ?? this._clip_y0) + (this._stable_clip_height ?? 0), y1);
-            this._stable_clip_width = stable_x1 - this._stable_clip_x0;
-            this._stable_clip_height = stable_y1 - this._stable_clip_y0;
+            [this._stable_clip_x0, this._stable_clip_width, this._stabilize_clip_x] =
+                this._stabilized_clip_axis(
+                    this._clip_x0,
+                    this._clip_width,
+                    previous_x0,
+                    previous_width,
+                    this._stable_clip_x0,
+                    this._stable_clip_width,
+                    this._stabilize_clip_x
+                );
+            [this._stable_clip_y0, this._stable_clip_height, this._stabilize_clip_y] =
+                this._stabilized_clip_axis(
+                    this._clip_y0,
+                    this._clip_height,
+                    previous_y0,
+                    previous_height,
+                    this._stable_clip_y0,
+                    this._stable_clip_height,
+                    this._stabilize_clip_y
+                );
 
             if (this._clip_settle_timeout_id)
                 GLib.Source.remove(this._clip_settle_timeout_id);
+
+            if (!this._stabilize_clip_x && !this._stabilize_clip_y) {
+                this._clip_settle_timeout_id = null;
+                return [
+                    this._stable_clip_x0,
+                    this._stable_clip_y0,
+                    this._stable_clip_width,
+                    this._stable_clip_height
+                ];
+            }
 
             this._clip_settle_timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 220, () => {
                 this._stable_clip_x0 = this._clip_x0;
                 this._stable_clip_y0 = this._clip_y0;
                 this._stable_clip_width = this._clip_width;
                 this._stable_clip_height = this._clip_height;
+                this._stabilize_clip_x = false;
+                this._stabilize_clip_y = false;
                 this._clip_settle_timeout_id = null;
                 this.clip = [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
                 this.queue_repaint();
@@ -419,6 +459,24 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._stable_clip_width,
                 this._stable_clip_height
             ];
+        }
+
+        _stabilized_clip_axis(start, size, previous_start, previous_size, stable_start, stable_size, stabilizing) {
+            const size_changed = previous_size !== null &&
+                previous_size >= 0 &&
+                Math.abs(size - previous_size) > CLIP_STABILIZE_EPSILON;
+
+            if (!stabilizing && !size_changed)
+                return [start, size, false];
+
+            const end = start + size;
+            const resolved_stable_start = stable_start ?? previous_start ?? start;
+            const resolved_stable_size = stable_size ?? previous_size ?? size;
+            const stable_end = resolved_stable_start + resolved_stable_size;
+            const resolved_start = Math.min(resolved_stable_start, start);
+            const resolved_end = Math.max(stable_end, end);
+
+            return [resolved_start, resolved_end - resolved_start, true];
         }
 
         update_scaled_uniforms() {
@@ -467,6 +525,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._stable_clip_y0 = null;
                 this._stable_clip_width = null;
                 this._stable_clip_height = null;
+                this._stabilize_clip_x = false;
+                this._stabilize_clip_y = false;
             }
 
             super.vfunc_set_actor(actor);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -25,6 +25,7 @@ const DEFAULT_PARAMS = {
     texture_repeat: 0,
     blur_direction: 0,
     private_pass: 0,
+    opacity_factor: 1,
     chained_effect: null,
     width: 0,
     height: 0,
@@ -154,6 +155,14 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 0, 1,
                 0,
             ),
+            'opacity_factor': GObject.ParamSpec.double(
+                `opacity_factor`,
+                `Opacity factor`,
+                `Opacity factor`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                1.0,
+            ),
             'chained_effect': GObject.ParamSpec.object(
                 `chained_effect`,
                 `Chained Effect`,
@@ -204,6 +213,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             this._stabilize_clip_x = false;
             this._stabilize_clip_y = false;
             this._clip_settle_timeout_id = null;
+            this._opacity_factor = null;
 
             utils.setup_params(this, params);
 
@@ -407,6 +417,18 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 this.set_uniform_value('private_pass', this._private_pass);
                 if (this._private_pass === 1)
                     this.set_enabled(this.blur_radius > 0.01);
+            }
+        }
+
+        get opacity_factor() {
+            return this._opacity_factor;
+        }
+
+        set opacity_factor(value) {
+            if (this._opacity_factor !== value) {
+                this._opacity_factor = value;
+
+                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
             }
         }
 
@@ -648,6 +670,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                         shadow: this.shadow,
                         mode: this.mode,
                         texture_repeat: this.texture_repeat,
+                        opacity_factor: this.opacity_factor,
                         width: this.width,
                         height: this.height,
                         clip: this.clip,

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -8,6 +8,7 @@ const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
 const SHADER_FILENAME = 'refraction.glsl';
 const CLIP_STABILIZE_EPSILON = 1.0;
+const MAX_BLUR_RADIUS = 48.0;
 
 const DEFAULT_PARAMS = {
     strength: 0.42,
@@ -15,6 +16,7 @@ const DEFAULT_PARAMS = {
     edge_size: 22,
     falloff: 2.4,
     corner_radius: 22,
+    rim_width: 4.8,
     rgb_fringing: 0.08,
     gloss: 0.55,
     webcam_gloss: false,
@@ -58,7 +60,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 `Blur Radius`,
                 `Internal glass blur radius`,
                 GObject.ParamFlags.READWRITE,
-                0.0, 80.0,
+                0.0, MAX_BLUR_RADIUS,
                 10.0,
             ),
             'falloff': GObject.ParamSpec.double(
@@ -76,6 +78,14 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 GObject.ParamFlags.READWRITE,
                 0.0, 200.0,
                 22.0,
+            ),
+            'rim_width': GObject.ParamSpec.double(
+                `rim_width`,
+                `Rim Width`,
+                `Refraction rim width`,
+                GObject.ParamFlags.READWRITE,
+                1.0, 6.5,
+                4.8,
             ),
             'rgb_fringing': GObject.ParamSpec.double(
                 `rgb_fringing`,
@@ -267,12 +277,12 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
 
         set blur_radius(value) {
             if (this._blur_radius !== value) {
-                this._blur_radius = value;
+                this._blur_radius = Math.min(value, MAX_BLUR_RADIUS);
 
                 this.update_scaled_uniforms();
 
                 if (this.chained_effect)
-                    this.chained_effect.blur_radius = value;
+                    this.chained_effect.blur_radius = this._blur_radius;
             }
         }
 
@@ -303,6 +313,22 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
 
                 if (this.chained_effect)
                     this.chained_effect.corner_radius = value;
+            }
+        }
+
+        get rim_width() {
+            return this._rim_width;
+        }
+
+        set rim_width(value) {
+            const rim_width = Math.max(1.0, Math.min(value, 6.5));
+            if (this._rim_width !== rim_width) {
+                this._rim_width = rim_width;
+
+                this.set_uniform_value('rim_width', parseFloat(this._rim_width - 1e-6));
+
+                if (this.chained_effect)
+                    this.chained_effect.rim_width = rim_width;
             }
         }
 
@@ -609,9 +635,10 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
 
             this.set_uniform_value('edge_size', parseFloat(edge_size - 1e-6));
             this.set_uniform_value('corner_radius', parseFloat(corner_radius - 1e-6));
-            this.set_uniform_value('blur_radius', parseFloat(this.blur_radius * scale_factor - 1e-6));
+            const blur_radius = Math.min(this.blur_radius, MAX_BLUR_RADIUS) * scale_factor;
+            this.set_uniform_value('blur_radius', parseFloat(blur_radius - 1e-6));
             if (this.private_pass === 1)
-                this.set_enabled(this.blur_radius > 0.01);
+                this.set_enabled(blur_radius > 0.01);
         }
 
         vfunc_set_actor(actor) {
@@ -664,6 +691,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                         edge_size: this.edge_size,
                         falloff: this.falloff,
                         corner_radius: this.corner_radius,
+                        rim_width: this.rim_width,
                         rgb_fringing: this.rgb_fringing,
                         gloss: this.gloss,
                         tint: this.tint,

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -5,8 +5,6 @@ import * as utils from '../conveniences/utils.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Gst = await utils.import_in_shell_only('gi://Gst');
-const GstApp = await utils.import_in_shell_only('gi://GstApp');
 
 const SHADER_FILENAME = 'refraction.glsl';
 const DEFAULT_PARAMS = {
@@ -17,8 +15,6 @@ const DEFAULT_PARAMS = {
     corner_radius: 22,
     rgb_fringing: 0.08,
     gloss: 0.55,
-    webcam_gloss: false,
-    webcam_device: '',
     tint: 0.18,
     shadow: 0.28,
     mode: 0,
@@ -89,20 +85,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 GObject.ParamFlags.READWRITE,
                 0.0, 1.0,
                 0.55,
-            ),
-            'webcam_gloss': GObject.ParamSpec.boolean(
-                `webcam_gloss`,
-                `Experimental Webcam Gloss`,
-                `Use webcam luminance to modulate gloss`,
-                GObject.ParamFlags.READWRITE,
-                false,
-            ),
-            'webcam_device': GObject.ParamSpec.string(
-                `webcam_device`,
-                `Experimental Webcam Device`,
-                `Video device used for webcam gloss`,
-                GObject.ParamFlags.READWRITE,
-                '',
             ),
             'tint': GObject.ParamSpec.double(
                 `tint`,
@@ -176,14 +158,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
             this._stable_clip_width = null;
             this._stable_clip_height = null;
             this._clip_settle_timeout_id = null;
-            this._webcam_pipeline = null;
-            this._webcam_sink = null;
-            this._webcam_poll_id = null;
-            this._webcam_pipeline_candidates = [];
-            this._webcam_pipeline_index = 0;
-            this._webcam_empty_polls = 0;
-            this._manual_gloss = DEFAULT_PARAMS.gloss;
-            this._live_gloss = DEFAULT_PARAMS.gloss;
 
             utils.setup_params(this, params);
 
@@ -291,42 +265,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
         set gloss(value) {
             if (this._gloss !== value) {
                 this._gloss = value;
-                this._manual_gloss = value;
 
-                if (!this.webcam_gloss)
-                    this.set_uniform_value('gloss', parseFloat(this._gloss - 1e-6));
-            }
-        }
-
-        get webcam_gloss() {
-            return this._webcam_gloss;
-        }
-
-        set webcam_gloss(value) {
-            if (this._webcam_gloss !== value) {
-                this._webcam_gloss = value;
-
-                if (this._webcam_gloss)
-                    this._start_webcam_gloss();
-                else {
-                    this._stop_webcam_gloss();
-                    this.set_uniform_value('gloss', parseFloat(this._manual_gloss - 1e-6));
-                }
-            }
-        }
-
-        get webcam_device() {
-            return this._webcam_device;
-        }
-
-        set webcam_device(value) {
-            if (this._webcam_device !== value) {
-                this._webcam_device = value ?? '';
-
-                if (this.webcam_gloss) {
-                    this._stop_webcam_gloss();
-                    this._start_webcam_gloss();
-                }
+                this.set_uniform_value('gloss', parseFloat(this._gloss - 1e-6));
             }
         }
 
@@ -368,158 +308,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
 
         set(params) {
             utils.setup_params(this, params);
-        }
-
-        _quoted_gst_string(value) {
-            return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
-        }
-
-        _start_webcam_gloss() {
-            if (!Gst || !GstApp || this._webcam_pipeline)
-                return;
-
-            try {
-                Gst.init(null);
-                this._webcam_pipeline_candidates = this._webcam_pipeline_descriptions();
-                this._webcam_pipeline_index = 0;
-                this._start_next_webcam_pipeline();
-
-                this._webcam_poll_id = GLib.timeout_add(GLib.PRIORITY_LOW, 125, () => {
-                    this._poll_webcam_gloss();
-                    return GLib.SOURCE_CONTINUE;
-                });
-            } catch (e) {
-                console.warn(`[Blur my Shell > refraction]   webcam gloss unavailable: ${e}`);
-                this._stop_webcam_gloss();
-                this.set_uniform_value('gloss', parseFloat(this._manual_gloss - 1e-6));
-            }
-        }
-
-        _webcam_pipeline_descriptions() {
-            const device = this.webcam_device?.startsWith('/dev/video')
-                ? this.webcam_device
-                : '/dev/video0';
-            const source = `v4l2src device=${this._quoted_gst_string(device)}`;
-            const sink = 'videoconvert ! videoscale ! video/x-raw,format=RGBA,width=24,height=16 ! appsink name=sink emit-signals=false sync=false max-buffers=1 drop=true';
-
-            return [
-                `${source} ! video/x-raw,format=YUY2,width=640,height=480,framerate=30/1 ! ${sink}`,
-                `${source} ! video/x-raw,width=640,height=480,framerate=30/1 ! ${sink}`,
-                `${source} ! image/jpeg,width=640,height=480,framerate=30/1 ! jpegdec ! ${sink}`,
-                `autovideosrc ! video/x-raw,width=640,height=480,framerate=30/1 ! ${sink}`,
-                `autovideosrc ! ${sink}`,
-            ];
-        }
-
-        _start_next_webcam_pipeline() {
-            this._stop_webcam_pipeline();
-            this._webcam_empty_polls = 0;
-
-            while (this._webcam_pipeline_index < this._webcam_pipeline_candidates.length) {
-                const description = this._webcam_pipeline_candidates[this._webcam_pipeline_index++];
-
-                try {
-                    this._webcam_pipeline = Gst.parse_launch(description);
-                    this._webcam_sink = this._webcam_pipeline.get_by_name('sink');
-                    this._webcam_pipeline.set_state(Gst.State.PLAYING);
-                    return true;
-                } catch (e) {
-                    console.warn(`[Blur my Shell > refraction]   webcam pipeline failed: ${e}`);
-                }
-            }
-
-            console.warn('[Blur my Shell > refraction]   webcam gloss unavailable: no camera pipeline could start');
-            this.set_uniform_value('gloss', parseFloat(this._manual_gloss - 1e-6));
-            return false;
-        }
-
-        _webcam_pipeline_has_error() {
-            const bus = this._webcam_pipeline?.get_bus();
-            if (!bus)
-                return false;
-
-            const message = bus.pop_filtered(Gst.MessageType.ERROR | Gst.MessageType.EOS);
-            if (!message)
-                return false;
-
-            if (message.type === Gst.MessageType.ERROR) {
-                const [error, debug] = message.parse_error();
-                console.warn(`[Blur my Shell > refraction]   webcam pipeline error: ${error.message}; ${debug}`);
-            }
-
-            return true;
-        }
-
-        _poll_webcam_gloss() {
-            if (!this._webcam_sink)
-                return;
-
-            if (this._webcam_pipeline_has_error()) {
-                this._start_next_webcam_pipeline();
-                return;
-            }
-
-            let sample = null;
-            try {
-                sample = this._webcam_sink.try_pull_sample(0);
-            } catch (e) {
-                console.warn(`[Blur my Shell > refraction]   webcam sample failed: ${e}`);
-                this._start_next_webcam_pipeline();
-                return;
-            }
-
-            if (!sample) {
-                this._webcam_empty_polls++;
-                if (this._webcam_empty_polls > 24)
-                    this._start_next_webcam_pipeline();
-                return;
-            }
-
-            this._webcam_empty_polls = 0;
-            const buffer = sample.get_buffer();
-            const [success, map] = buffer.map(Gst.MapFlags.READ);
-            if (!success)
-                return;
-
-            try {
-                let sum = 0;
-                const data = map.data;
-                for (let i = 0; i + 2 < data.length; i += 4)
-                    sum += data[i] * 0.2126 + data[i + 1] * 0.7152 + data[i + 2] * 0.0722;
-
-                const luma = data.length > 0 ? sum / (data.length / 4) / 255 : 0.5;
-                const target = Math.max(0.05, Math.min(1.0, this._manual_gloss * (0.45 + luma * 1.25)));
-                this._live_gloss += (target - this._live_gloss) * 0.22;
-                this.set_uniform_value('gloss', parseFloat(this._live_gloss - 1e-6));
-                this.queue_repaint();
-            } finally {
-                buffer.unmap(map);
-            }
-        }
-
-        _stop_webcam_gloss() {
-            if (this._webcam_poll_id) {
-                GLib.Source.remove(this._webcam_poll_id);
-                this._webcam_poll_id = null;
-            }
-
-            this._stop_webcam_pipeline();
-            this._webcam_pipeline_candidates = [];
-            this._webcam_pipeline_index = 0;
-        }
-
-        _stop_webcam_pipeline() {
-            if (this._webcam_pipeline) {
-                try {
-                    this._webcam_pipeline.set_state(Gst.State.NULL);
-                } catch (e) {
-                    console.warn(`[Blur my Shell > refraction]   could not stop webcam gloss: ${e}`);
-                }
-            }
-
-            this._webcam_pipeline = null;
-            this._webcam_sink = null;
-            this._webcam_empty_polls = 0;
         }
 
         get width() {
@@ -646,14 +434,12 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES ?
                 this._stable_clip_y0 = null;
                 this._stable_clip_width = null;
                 this._stable_clip_height = null;
-                this._stop_webcam_gloss();
             }
 
             super.vfunc_set_actor(actor);
         }
 
         vfunc_dispose() {
-            this._stop_webcam_gloss();
             if (super.vfunc_dispose)
                 super.vfunc_dispose();
         }

--- a/src/preferences/pipelines_management/effect_row.js
+++ b/src/preferences/pipelines_management/effect_row.js
@@ -1,5 +1,6 @@
 import Adw from 'gi://Adw';
 import GObject from 'gi://GObject';
+import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk';
 import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
@@ -147,6 +148,25 @@ export const EffectRow = GObject.registerClass({
                     );
                     break;
 
+                case "video_device":
+                    row = new Adw.ComboRow({ model: new Gtk.StringList });
+                    row._bms_values = this.list_video_devices();
+                    row._bms_values.forEach(device => row.model.append(device.label));
+
+                    const selected_value = this.get_effect_param(param_key);
+                    let selected_index = row._bms_values.findIndex(device => device.value === selected_value);
+                    if (selected_index < 0 && selected_value) {
+                        row._bms_values.push({ label: selected_value, value: selected_value });
+                        row.model.append(selected_value);
+                        selected_index = row._bms_values.length - 1;
+                    }
+                    row.selected = Math.max(0, selected_index);
+                    row.connect(
+                        'notify::selected',
+                        () => this.set_effect_param(param_key, row._bms_values[row.selected]?.value ?? '')
+                    );
+                    break;
+
                 case "rgba":
                     row = new Adw.ActionRow;
                     let color_button = new Gtk.ColorButton({
@@ -217,6 +237,29 @@ export const EffectRow = GObject.registerClass({
             this._warn(`effect not found when setting key ${key}`);
 
         this.pipelines_manager.update_pipeline_effects(this.pipeline_id, effects, false);
+    }
+
+    list_video_devices() {
+        const devices = [{ label: _("Default camera (auto)"), value: '' }];
+
+        try {
+            const dir = GLib.Dir.open('/dev', 0);
+            let name;
+            while ((name = dir.read_name()) !== null) {
+                if (/^video[0-9]+$/.test(name))
+                    devices.push({ label: `/dev/${name}`, value: `/dev/${name}` });
+            }
+        } catch (e) {
+            this._warn(`could not list video devices: ${e}`);
+        }
+
+        return devices.sort((a, b) => {
+            if (!a.value)
+                return -1;
+            if (!b.value)
+                return 1;
+            return a.value.localeCompare(b.value, undefined, { numeric: true });
+        });
     }
 
     _warn(str) {

--- a/src/preferences/pipelines_management/effect_row.js
+++ b/src/preferences/pipelines_management/effect_row.js
@@ -1,6 +1,5 @@
 import Adw from 'gi://Adw';
 import GObject from 'gi://GObject';
-import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk';
 import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
@@ -148,25 +147,6 @@ export const EffectRow = GObject.registerClass({
                     );
                     break;
 
-                case "video_device":
-                    row = new Adw.ComboRow({ model: new Gtk.StringList });
-                    row._bms_values = this.list_video_devices();
-                    row._bms_values.forEach(device => row.model.append(device.label));
-
-                    const selected_value = this.get_effect_param(param_key);
-                    let selected_index = row._bms_values.findIndex(device => device.value === selected_value);
-                    if (selected_index < 0 && selected_value) {
-                        row._bms_values.push({ label: selected_value, value: selected_value });
-                        row.model.append(selected_value);
-                        selected_index = row._bms_values.length - 1;
-                    }
-                    row.selected = Math.max(0, selected_index);
-                    row.connect(
-                        'notify::selected',
-                        () => this.set_effect_param(param_key, row._bms_values[row.selected]?.value ?? '')
-                    );
-                    break;
-
                 case "rgba":
                     row = new Adw.ActionRow;
                     let color_button = new Gtk.ColorButton({
@@ -237,29 +217,6 @@ export const EffectRow = GObject.registerClass({
             this._warn(`effect not found when setting key ${key}`);
 
         this.pipelines_manager.update_pipeline_effects(this.pipeline_id, effects, false);
-    }
-
-    list_video_devices() {
-        const devices = [{ label: _("Default camera (auto)"), value: '' }];
-
-        try {
-            const dir = GLib.Dir.open('/dev', 0);
-            let name;
-            while ((name = dir.read_name()) !== null) {
-                if (/^video[0-9]+$/.test(name))
-                    devices.push({ label: `/dev/${name}`, value: `/dev/${name}` });
-            }
-        } catch (e) {
-            this._warn(`could not list video devices: ${e}`);
-        }
-
-        return devices.sort((a, b) => {
-            if (!a.value)
-                return -1;
-            if (!b.value)
-                return 1;
-            return a.value.localeCompare(b.value, undefined, { numeric: true });
-        });
     }
 
     _warn(str) {


### PR DESCRIPTION
## Summary

Adds a new Blur my Shell pipeline effect based on the iOS 26 Liquid Glass look. The shader is directly adapted from winaviation's Liquid (Gl)ass tweak, specifically `Shared/LGMetalShaderSource.m`, and ported from Metal shader code to GLSL for Blur my Shell

Source: https://github.com/winaviation-tweaks/liquidass

## How it works

The effect plugs into the existing Blur my Shell effect pipeline and samples the current pipeline texture behind the actor. From there, the shader uses a rounded-rect distance field to find the glass edge, corner radius, and outward normal. That edge data drives a Snell-style refraction profile so pixels near the border are displaced like they are passing through a beveled piece of glass

The shader also applies a small internal blur pass, optional RGB fringing, tint, inner shadow, and a highlight pass based on backdrop luminance so brighter wallpaper areas can catch the rim a bit more naturally

## Why draft

Opening this as a draft because the effect is working, but there are still a couple of visual issues I want to sort out before marking it ready for review

I am still looking into the known issues below. Suggestions or pointers are appreciated, especially from anyone more familiar with the effect pipeline or Dash to Dock

## Known issues

- 45 degree seams can appear on rounded corners when the refraction effect is applied. This is much less noticeable on smaller elements
- ~~Dash to Dock has a weird shifting effect when item magnification is enabled~~ Was caused by my fork of Dash to Dock.

## Notes

The latest pushed change only formats the refraction shader and effect wrapper for readability. The main behavior is from the earlier refraction effect work

## Testing

- Tested manually on GNOME 50, Wayland
- Checked JavaScript syntax with `node --check src/effects/refraction.js`
- Checked whitespace/errors in the diff with `git diff --check`