### PR TITLE
Remove corner_radius from DEFAULT_PARAMS

### DIFF
--- a/src/effects/native_dynamic_gaussian_blur.js
+++ b/src/effects/native_dynamic_gaussian_blur.js
@@ -12,7 +12,7 @@ if (BlurOrShell === null) {
 
 
 const DEFAULT_PARAMS = {
-    unscaled_radius: 30, brightness: 0.6, corner_radius: 14
+    unscaled_radius: 30, brightness: 0.6
 };
 
 


### PR DESCRIPTION
Remove `corner_radius` from `DEFAULT_PARAMS` for Dynamic blur to fix a regression from https://github.com/aunetx/blur-my-shell/pull/912 (a very dirty one at that) that made the corner radius use the default param on startup instead of using the one from user option

This value doesn't seem to do anything as everything else use the value from user option anyway.

