### PR TITLE
Fix shader uniform handling for GNOME 48+ compatibility

### DIFF
--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -2,6 +2,7 @@ import St from 'gi://St';
 import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Background from 'resource:///org/gnome/shell/ui/background.js';
+import * as uniforms from './shader_uniforms.js';
 
 /// A `Pipeline` object is a handy way to manage the effects attached to an actor. It only manages
 /// one actor at a time (so blurring multiple widgets will need multiple `Pipeline`), and is
@@ -163,7 +164,9 @@ export const Pipeline = class Pipeline {
 
         // build the new effects to be added
         pipeline.effects.forEach(effect => {
-            if ('new_' + effect.type + '_effect' in this.effects_manager)
+            if (effect.type === 'pixelize')
+                this.build_pixelize_effect(effect);
+            else if ('new_' + effect.type + '_effect' in this.effects_manager)
                 this.build_effect(effect);
             else
                 this._warn(`could not add effect to actor, effect "${effect.type}" not found`);
@@ -172,9 +175,34 @@ export const Pipeline = class Pipeline {
 
         // add the effects to the actor
         if (this.actor)
-            this.effects.forEach(effect => this.actor.add_effect(effect));
+            this.effects.forEach(effect => {
+                this.actor.add_effect(effect);
+                uniforms.mark_dirty(effect);
+            });
         else
             this._warn(`could not add effect to actor, actor does not exist anymore`);
+    }
+
+    build_pixelize_effect(effect_infos) {
+        const effect_params = this.get_effect_params(effect_infos);
+        const effect_overrides = this.get_effect_overrides(effect_infos.type, effect_params);
+        const params = {
+            ...effect_params,
+            ...effect_overrides,
+        };
+
+        const downscale = this.effects_manager.new_downscale_effect({
+            divider: params.factor,
+            downsampling_mode: params.downsampling_mode,
+            opacity_factor: params.opacity_factor,
+        });
+        const upscale = this.effects_manager.new_upscale_effect({
+            factor: params.factor,
+            opacity_factor: params.opacity_factor,
+        });
+
+        this.setup_effect(downscale, effect_infos, effect_params, 'downscale');
+        this.setup_effect(upscale, effect_infos, effect_params, 'upscale');
     }
 
     /// Given an `effect_infos` object containing the effect type, id and params, build an effect
@@ -186,30 +214,37 @@ export const Pipeline = class Pipeline {
             ...effect_params,
             ...effect_overrides,
         });
+        this.setup_effect(effect, effect_infos, effect_params);
+    }
+
+    setup_effect(effect, effect_infos, effect_params, pixelize_role = null) {
         effect._bms_effect_type = effect_infos.type;
+        effect._bms_effect_id = effect_infos.id;
         effect._bms_effect_params = effect_params;
+        effect._bms_pixelize_role = pixelize_role;
         this.effects.push(effect);
 
         // connect to settings changes
         effect._effect_key_removed_id = this.pipelines_manager.connect(
             this.pipeline_id + '::effect-' + effect_infos.id + '-key-removed', (_, key) => {
-                effect._bms_effect_params[key] = effect.constructor.default_params[key];
+                const default_value = this.get_effect_default_param(effect, key);
+                effect._bms_effect_params[key] = default_value;
                 if (!this.apply_effect_override(effect, key))
-                    effect[key] = effect.constructor.default_params[key];
+                    this.set_effect_param(effect, key, default_value);
             }
         );
         effect._effect_key_updated_id = this.pipelines_manager.connect(
             this.pipeline_id + '::effect-' + effect_infos.id + '-key-updated', (_, key, value) => {
                 effect._bms_effect_params[key] = value;
                 if (!this.apply_effect_override(effect, key))
-                    effect[key] = value;
+                    this.set_effect_param(effect, key, value);
             }
         );
         effect._effect_key_added_id = this.pipelines_manager.connect(
             this.pipeline_id + '::effect-' + effect_infos.id + '-key-added', (_, key, value) => {
                 effect._bms_effect_params[key] = value;
                 if (!this.apply_effect_override(effect, key))
-                    effect[key] = value;
+                    this.set_effect_param(effect, key, value);
             }
         );
     }
@@ -218,8 +253,15 @@ export const Pipeline = class Pipeline {
         const effect_class = this.effects_manager.SUPPORTED_EFFECTS[effect_infos.type]?.class;
         return {
             ...(effect_class?.default_params ?? {}),
-            ...effect_infos.params,
+            ...(effect_infos.params ?? {}),
         };
+    }
+
+    get_effect_default_param(effect, key) {
+        return this.effects_manager.SUPPORTED_EFFECTS[effect._bms_effect_type]
+            ?.class
+            ?.default_params
+            ?.[key];
     }
 
     get_effect_overrides(effect_type, effect_params = {}) {
@@ -232,7 +274,7 @@ export const Pipeline = class Pipeline {
         if (!(key in overrides))
             return false;
 
-        effect[key] = overrides[key];
+        this.set_effect_param(effect, key, overrides[key]);
         return true;
     }
 
@@ -242,8 +284,32 @@ export const Pipeline = class Pipeline {
                 return;
 
             const overrides = this.get_effect_overrides(effect._bms_effect_type, effect._bms_effect_params);
-            Object.keys(overrides).forEach(key => effect[key] = overrides[key]);
+            Object.keys(overrides).forEach(key => this.set_effect_param(effect, key, overrides[key]));
         });
+    }
+
+    set_effect_param(effect, key, value) {
+        if (effect._bms_effect_type !== 'pixelize') {
+            effect[key] = value;
+            return;
+        }
+
+        if (key === 'factor') {
+            if (effect._bms_pixelize_role === 'downscale')
+                effect.divider = value;
+            else if (effect._bms_pixelize_role === 'upscale')
+                effect.factor = value;
+            return;
+        }
+
+        if (key === 'downsampling_mode') {
+            if (effect._bms_pixelize_role === 'downscale')
+                effect.downsampling_mode = value;
+            return;
+        }
+
+        if (key in effect)
+            effect[key] = value;
     }
 
     /// Remove every effect from the actor it is attached to. Please note that they are not
@@ -262,7 +328,9 @@ export const Pipeline = class Pipeline {
             delete effect._effect_key_updated_id;
             delete effect._effect_key_added_id;
             delete effect._bms_effect_type;
+            delete effect._bms_effect_id;
             delete effect._bms_effect_params;
+            delete effect._bms_pixelize_role;
         });
         this.effects = [];
     }

--- a/src/conveniences/shader_uniforms.js
+++ b/src/conveniences/shader_uniforms.js
@@ -1,0 +1,63 @@
+import GObject from 'gi://GObject';
+
+const INTEGRAL_UNIFORMS = new Set([
+    'corners_bottom',
+    'corners_top',
+    'divider',
+    'dir',
+    'downsampling_mode',
+    'factor',
+    'iterations',
+    'mode',
+    'operation',
+    'prefer_closer_pixels',
+    'straight_corners',
+    'use_base_pixel',
+]);
+
+export function set_uniform(effect, name, value) {
+    if (!effect._bms_uniforms)
+        effect._bms_uniforms = new Map();
+
+    effect._bms_uniforms.set(name, value);
+    effect._bms_uniforms_dirty = true;
+    try {
+        effect.queue_repaint();
+    } catch (e) { }
+}
+
+export function mark_dirty(effect) {
+    if (effect._bms_uniforms)
+        effect._bms_uniforms_dirty = true;
+}
+
+export function upload_uniforms(effect) {
+    if (!effect._bms_uniforms_dirty || !effect._bms_uniforms || !effect.get_actor?.())
+        return;
+
+    for (const [name, value] of effect._bms_uniforms) {
+        try {
+            effect.set_uniform_value(name, get_shader_value(name, value));
+        } catch (e) {
+            if (!effect._bms_uniform_warning_shown) {
+                effect._bms_uniform_warning_shown = true;
+                console.warn(`[Blur my Shell] shader uniform upload failed for ${effect.constructor.name}`, e);
+            }
+        }
+    }
+
+    effect._bms_uniforms_dirty = false;
+}
+
+function get_shader_value(name, value) {
+    if (typeof value !== 'number')
+        return value;
+
+    if (INTEGRAL_UNIFORMS.has(name))
+        return Math.trunc(value);
+
+    const float_value = new GObject.Value();
+    float_value.init(GObject.TYPE_FLOAT);
+    float_value.set_float(value);
+    return float_value;
+}

--- a/src/effects/color.glsl
+++ b/src/effects/color.glsl
@@ -54,7 +54,7 @@ float soft_light_channel(float base, float _blend) {
 
 vec3 get_blend(vec3 base, vec3 _blend) {
     if (mode == MULTIPLY) return base * _blend;
-    if (mode == SCREEN) return 1 - (1 - base) * (1 - _blend);
+    if (mode == SCREEN) return 1.0 - (1.0 - base) * (1.0 - _blend);
     if (mode == OVERLAY) {
         vec3 result;
         result.r = base.r < 0.5 ? (2.0 * base.r * _blend.r) : (1.0 - 2.0 * (1.0 - base.r) * (1.0 - _blend.r));
@@ -64,10 +64,10 @@ vec3 get_blend(vec3 base, vec3 _blend) {
     }
     if (mode == DARKEN) return min(base, _blend);
     if (mode == LIGHTEN) return max(base, _blend);
-    if (mode == PLUS_DARKER) return base + _blend - 1;
+    if (mode == PLUS_DARKER) return base + _blend - vec3(1.0);
     if (mode == PLUS_LIGHTER) return base + _blend;
-    if (mode == COLOR_DODGE) return base / (1 - _blend);
-    if (mode == COLOR_BURN) return 1 - (1 - base) / _blend;
+    if (mode == COLOR_DODGE) return base / max(vec3(1e-6), 1.0 - _blend);
+    if (mode == COLOR_BURN) return 1.0 - (1.0 - base) / max(vec3(1e-6), _blend);
     if (mode == HARD_LIGHT) {
         vec3 result;
         result.r = _blend.r < 0.5 ? (2.0 * base.r * _blend.r) : (1.0 - 2.0 * (1.0 - base.r) * (1.0 - _blend.r));
@@ -79,7 +79,7 @@ vec3 get_blend(vec3 base, vec3 _blend) {
         return vec3(soft_light_channel(base.r, _blend.r), soft_light_channel(base.g, _blend.g), soft_light_channel(base.b, _blend.b));
     }
     if (mode == DIFFERENCE) return abs(base - _blend);
-    if (mode == EXCLUSION) return 0.5 - 2 * (base - 0.5) * (_blend - 0.5);
+    if (mode == EXCLUSION) return 0.5 - 2.0 * (base - 0.5) * (_blend - 0.5);
     if (mode == HUE) {
         vec3 base_hsl = rgb_to_hsl(base);
         vec3 blend_hsl = rgb_to_hsl(_blend);
@@ -107,7 +107,7 @@ void main() {
     vec4 c = texture2D(tex, cogl_tex_coord_in[0].st);
     vec3 pix_color = c.xyz;
     vec3 color = get_blend(pix_color, vec3(red, green, blue));
-    vec4 effect_color = vec4(mix(pix_color, color, blend), 1.);
+    float amount = blend * opacity_factor;
 
-    cogl_color_out = mix(c, effect_color, opacity_factor);
+    cogl_color_out = vec4(mix(pix_color, color, amount), c.a);
 }

--- a/src/effects/color.js
+++ b/src/effects/color.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
@@ -72,9 +73,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
         // Luminosity (17)
     }, class ColorEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            // initialize without color as a parameter
-            const { color, ...parent_params } = params;
-            super(parent_params);
+            super();
 
             this._red = null;
             this._green = null;
@@ -89,7 +88,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
                 this.set_shader_source(this._source);
 
             // set params; utils.setup_params doesn't work here with color
-            this.color = 'color' in params ? color : this.constructor.default_params.color;
+            this.color = 'color' in params ? params.color : this.constructor.default_params.color;
             this.blend_mode = 'blend_mode' in params ?  params.blend_mode : this.constructor.default_params.blend_mode;
             this.opacity_factor = 'opacity_factor' in params ? params.opacity_factor : this.constructor.default_params.opacity_factor;
         }
@@ -106,7 +105,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             if (this._red !== value) {
                 this._red = value;
 
-                this.set_uniform_value('red', parseFloat(this._red - 1e-6));
+                uniforms.set_uniform(this, 'red', parseFloat(this._red - 1e-6));
             }
         }
 
@@ -118,7 +117,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             if (this._green !== value) {
                 this._green = value;
 
-                this.set_uniform_value('green', parseFloat(this._green - 1e-6));
+                uniforms.set_uniform(this, 'green', parseFloat(this._green - 1e-6));
             }
         }
 
@@ -130,7 +129,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             if (this._blue !== value) {
                 this._blue = value;
 
-                this.set_uniform_value('blue', parseFloat(this._blue - 1e-6));
+                uniforms.set_uniform(this, 'blue', parseFloat(this._blue - 1e-6));
             }
         }
 
@@ -142,7 +141,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             if (this._blend !== value) {
                 this._blend = value;
 
-                this.set_uniform_value('blend', parseFloat(this._blend - 1e-6));
+                uniforms.set_uniform(this, 'blend', parseFloat(this._blend - 1e-6));
                 this.set_enabled(this.blend > 0);
             }
         }
@@ -155,7 +154,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             if (this._blend_mode !== value) {
                 this._blend_mode = value;
 
-                this.set_uniform_value('mode', this._blend_mode);
+                uniforms.set_uniform(this, 'mode', this._blend_mode);
             }
         }
 
@@ -167,7 +166,7 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
         }
 
@@ -189,5 +188,10 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             this.blend_mode = params.blend_mode;
             if ('opacity_factor' in params)
                 this.opacity_factor = params.opacity_factor;
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/corner.glsl
+++ b/src/effects/corner.glsl
@@ -30,17 +30,20 @@ float circle_bounds(vec2 p, vec2 center, float clip_radius) {
 }
 
 vec4 getTexture(vec2 uv) {
-    if (uv.x < 2. / width)
-        uv.x = 2. / width;
+    float w = max(1.0, width);
+    float h = max(1.0, height);
 
-    if (uv.y < 2. / height)
-        uv.y = 2. / height;
+    if (uv.x < 2. / w)
+        uv.x = 2. / w;
 
-    if (uv.x > 1. - 3. / width)
-        uv.x = 1. - 3. / width;
+    if (uv.y < 2. / h)
+        uv.y = 2. / h;
 
-    if (uv.y > 1. - 3. / height)
-        uv.y = 1. - 3. / height;
+    if (uv.x > 1. - 3. / w)
+        uv.x = 1. - 3. / w;
+
+    if (uv.y > 1. - 3. / h)
+        uv.y = 1. - 3. / h;
 
     return texture2D(tex, uv);
 }

--- a/src/effects/corner.js
+++ b/src/effects/corner.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
@@ -56,33 +57,23 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
                 GObject.ParamFlags.READWRITE,
                 true,
             ),
-            // FIXME this works but it logs an error, because I'm not a double...
-            // I don't want to fiddle with GVariants again
-            'clip': GObject.ParamSpec.double(
-                `clip`,
-                `Clip`,
-                `Clip`,
-                GObject.ParamFlags.READWRITE,
-                0.0, Number.MAX_SAFE_INTEGER,
-                0.0,
-            ),
         }
     }, class CornerEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
+            super();
 
             this._clip_x0 = null;
             this._clip_y0 = null;
             this._clip_width = null;
             this._clip_height = null;
 
-            utils.setup_params(this, params);
-            this.straight_corners = false;
-
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
+            this.straight_corners = false;
 
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
             theme_context.connectObject('notify::scale-factor', _ => this.update_radius(), this);
@@ -113,7 +104,7 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
             if (this._clip_width >= 0 || this._clip_height >= 0)
                 radius = Math.min(radius, this._clip_width / 2, this._clip_height / 2);
 
-            this.set_uniform_value('radius', parseFloat(radius - 1e-6));
+            uniforms.set_uniform(this, 'radius', parseFloat(radius - 1e-6));
         }
 
         get width() {
@@ -121,10 +112,11 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set width(value) {
-            if (this._width !== value) {
-                this._width = value;
+            const v = Math.max(1, value || 1);
+            if (this._width !== v) {
+                this._width = v;
 
-                this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
+                uniforms.set_uniform(this, 'width', parseFloat(this._width + 3.0 - 1e-6));
                 this.update_radius();
             }
         }
@@ -134,10 +126,11 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set height(value) {
-            if (this._height !== value) {
-                this._height = value;
+            const v = Math.max(1, value || 1);
+            if (this._height !== v) {
+                this._height = v;
 
-                this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
+                uniforms.set_uniform(this, 'height', parseFloat(this._height + 3.0 - 1e-6));
                 this.update_radius();
             }
         }
@@ -150,7 +143,7 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
             if (this._corners_top !== value) {
                 this._corners_top = value;
 
-                this.set_uniform_value('corners_top', this._corners_top ? 1 : 0);
+                uniforms.set_uniform(this, 'corners_top', this._corners_top ? 1 : 0);
             }
         }
 
@@ -162,7 +155,7 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
             if (this._corners_bottom !== value) {
                 this._corners_bottom = value;
 
-                this.set_uniform_value('corners_bottom', this._corners_bottom ? 1 : 0);
+                uniforms.set_uniform(this, 'corners_bottom', this._corners_bottom ? 1 : 0);
             }
         }
 
@@ -174,7 +167,7 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
             if (this._straight_corners !== value) {
                 this._straight_corners = value;
 
-                this.set_uniform_value('straight_corners', this._straight_corners ? 1 : 0);
+                uniforms.set_uniform(this, 'straight_corners', this._straight_corners ? 1 : 0);
             }
         }
 
@@ -184,10 +177,10 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
 
         set clip(value) {
             [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height] = value;
-            this.set_uniform_value('clip_x0', parseFloat(this._clip_x0 - 1e-6));
-            this.set_uniform_value('clip_y0', parseFloat(this._clip_y0 - 1e-6));
-            this.set_uniform_value('clip_width', parseFloat(this._clip_width + 3 - 1e-6));
-            this.set_uniform_value('clip_height', parseFloat(this._clip_height + 3 - 1e-6));
+            uniforms.set_uniform(this, 'clip_x0', parseFloat(this._clip_x0 - 1e-6));
+            uniforms.set_uniform(this, 'clip_y0', parseFloat(this._clip_y0 - 1e-6));
+            uniforms.set_uniform(this, 'clip_width', parseFloat(this._clip_width <= 0 ? -1 : this._clip_width + 3 - 1e-6));
+            uniforms.set_uniform(this, 'clip_height', parseFloat(this._clip_height <= 0 ? -1 : this._clip_height + 3 - 1e-6));
             this.update_radius();
         }
 
@@ -220,5 +213,10 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
             }
 
             super.vfunc_set_actor(actor);
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/derivative.glsl
+++ b/src/effects/derivative.glsl
@@ -5,19 +5,19 @@ uniform float height;
 uniform float opacity_factor;
 
 #define CORRECTION 2.25
-#define SIZE_ADDITION 3
+#define SIZE_ADDITION 3.0
 
 vec4 get_texture_at_position(vec2 position) {
     vec2 raw_position = position + vec2(CORRECTION, CORRECTION);
-    vec2 raw_uv = raw_position / vec2(width + SIZE_ADDITION, height + SIZE_ADDITION);
+    vec2 raw_uv = raw_position / vec2(max(1.0, width + SIZE_ADDITION), max(1.0, height + SIZE_ADDITION));
 
     return texture2D(tex, raw_uv);
 }
 
 vec4 try_get_texture_at_position(vec2 position, inout int count) {
     if (any(greaterThanEqual(position, vec2(width, height))) ||
-        any(lessThan(position, vec2(0, 0)))) {
-        return vec4(0);
+        any(lessThan(position, vec2(0.0, 0.0)))) {
+        return vec4(0.0);
     } else {
         count++;
         return get_texture_at_position(position);
@@ -32,44 +32,44 @@ ivec2 get_corrected_position() {
 
 void main() {
     ivec2 corrected_position = get_corrected_position();
-    vec4 source_color = get_texture_at_position(corrected_position);
+    vec4 source_color = get_texture_at_position(vec2(corrected_position));
     vec4 effect_color = source_color;
 
     // 1-step derivative
     if (operation == 0) {
-        vec4 color = vec4(0);
+        vec4 color = vec4(0.0);
         int c = 0;
-        color += try_get_texture_at_position(corrected_position + vec2(0, 1), c);
-        color -= try_get_texture_at_position(corrected_position + vec2(0, 0), c);
-        color += try_get_texture_at_position(corrected_position + vec2(1, 0), c);
-        color -= try_get_texture_at_position(corrected_position + vec2(0, 0), c);
+        color += try_get_texture_at_position(vec2(corrected_position) + vec2(0.0, 1.0), c);
+        color -= try_get_texture_at_position(vec2(corrected_position) + vec2(0.0, 0.0), c);
+        color += try_get_texture_at_position(vec2(corrected_position) + vec2(1.0, 0.0), c);
+        color -= try_get_texture_at_position(vec2(corrected_position) + vec2(0.0, 0.0), c);
         if (c < 4) {
-            color = vec4(0);
+            color = vec4(0.0);
         }
-        effect_color = vec4(color.xyz, 1.);
+        effect_color = vec4(color.xyz, source_color.a);
     } else
     // 2-step derivative
     if (operation == 1) {
-        vec4 color = vec4(0);
+        vec4 color = vec4(0.0);
         int c = 0;
-        color += try_get_texture_at_position(corrected_position + vec2(0, 1), c);
-        color -= try_get_texture_at_position(corrected_position + vec2(0, -1), c);
-        color += try_get_texture_at_position(corrected_position + vec2(1, 0), c);
-        color -= try_get_texture_at_position(corrected_position + vec2(-1, 0), c);
+        color += try_get_texture_at_position(vec2(corrected_position) + vec2(0.0, 1.0), c);
+        color -= try_get_texture_at_position(vec2(corrected_position) + vec2(0.0, -1.0), c);
+        color += try_get_texture_at_position(vec2(corrected_position) + vec2(1.0, 0.0), c);
+        color -= try_get_texture_at_position(vec2(corrected_position) + vec2(-1.0, 0.0), c);
         if (c < 4) {
-            color = vec4(0);
+            color = vec4(0.0);
         }
-        effect_color = vec4(color.xyz / 2, 1.);
+        effect_color = vec4(color.xyz / 2.0, source_color.a);
     } else
     // laplacian
     if (operation == 2) {
-        vec4 color = vec4(0);
-        color = -4 * get_texture_at_position(corrected_position);
-        color += get_texture_at_position(corrected_position + vec2(0, 1));
-        color += get_texture_at_position(corrected_position + vec2(0, -1));
-        color += get_texture_at_position(corrected_position + vec2(1, 0));
-        color += get_texture_at_position(corrected_position + vec2(-1, 0));
-        effect_color = vec4(color.xyz, 1.);
+        vec4 color = vec4(0.0);
+        color = -4.0 * get_texture_at_position(vec2(corrected_position));
+        color += get_texture_at_position(vec2(corrected_position) + vec2(0.0, 1.0));
+        color += get_texture_at_position(vec2(corrected_position) + vec2(0.0, -1.0));
+        color += get_texture_at_position(vec2(corrected_position) + vec2(1.0, 0.0));
+        color += get_texture_at_position(vec2(corrected_position) + vec2(-1.0, 0.0));
+        effect_color = vec4(color.xyz, source_color.a);
     }
 
     cogl_color_out = mix(source_color, effect_color, opacity_factor);

--- a/src/effects/derivative.js
+++ b/src/effects/derivative.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -50,14 +51,14 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class DerivativeEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -72,7 +73,7 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
             if (this._operation !== value) {
                 this._operation = value;
 
-                this.set_uniform_value('operation', this._operation);
+                uniforms.set_uniform(this, 'operation', this._operation);
             }
         }
 
@@ -84,7 +85,7 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
         }
 
@@ -93,10 +94,11 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set width(value) {
-            if (this._width !== value) {
-                this._width = value;
+            const v = Math.max(1, value || 1);
+            if (this._width !== v) {
+                this._width = v;
 
-                this.set_uniform_value('width', parseFloat(this._width - 1e-6));
+                uniforms.set_uniform(this, 'width', parseFloat(this._width - 1e-6));
             }
         }
 
@@ -105,10 +107,11 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set height(value) {
-            if (this._height !== value) {
-                this._height = value;
+            const v = Math.max(1, value || 1);
+            if (this._height !== v) {
+                this._height = v;
 
-                this.set_uniform_value('height', parseFloat(this._height - 1e-6));
+                uniforms.set_uniform(this, 'height', parseFloat(this._height - 1e-6));
             }
         }
 
@@ -132,8 +135,14 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
         }
 
         vfunc_paint_target(paint_node, paint_context) {
-            // force setting nearest-neighbour texture filtering
-            this.get_pipeline().set_layer_filters(0, 9728, 9728);
+            uniforms.upload_uniforms(this);
+
+            const pipeline = this.get_pipeline();
+            if (pipeline) {
+                try {
+                    pipeline.set_layer_filters(0, 9728, 9728);
+                } catch (e) { }
+            }
 
             super.vfunc_paint_target(paint_node, paint_context);
         }

--- a/src/effects/downscale.glsl
+++ b/src/effects/downscale.glsl
@@ -6,11 +6,11 @@ uniform int downsampling_mode;
 uniform float opacity_factor;
 
 #define CORRECTION 2.25
-#define SIZE_ADDITION 3
+#define SIZE_ADDITION 3.0
 
 vec4 get_texture_at_position(vec2 position) {
     vec2 raw_position = position + vec2(CORRECTION, CORRECTION);
-    vec2 raw_uv = raw_position / vec2(width + SIZE_ADDITION, height + SIZE_ADDITION);
+    vec2 raw_uv = raw_position / vec2(max(1.0, width + SIZE_ADDITION), max(1.0, height + SIZE_ADDITION));
 
     return texture2D(tex, raw_uv);
 }
@@ -23,14 +23,12 @@ vec2 get_corrected_position() {
 
 void main() {
     vec4 source_color = texture2D(tex, cogl_tex_coord0_in.st);
-    vec4 effect_color = vec4(0);
+    vec4 effect_color = vec4(0.0);
     ivec2 corrected_position = ivec2(get_corrected_position());
-    vec2 multiplied_position = corrected_position * divider;
+    vec2 multiplied_position = vec2(corrected_position) * float(divider);
 
     if (any(greaterThan(multiplied_position, vec2(width, height)))) {
-        if (opacity_factor >= 1.)
-            discard;
-        cogl_color_out = vec4(0);
+        cogl_color_out = mix(source_color, effect_color, opacity_factor);
         return;
     }
 
@@ -41,15 +39,15 @@ void main() {
         int count = 0;
         for (int i = 0; i < divider; i++) {
             for (int j = 0; j < divider; j++) {
-                vec2 lookup_position = multiplied_position + vec2(i, j);
-                if (all(greaterThanEqual(lookup_position, vec2(0, 0))) &&
+                vec2 lookup_position = multiplied_position + vec2(float(i), float(j));
+                if (all(greaterThanEqual(lookup_position, vec2(0.0, 0.0))) &&
                     all(lessThan(lookup_position, vec2(width, height)))) {
                     color += get_texture_at_position(lookup_position);
                     count += 1;
                 }
             }
         }
-        effect_color = color / count;
+        effect_color = color / max(1.0, float(count));
 
     } else
     // mode 1: triangular downsampling
@@ -60,22 +58,22 @@ void main() {
         int force = 1;
         for (int i = 0; i < divider; i++) {
             for (int j = 0; j < divider; j++) {
-                vec2 lookup_position = multiplied_position + vec2(i, j);
-                if (all(greaterThanEqual(lookup_position, vec2(0, 0))) &&
+                vec2 lookup_position = multiplied_position + vec2(float(i), float(j));
+                if (all(greaterThanEqual(lookup_position, vec2(0.0, 0.0))) &&
                     all(lessThan(lookup_position, vec2(width, height)))) {
-                    force = 1 + divider - int(abs(divider - i - j));
-                    color += get_texture_at_position(lookup_position) * force;
+                    force = 1 + divider - int(abs(float(divider - i - j)));
+                    color += get_texture_at_position(lookup_position) * float(force);
                     count += force;
                 }
             }
         }
-        effect_color = color / count;
+        effect_color = color / max(1.0, float(count));
 
     } else
     // mode 2: Dirac downsampling
     if (downsampling_mode == 2) {
 
-        vec2 lookup_position = min(multiplied_position + vec2(divider, divider) / 2, vec2(width - 1, height - 1));
+        vec2 lookup_position = min(multiplied_position + vec2(float(divider)) * 0.5, vec2(width - 1.0, height - 1.0));
         effect_color = get_texture_at_position(lookup_position);
 
     }

--- a/src/effects/downscale.js
+++ b/src/effects/downscale.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -58,14 +59,14 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class DownscaleEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -77,10 +78,11 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set divider(value) {
-            if (this._divider !== value) {
-                this._divider = value;
+            const v = Math.max(1, value || 1);
+            if (this._divider !== v) {
+                this._divider = v;
 
-                this.set_uniform_value('divider', this._divider);
+                uniforms.set_uniform(this, 'divider', this._divider);
             }
         }
 
@@ -92,7 +94,7 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
             if (this._downsampling_mode !== value) {
                 this._downsampling_mode = value;
 
-                this.set_uniform_value('downsampling_mode', this._downsampling_mode);
+                uniforms.set_uniform(this, 'downsampling_mode', this._downsampling_mode);
             }
         }
 
@@ -104,7 +106,7 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
         }
 
@@ -113,10 +115,11 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set width(value) {
-            if (this._width !== value) {
-                this._width = value;
+            const v = Math.max(1, value || 1);
+            if (this._width !== v) {
+                this._width = v;
 
-                this.set_uniform_value('width', parseFloat(this._width - 1e-6));
+                uniforms.set_uniform(this, 'width', parseFloat(this._width - 1e-6));
             }
         }
 
@@ -125,10 +128,11 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set height(value) {
-            if (this._height !== value) {
-                this._height = value;
+            const v = Math.max(1, value || 1);
+            if (this._height !== v) {
+                this._height = v;
 
-                this.set_uniform_value('height', parseFloat(this._height - 1e-6));
+                uniforms.set_uniform(this, 'height', parseFloat(this._height - 1e-6));
             }
         }
 
@@ -152,8 +156,14 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         vfunc_paint_target(paint_node, paint_context) {
-            // force setting nearest-neighbour texture filtering
-            this.get_pipeline().set_layer_filters(0, 9728, 9728);
+            uniforms.upload_uniforms(this);
+
+            const pipeline = this.get_pipeline();
+            if (pipeline) {
+                try {
+                    pipeline.set_layer_filters(0, 9728, 9728);
+                } catch (e) { }
+            }
 
             super.vfunc_paint_target(paint_node, paint_context);
         }

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -38,12 +38,6 @@ export function get_effects_groups(_ = _ => "") {
                 "rgb_to_hsl",
                 "hsl_to_rgb"
             ]
-        },
-        shape_effects: {
-            name: _("Shape effects"),
-            contains: [
-                "corner"
-            ]
         }
     };
 };

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -38,6 +38,12 @@ export function get_effects_groups(_ = _ => "") {
                 "rgb_to_hsl",
                 "hsl_to_rgb"
             ]
+        },
+        shape_effects: {
+            name: _("Shape effects"),
+            contains: [
+                "corner"
+            ]
         }
     };
 };

--- a/src/effects/gaussian_blur.glsl
+++ b/src/effects/gaussian_blur.glsl
@@ -6,30 +6,35 @@ uniform float width;
 uniform float height;
 
 vec4 getTexture(vec2 uv) {
-    if (uv.x < 3. / width)
-        uv.x = 3. / width;
+    float w = max(1.0, width);
+    float h = max(1.0, height);
 
-    if (uv.y < 3. / height)
-        uv.y = 3. / height;
+    if (uv.x < 3. / w)
+        uv.x = 3. / w;
 
-    if (uv.x > 1. - 3. / width)
-        uv.x = 1. - 3. / width;
+    if (uv.y < 3. / h)
+        uv.y = 3. / h;
 
-    if (uv.y > 1. - 3. / height)
-        uv.y = 1. - 3. / height;
+    if (uv.x > 1. - 3. / w)
+        uv.x = 1. - 3. / w;
+
+    if (uv.y > 1. - 3. / h)
+        uv.y = 1. - 3. / h;
 
     return texture2D(tex, uv);
 }
 
 void main(void) {
     vec2 uv = cogl_tex_coord_in[0].xy;
-    vec2 direction = vec2(dir, (1.0 - dir));
+    vec2 direction = vec2(float(dir), 1.0 - float(dir));
 
+    float w = max(1.0, width);
+    float h = max(1.0, height);
     float pixel_step;
     if (dir == 0)
-        pixel_step = 1.0 / height;
+        pixel_step = 1.0 / h;
     else
-        pixel_step = 1.0 / width;
+        pixel_step = 1.0 / w;
 
     vec3 gauss_coefficient;
     gauss_coefficient.x = 1.0 / (sqrt(2.0 * 3.14159265) * sigma);

--- a/src/effects/gaussian_blur.js
+++ b/src/effects/gaussian_blur.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
@@ -67,19 +68,19 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class GaussianBlurEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
 
+            utils.setup_params(this, params);
+
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
             theme_context.connectObject(
                 'notify::scale-factor', _ =>
-                this.set_uniform_value('sigma',
+                uniforms.set_uniform(this, 'sigma',
                     parseFloat(this.radius * theme_context.scale_factor / 2 - 1e-6)
                 ),
                 this
@@ -101,7 +102,7 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
                 const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
                 // like Clutter, we use the assumption radius = 2*sigma
-                this.set_uniform_value('sigma', parseFloat(this._radius * scale_factor / 2 - 1e-6));
+                uniforms.set_uniform(this, 'sigma', parseFloat(this._radius * scale_factor / 2 - 1e-6));
                 this.set_enabled(this.radius > 0.);
 
                 if (this.chained_effect)
@@ -117,7 +118,7 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
             if (this._brightness !== value) {
                 this._brightness = value;
 
-                this.set_uniform_value('brightness', parseFloat(this._brightness - 1e-6));
+                uniforms.set_uniform(this, 'brightness', parseFloat(this._brightness - 1e-6));
 
                 if (this.chained_effect)
                     this.chained_effect.brightness = value;
@@ -129,13 +130,14 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set width(value) {
-            if (this._width !== value) {
-                this._width = value;
+            const v = Math.max(1, value || 1);
+            if (this._width !== v) {
+                this._width = v;
 
-                this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
+                uniforms.set_uniform(this, 'width', parseFloat(this._width + 3.0 - 1e-6));
 
                 if (this.chained_effect)
-                    this.chained_effect.width = value;
+                    this.chained_effect.width = v;
             }
         }
 
@@ -144,13 +146,14 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set height(value) {
-            if (this._height !== value) {
-                this._height = value;
+            const v = Math.max(1, value || 1);
+            if (this._height !== v) {
+                this._height = v;
 
-                this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
+                uniforms.set_uniform(this, 'height', parseFloat(this._height + 3.0 - 1e-6));
 
                 if (this.chained_effect)
-                    this.chained_effect.height = value;
+                    this.chained_effect.height = v;
             }
         }
 
@@ -159,8 +162,10 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set direction(value) {
-            if (this._direction !== value)
+            if (this._direction !== value) {
                 this._direction = value;
+                uniforms.set_uniform(this, "dir", this._direction);
+            }
         }
 
         get chained_effect() {
@@ -202,12 +207,12 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
                     });
                 if (actor !== null)
                     actor.add_effect(this.chained_effect);
+                uniforms.mark_dirty(this.chained_effect);
             }
         }
 
         vfunc_paint_target(paint_node, paint_context) {
-            this.set_uniform_value("dir", this.direction);
-
+            uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/hsl_to_rgb.js
+++ b/src/effects/hsl_to_rgb.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -26,14 +27,14 @@ export const HslToRgbEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class HslToRgbEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -48,7 +49,12 @@ export const HslToRgbEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/luminosity.glsl
+++ b/src/effects/luminosity.glsl
@@ -34,7 +34,7 @@ void main() {
     pix_hsl.z = clamp(pix_hsl.z * brightness_multiplicator, 0., 1.);
     pix_hsl.z = clamp((pix_hsl.z - contrast_center) * contrast + contrast_center + brightness_shift, 0., 1.);
     pix_hsl.y = clamp(pix_hsl.y * saturation_multiplicator, 0., 1.);
-    vec4 effect_color = vec4(hsl_to_rgb(pix_hsl) * c.a, c.a);
 
+    vec4 effect_color = vec4(hsl_to_rgb(pix_hsl) * c.a, c.a);
     cogl_color_out = mix(c, effect_color, opacity_factor);
 }

--- a/src/effects/luminosity.js
+++ b/src/effects/luminosity.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -66,14 +67,14 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class LuminosityEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -88,7 +89,7 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
             if (this._brightness_shift !== value) {
                 this._brightness_shift = value;
 
-                this.set_uniform_value('brightness_shift', parseFloat(this._brightness_shift - 1e-6));
+                uniforms.set_uniform(this, 'brightness_shift', parseFloat(this._brightness_shift - 1e-6));
             }
         }
 
@@ -104,7 +105,7 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
                 let brightness_mul = 600.;
                 if (value < 1.995)
                     brightness_mul = 3. * (1. / (1. - (value / 2.) ** 2) - 1.);
-                this.set_uniform_value('brightness_multiplicator', parseFloat(brightness_mul - 1e-6));
+                uniforms.set_uniform(this, 'brightness_multiplicator', parseFloat(brightness_mul - 1e-6));
             }
         }
 
@@ -116,7 +117,7 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
             if (this._contrast !== value) {
                 this._contrast = value;
 
-                this.set_uniform_value('contrast', parseFloat(this._contrast - 1e-6));
+                uniforms.set_uniform(this, 'contrast', parseFloat(this._contrast - 1e-6));
             }
         }
 
@@ -128,7 +129,7 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
             if (this._contrast_center !== value) {
                 this._contrast_center = value;
 
-                this.set_uniform_value('contrast_center', parseFloat(this._contrast_center - 1e-6));
+                uniforms.set_uniform(this, 'contrast_center', parseFloat(this._contrast_center - 1e-6));
             }
         }
 
@@ -143,7 +144,7 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
                 let saturation_mul = 600.;
                 if (value < 1.995)
                     saturation_mul = 3. * (1. / (1. - (value / 2.) ** 2) - 1.);
-                this.set_uniform_value('saturation_multiplicator', parseFloat(saturation_mul - 1e-6));
+                uniforms.set_uniform(this, 'saturation_multiplicator', parseFloat(saturation_mul - 1e-6));
             }
         }
 
@@ -155,7 +156,12 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/monte_carlo_blur.glsl
+++ b/src/effects/monte_carlo_blur.glsl
@@ -18,7 +18,7 @@ float rand(inout float r) {
 
 void main() {
     vec2 uv = cogl_tex_coord0_in.st;
-    vec2 p = 16 * radius / vec2(width, height);
+    vec2 p = 16.0 * radius / vec2(width, height);
     float r = srand(uv);
 
     vec2 rv;
@@ -36,17 +36,17 @@ void main() {
         new_uv = uv + rv.x * dir * p;
         if (new_uv.x > 2. / width && new_uv.y > 2. / height && new_uv.x < 1. - 3. / width && new_uv.y < 1. - 3. / height) {
             strength = prefer_closer_pixels ? ((iterations - i) * (iterations - i)) : 1;
-            c += strength * texture2D(tex, new_uv);
+            c += float(strength) * texture2D(tex, new_uv);
             count += strength;
         }
     }
 
     if (count == 0 || use_base_pixel) {
         strength = prefer_closer_pixels ? ((iterations + 1) * (iterations + 1)) : 1;
-        c += strength * texture2D(tex, uv);
+        c += float(strength) * texture2D(tex, uv);
         count += strength;
     }
 
     c.xyz *= brightness;
-    cogl_color_out = c / count;
+    cogl_color_out = c / max(1.0, float(count));
 }

--- a/src/effects/monte_carlo_blur.js
+++ b/src/effects/monte_carlo_blur.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
@@ -75,19 +76,19 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class MonteCarloBlurEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
 
+            utils.setup_params(this, params);
+
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
             theme_context.connectObject(
                 'notify::scale-factor',
-                _ => this.set_uniform_value('radius',
+                _ => uniforms.set_uniform(this, 'radius',
                     parseFloat(this._radius * theme_context.scale_factor - 1e-6)
                 ),
                 this
@@ -108,7 +109,7 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
 
                 const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
-                this.set_uniform_value('radius', parseFloat(this._radius * scale_factor - 1e-6));
+                uniforms.set_uniform(this, 'radius', parseFloat(this._radius * scale_factor - 1e-6));
                 this.set_enabled(this.radius > 0. && this.iterations > 0);
             }
         }
@@ -121,7 +122,7 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
             if (this._iterations !== value) {
                 this._iterations = value;
 
-                this.set_uniform_value('iterations', this._iterations);
+                uniforms.set_uniform(this, 'iterations', this._iterations);
                 this.set_enabled(this.radius > 0. && this.iterations > 0);
             }
         }
@@ -134,7 +135,7 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
             if (this._brightness !== value) {
                 this._brightness = value;
 
-                this.set_uniform_value('brightness', parseFloat(this._brightness - 1e-6));
+                uniforms.set_uniform(this, 'brightness', parseFloat(this._brightness - 1e-6));
             }
         }
 
@@ -143,10 +144,11 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set width(value) {
-            if (this._width !== value) {
-                this._width = value;
+            const v = Math.max(1, value || 1);
+            if (this._width !== v) {
+                this._width = v;
 
-                this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
+                uniforms.set_uniform(this, 'width', parseFloat(this._width + 3.0 - 1e-6));
             }
         }
 
@@ -155,10 +157,11 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set height(value) {
-            if (this._height !== value) {
-                this._height = value;
+            const v = Math.max(1, value || 1);
+            if (this._height !== v) {
+                this._height = v;
 
-                this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
+                uniforms.set_uniform(this, 'height', parseFloat(this._height + 3.0 - 1e-6));
             }
         }
 
@@ -170,7 +173,7 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
             if (this._use_base_pixel !== value) {
                 this._use_base_pixel = value;
 
-                this.set_uniform_value('use_base_pixel', this._use_base_pixel ? 1 : 0);
+                uniforms.set_uniform(this, 'use_base_pixel', this._use_base_pixel ? 1 : 0);
             }
         }
 
@@ -182,7 +185,7 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
             if (this._prefer_closer_pixels !== value) {
                 this._prefer_closer_pixels = value;
 
-                this.set_uniform_value('prefer_closer_pixels', this._prefer_closer_pixels ? 1 : 0);
+                uniforms.set_uniform(this, 'prefer_closer_pixels', this._prefer_closer_pixels ? 1 : 0);
             }
         }
 
@@ -203,5 +206,10 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
                 this._actor_connection_size_id = null;
 
             super.vfunc_set_actor(actor);
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/native_dynamic_gaussian_blur.js
+++ b/src/effects/native_dynamic_gaussian_blur.js
@@ -17,14 +17,22 @@ const DEFAULT_PARAMS = {
 
 
 export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
+    { default_params: DEFAULT_PARAMS, supports_corner_radius: false } :
     new GObject.registerClass({
         GTypeName: "NativeDynamicBlurEffect"
     }, class NativeDynamicBlurEffect extends BlurOrShell.BlurEffect {
         constructor(params) {
-            const { unscaled_radius, brightness, corner_radius, ...parent_params } = params;
+            const normalized_params = { ...params };
+            if (!('unscaled_radius' in normalized_params) && 'radius' in normalized_params)
+                normalized_params.unscaled_radius = normalized_params.radius;
+            delete normalized_params.radius;
+
+            const { unscaled_radius, brightness, corner_radius, ...parent_params } = normalized_params;
+            delete normalized_params.corner_radius;
+            const unscaled_corner_radius = corner_radius ?? 0;
+            normalized_params.unscaled_corner_radius = unscaled_corner_radius;
             if (IS_BLUR_MODULE)
-                super({ ...parent_params, mode: BlurOrShell.BlurMode.BACKGROUND, ...{ 'corner_radius': corner_radius } });
+                super({ ...parent_params, mode: BlurOrShell.BlurMode.BACKGROUND, ...{ 'corner_radius': unscaled_corner_radius } });
             else
                 super({ ...parent_params, mode: BlurOrShell.BlurMode.BACKGROUND });
 
@@ -32,17 +40,22 @@ export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
             this._theme_context.connectObject(
                 'notify::scale-factor',
                 _ => {
-                    this.radius = this.unscaled_radius * this._theme_context.scale_factor;
-                    this.corner_radius = this.unscaled_corner_radius * this._theme_context.scale_factor;
+                    this.radius = Math.max(0, this.unscaled_radius * this._theme_context.scale_factor);
+                    if (IS_BLUR_MODULE)
+                        this.corner_radius = this.unscaled_corner_radius * this._theme_context.scale_factor;
                 },
                 this
             );
 
-            utils.setup_params(this, params);
+            utils.setup_params(this, normalized_params);
         }
 
         static get default_params() {
             return DEFAULT_PARAMS;
+        }
+
+        static get supports_corner_radius() {
+            return IS_BLUR_MODULE;
         }
 
         get unscaled_radius() {
@@ -51,7 +64,7 @@ export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
 
         set unscaled_radius(value) {
             this._unscaled_radius = value;
-            this.radius = value * this._theme_context.scale_factor;
+            this.radius = Math.max(0, value * this._theme_context.scale_factor);
         }
 
         get unscaled_corner_radius() {
@@ -60,6 +73,7 @@ export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
 
         set unscaled_corner_radius(value) {
             this._unscaled_corner_radius = value;
-            this.corner_radius = value * this._theme_context.scale_factor;
+            if (IS_BLUR_MODULE)
+                this.corner_radius = value * this._theme_context.scale_factor;
         }
     });

--- a/src/effects/native_static_gaussian_blur.js
+++ b/src/effects/native_static_gaussian_blur.js
@@ -15,17 +15,22 @@ export const NativeStaticBlurEffect = utils.IS_IN_PREFERENCES ?
         GTypeName: "NativeStaticBlurEffect"
     }, class NativeStaticBlurEffect extends Shell.BlurEffect {
         constructor(params) {
-            const { unscaled_radius, brightness, ...parent_params } = params;
+            const normalized_params = { ...params };
+            if (!('unscaled_radius' in normalized_params) && 'radius' in normalized_params)
+                normalized_params.unscaled_radius = normalized_params.radius;
+            delete normalized_params.radius;
+
+            const { unscaled_radius, brightness, ...parent_params } = normalized_params;
             super({ ...parent_params, mode: Shell.BlurMode.ACTOR });
 
             this._theme_context = St.ThemeContext.get_for_stage(global.stage);
             this._theme_context.connectObject(
                 'notify::scale-factor',
-                _ => this.radius = this.unscaled_radius * this._theme_context.scale_factor,
+                _ => this.radius = Math.max(0.5, this.unscaled_radius * this._theme_context.scale_factor),
                 this
             );
 
-            utils.setup_params(this, params);
+            utils.setup_params(this, normalized_params);
         }
 
         static get default_params() {
@@ -38,6 +43,6 @@ export const NativeStaticBlurEffect = utils.IS_IN_PREFERENCES ?
 
         set unscaled_radius(value) {
             this._unscaled_radius = value;
-            this.radius = value * this._theme_context.scale_factor;
+            this.radius = Math.max(0.5, value * this._theme_context.scale_factor);
         }
     });

--- a/src/effects/noise.glsl
+++ b/src/effects/noise.glsl
@@ -4,7 +4,7 @@ uniform float lightness;
 uniform float opacity_factor;
 
 float PHI = 1.61803398874989484820459;
-float SEED = 24;
+float SEED = 24.0;
 
 float noise_gen(in vec2 xy) {
     float r = fract(tan(distance(xy * PHI, xy) * SEED) * xy.x);
@@ -14,9 +14,9 @@ float noise_gen(in vec2 xy) {
 
 void main() {
     vec4 c = texture2D(tex, cogl_tex_coord_in[0].st);
-    vec3 pix_color = c.xyz;
-    float blend = noise * (1. - noise_gen(gl_FragCoord.xy));
-    vec4 effect_color = vec4(mix(pix_color, lightness * pix_color, blend), 1.);
+    float blend = noise * (1. - noise_gen(gl_FragCoord.xy)) * opacity_factor;
+    vec3 pix_color = c.rgb;
+    vec3 noise_color = vec3(lightness);
 
-    cogl_color_out = mix(c, effect_color, opacity_factor);
+    cogl_color_out = vec4(mix(pix_color, noise_color, blend), c.a);
 }

--- a/src/effects/noise.js
+++ b/src/effects/noise.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -42,14 +43,14 @@ export const NoiseEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class NoiseEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -64,7 +65,7 @@ export const NoiseEffect = utils.IS_IN_PREFERENCES ?
             if (this._noise !== value) {
                 this._noise = value;
 
-                this.set_uniform_value('noise', parseFloat(this._noise - 1e-6));
+                uniforms.set_uniform(this, 'noise', parseFloat(this._noise - 1e-6));
                 this.set_enabled(this.noise > 0. && this.lightness != 1);
             }
         }
@@ -77,7 +78,7 @@ export const NoiseEffect = utils.IS_IN_PREFERENCES ?
             if (this._lightness !== value) {
                 this._lightness = value;
 
-                this.set_uniform_value('lightness', parseFloat(this._lightness - 1e-6));
+                uniforms.set_uniform(this, 'lightness', parseFloat(this._lightness - 1e-6));
                 this.set_enabled(this.noise > 0. && this.lightness != 1);
             }
         }
@@ -90,7 +91,12 @@ export const NoiseEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/pixelize.js
+++ b/src/effects/pixelize.js
@@ -3,9 +3,6 @@ import GObject from 'gi://GObject';
 import * as utils from '../conveniences/utils.js';
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
-import { UpscaleEffect } from './upscale.js';
-import { DownscaleEffect } from './downscale.js';
-
 const DEFAULT_PARAMS = {
     factor: 8, downsampling_mode: 0, opacity_factor: 1
 };
@@ -45,9 +42,6 @@ export const PixelizeEffect = utils.IS_IN_PREFERENCES ?
         constructor(params) {
             super();
 
-            this.upscale_effect = new UpscaleEffect({});
-            this.downscale_effect = new DownscaleEffect({});
-
             utils.setup_params(this, params);
         }
 
@@ -56,21 +50,19 @@ export const PixelizeEffect = utils.IS_IN_PREFERENCES ?
         }
 
         get factor() {
-            // should be the same as `this.downscale_effect.divider`
-            return this.upscale_effect.factor;
+            return this._factor;
         }
 
         set factor(value) {
-            this.upscale_effect.factor = value;
-            this.downscale_effect.divider = value;
+            this._factor = value;
         }
 
         get downsampling_mode() {
-            return this.downscale_effect.downsampling_mode;
+            return this._downsampling_mode;
         }
 
         set downsampling_mode(value) {
-            this.downscale_effect.downsampling_mode = value;
+            this._downsampling_mode = value;
         }
 
         get opacity_factor() {
@@ -78,31 +70,6 @@ export const PixelizeEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set opacity_factor(value) {
-            if (this._opacity_factor !== value) {
-                this._opacity_factor = value;
-                this.upscale_effect.opacity_factor = value;
-                this.downscale_effect.opacity_factor = value;
-            }
-        }
-
-        vfunc_set_actor(actor) {
-            // deattach effects from old actor
-            this.upscale_effect?.actor?.remove_effect(this.upscale_effect);
-            this.downscale_effect?.actor?.remove_effect(this.downscale_effect);
-            // attach effects to new actor
-            if (actor) {
-                if (this.upscale_effect)
-                    actor.add_effect(this.upscale_effect);
-                if (this.downscale_effect)
-                    actor.add_effect(this.downscale_effect);
-            }
-
-            super.vfunc_set_actor(actor);
-        }
-
-        vfunc_set_enabled(is_enabled) {
-            this.upscale_effect?.set_enabled(is_enabled);
-            this.downscale_effect?.set_enabled(is_enabled);
-            super.vfunc_set_enabled(is_enabled);
+            this._opacity_factor = value;
         }
     });

--- a/src/effects/rgb_to_hsl.js
+++ b/src/effects/rgb_to_hsl.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -26,14 +27,14 @@ export const RgbToHslEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class RgbToHslEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -48,7 +49,12 @@ export const RgbToHslEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
         }
     });

--- a/src/effects/upscale.glsl
+++ b/src/effects/upscale.glsl
@@ -5,11 +5,11 @@ uniform float height;
 uniform float opacity_factor;
 
 #define CORRECTION 2.25
-#define SIZE_ADDITION 3
+#define SIZE_ADDITION 3.0
 
 vec4 get_texture_at_position(vec2 position) {
     vec2 raw_position = position + vec2(CORRECTION, CORRECTION);
-    vec2 raw_uv = raw_position / vec2(width + SIZE_ADDITION, height + SIZE_ADDITION);
+    vec2 raw_uv = raw_position / vec2(max(1.0, width + SIZE_ADDITION), max(1.0, height + SIZE_ADDITION));
 
     return texture2D(tex, raw_uv);
 }
@@ -23,34 +23,35 @@ ivec2 get_corrected_position() {
 void main() {
     vec4 source_color = texture2D(tex, cogl_tex_coord0_in.st);
     ivec2 corrected_position = get_corrected_position();
+    int safe_factor = max(1, factor);
 
-    vec2 adjusted_position = corrected_position / factor;
+    vec2 adjusted_position = vec2(corrected_position / safe_factor);
 
     vec4 effect_color = get_texture_at_position(adjusted_position);
     cogl_color_out = mix(source_color, effect_color, opacity_factor);
 
     // round
-    if (distance(corrected_position, (floor(adjusted_position) + 0.5) * factor) < factor / 2.5) {
+    if (distance(vec2(corrected_position), (floor(adjusted_position) + 0.5) * float(safe_factor)) < float(safe_factor) / 2.5) {
         //cogl_color_out = get_texture_at_position(adjusted_position);
     } else {
         //cogl_color_out = vec4(0, 0, 0, 1);
     }
 
     // square
-    if (mod(corrected_position.x, factor) >= 2 && mod(corrected_position.y, factor) >= 2) {
+    if (mod(float(corrected_position.x), float(safe_factor)) >= 2.0 && mod(float(corrected_position.y), float(safe_factor)) >= 2.0) {
         //cogl_color_out = get_texture_at_position(adjusted_position);
     } else {
         //cogl_color_out = vec4(0, 0, 0, 1);
     }
 
     // local mix
-    vec4 color = vec4(0);
+    vec4 color = vec4(0.0);
     int count = 0;
     for (int i = -1; i <= 1; i++) {
         for (int j = -1; j <= 1; j++) {
-            vec2 lookup_position = adjusted_position + vec2(i, j);
-            if (all(greaterThanEqual(lookup_position, vec2(0, 0))) &&
-                all(lessThan(lookup_position, vec2(width, height) / factor))) {
+            vec2 lookup_position = adjusted_position + vec2(float(i), float(j));
+            if (all(greaterThanEqual(lookup_position, vec2(0.0, 0.0))) &&
+                all(lessThan(lookup_position, vec2(width, height) / float(safe_factor)))) {
                 color += get_texture_at_position(lookup_position);
                 count += 1;
             }

--- a/src/effects/upscale.js
+++ b/src/effects/upscale.js
@@ -1,6 +1,7 @@
 import GObject from 'gi://GObject';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
 
@@ -50,14 +51,14 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
         }
     }, class UpscaleEffect extends Clutter.ShaderEffect {
         constructor(params) {
-            super(params);
-
-            utils.setup_params(this, params);
+            super();
 
             // set shader source
             this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
             if (this._source)
                 this.set_shader_source(this._source);
+
+            utils.setup_params(this, params);
         }
 
         static get default_params() {
@@ -69,10 +70,11 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set factor(value) {
-            if (this._factor !== value) {
-                this._factor = value;
+            const v = Math.max(1, value || 1);
+            if (this._factor !== v) {
+                this._factor = v;
 
-                this.set_uniform_value('factor', this._factor);
+                uniforms.set_uniform(this, 'factor', this._factor);
             }
         }
 
@@ -84,7 +86,7 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
             if (this._opacity_factor !== value) {
                 this._opacity_factor = value;
 
-                this.set_uniform_value('opacity_factor', parseFloat(this._opacity_factor));
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
             }
         }
 
@@ -93,10 +95,11 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set width(value) {
-            if (this._width !== value) {
-                this._width = value;
+            const v = Math.max(1, value || 1);
+            if (this._width !== v) {
+                this._width = v;
 
-                this.set_uniform_value('width', parseFloat(this._width - 1e-6));
+                uniforms.set_uniform(this, 'width', parseFloat(this._width - 1e-6));
             }
         }
 
@@ -105,10 +108,11 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         set height(value) {
-            if (this._height !== value) {
-                this._height = value;
+            const v = Math.max(1, value || 1);
+            if (this._height !== v) {
+                this._height = v;
 
-                this.set_uniform_value('height', parseFloat(this._height - 1e-6));
+                uniforms.set_uniform(this, 'height', parseFloat(this._height - 1e-6));
             }
         }
 
@@ -132,8 +136,14 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
         }
 
         vfunc_paint_target(paint_node, paint_context) {
-            // force setting nearest-neighbour texture filtering
-            this.get_pipeline().set_layer_filters(0, 9728, 9728);
+            uniforms.upload_uniforms(this);
+
+            const pipeline = this.get_pipeline();
+            if (pipeline) {
+                try {
+                    pipeline.set_layer_filters(0, 9728, 9728);
+                } catch (e) { }
+            }
 
             super.vfunc_paint_target(paint_node, paint_context);
         }


### PR DESCRIPTION
## Summary

- Adds `shader_uniforms.js` to centralize Clutter effect uniform uploads and avoid GNOME 48+ breakage from direct `set_uniform_value` usage.
- Updates all effect GLSL/JS pairs to use consistent uniform names and deferred upload via `upload_uniforms`.
- Extracted from the shared blur surfaces refactor (`dc49123`) without the larger architectural changes or the experimental Cogl snippet rewrite.