### PR TITLE
fix(panel): remove immediate update_size() to fix "Can't update stage views" spam

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -262,8 +262,7 @@ export const PanelBlur = class PanelBlur {
         };
         this.actors_list.push(actors);
 
-        // update the size of the actor
-        this.update_size(actors);
+        // defer size update to idle to avoid allocation race
         this.queue_update_size(actors);
 
         // connect to the relevant actors geometry changes


### PR DESCRIPTION
### Problem

Blur My Shell floods the journal with `Can't update stage views` warnings at
startup and after Shell restarts.

### Root cause

`src/components/panel.js` calls `this.update_size(actors)` immediately after
inserting a new `Meta.BackgroundGroup` into the panel box — before Clutter runs
an allocation cycle. The deferred `this.queue_update_size(actors)` already
handles this correctly via `GLib.idle_add`. The immediate call is redundant.

### Fix

Remove the immediate `this.update_size(actors)`, keeping only
`this.queue_update_size(actors)`.

### Verification

- GNOME Shell 50.2 + Wayland
- Before: ~50 "Can't update stage views" per startup
- After: 0
- Panel blur visually unchanged

### Related

- #861 fixed the same allocation race for Dash-to-Dock — this applies the
  equivalent fix to the native GNOME panel path