### PR TITLE
feat(shaders): GNOME 51 Cogl.Snippet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A GNOME Shell extension that adds a blur look to different parts of the GNOME Sh
     - static blur uses the selected pipeline, like other static blur components
     - you can choose a transparent, light, dark, or automatic background above the blur
     - popup blur has separate corner-radius settings for the different popup surface types
-    - rounded corners for dynamic blur require the GNOME Rounded Blur library from the included guide
+    - rounded corners for dynamic blur currently require the GNOME Rounded Blur compatibility library from the included guide; native Shell support will be used automatically once available
   - lockscreen — to customize the already existing blur
     - uses static blur only
   - [Window List](https://extensions.gnome.org/extension/602/window-list/) extension
@@ -74,7 +74,7 @@ For the difference between static blur and dynamic blur:
   - even though it is static, this method of applying effects is not always so fast: for example, applying non-native gaussian blur, or Monte Carlo blur with a lot of iterations will make GNOME Shell quite slow while using the overview or switching workspace. This is being worked on, but for the moment you can for example limit yourself to 5 to 10 iterations for the Monte Carlo blur (which looks cool anyway!), and use native gaussian blur (which is very slightly less precise, but that really does not change anything in reality)
 - dynamic blur makes the component translucent, and blur directly what is behind it
   - you can only use a gaussian blur for this kind of blurring
-  - by default, it is not possible to add corners, however, you can achieve that with an additional library. Consult this [guide](https://github.com/aunetx/blur-my-shell/blob/master/scripts/GUIDE.md) on how to install library yourself
+  - rounded corners currently require the GNOME Rounded Blur compatibility library; consult this [guide](https://github.com/aunetx/blur-my-shell/blob/master/scripts/GUIDE.md) to install it
   - you can still configure the gaussian blur to make it look as cool as you want
   - this method of blurring is not very efficient: even though it should not slow down your computer to a halt, using static blur is still preferred when possible
   - the gaussian blur effect that is being used has implementation defects, which make if having artifacts in the form of black rectangles when interacting with things that are close to the effect

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
         "47",
         "48",
         "49",
-        "50"
+        "50",
+        "51"
     ],
     "url": "https://github.com/aunetx/blur-my-shell",
     "uuid": "blur-my-shell@aunetx",

--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -504,7 +504,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
             })
         } else {
             if (meta_window.bg_manager?._bms_pipeline?.effect)
-                meta_window.bg_manager._bms_pipeline.effect.corner_radius = use_0_radius ?
+                meta_window.bg_manager._bms_pipeline.effect.unscaled_corner_radius = use_0_radius ?
                     0 : this.settings.applications.CORNER_RADIUS;
         }
     }

--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -1,8 +1,10 @@
 import Meta from 'gi://Meta';
+import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
 
 import { PaintSignals } from '../conveniences/paint_signals.js';
+import * as utils from '../conveniences/utils.js';
 
 import { Pipeline } from '../conveniences/pipeline.js';
 import { DummyPipeline } from '../conveniences/dummy_pipeline.js';
@@ -190,15 +192,16 @@ class DashInfos {
             if (!dash_box)
                 return;
 
-            this.background.x = dash_box.background_x;
-            this.background.y = dash_box.background_y;
+            const inset = utils.static_blur_clip_inset(Clutter);
+            const clip_x = Math.floor(dash_box.clip_x) - inset;
+            const clip_y = Math.floor(dash_box.clip_y) - inset;
+            const clip_w = Math.ceil(this.dash_background.width) + inset * 2;
+            const clip_h = Math.ceil(this.dash_background.height) + inset * 2;
 
-            this.background.set_clip(
-                dash_box.clip_x,
-                dash_box.clip_y,
-                this.dash_background.width,
-                this.dash_background.height
-            );
+            this.background.x = dash_box.background_x + inset;
+            this.background.y = dash_box.background_y + inset;
+
+            this.background.set_clip(clip_x, clip_y, clip_w, clip_h);
         } else {
             this.background.width = this.dash_background.width;
             this.background.height = this.dash_background.height;

--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -1,5 +1,4 @@
 import Meta from 'gi://Meta';
-import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
 
@@ -192,7 +191,7 @@ class DashInfos {
             if (!dash_box)
                 return;
 
-            const inset = utils.static_blur_clip_inset(Clutter);
+            const inset = utils.static_blur_clip_inset();
             const clip_x = Math.floor(dash_box.clip_x) - inset;
             const clip_y = Math.floor(dash_box.clip_y) - inset;
             const clip_w = Math.ceil(this.dash_background.width) + inset * 2;

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -1,9 +1,11 @@
 import St from 'gi://St';
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
+import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { PaintSignals } from '../conveniences/paint_signals.js';
+import * as utils from '../conveniences/utils.js';
 
 import { Pipeline } from '../conveniences/pipeline.js';
 import { DummyPipeline } from '../conveniences/dummy_pipeline.js';
@@ -397,14 +399,20 @@ export const PanelBlur = class PanelBlur {
             let is_bottom_panel = is_horizontal &&
                 distance_to_bottom < distance_to_top;
 
-            background.set_clip(
-                x,
-                is_bottom_panel ? y - 1 : y,
-                geometry_width,
-                is_bottom_panel ? geometry_height + 1 : geometry_height
-            );
-            background.x = g_x - x;
-            background.y = .5 + g_y - y;
+            const inset = utils.static_blur_clip_inset(Clutter);
+            const offset = utils.subpixel_stage_offset(Clutter);
+            const workspace_edge_inset = is_bottom_panel
+                ? Math.max(inset, 1)
+                : inset;
+            const clip_x = Math.floor(x) - inset;
+            const clip_y = Math.floor(y) - workspace_edge_inset;
+            const clip_w = Math.ceil(geometry_width) + inset * 2;
+            const clip_h = Math.ceil(geometry_height) +
+                inset + workspace_edge_inset;
+
+            background.set_clip(clip_x, clip_y, clip_w, clip_h);
+            background.x = g_x - x + inset;
+            background.y = offset + g_y - y + inset;
         } else {
             // updated coordinates for dynamic blur
             if (actors.is_dtp_panel) {

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -1,7 +1,6 @@
 import St from 'gi://St';
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
-import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { PaintSignals } from '../conveniences/paint_signals.js';
@@ -399,8 +398,8 @@ export const PanelBlur = class PanelBlur {
             let is_bottom_panel = is_horizontal &&
                 distance_to_bottom < distance_to_top;
 
-            const inset = utils.static_blur_clip_inset(Clutter);
-            const offset = utils.subpixel_stage_offset(Clutter);
+            const inset = utils.static_blur_clip_inset();
+            const offset = utils.subpixel_stage_offset();
             const workspace_edge_inset = is_bottom_panel
                 ? Math.max(inset, 1)
                 : inset;

--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -315,6 +315,10 @@ export const PopupBlurSurface = class PopupBlurSurface {
         try {
             if (!this.is_owned_actor_destroyed())
                 this.actor?.show?.();
+            if (this.static_blur) {
+                this.static_actor?.refresh_corner();
+                this.static_actor?.blur_actor?.show?.();
+            }
         } catch (e) { }
     }
 
@@ -322,6 +326,8 @@ export const PopupBlurSurface = class PopupBlurSurface {
         try {
             if (!this.is_owned_actor_destroyed())
                 this.actor?.hide?.();
+            if (this.static_blur)
+                this.static_actor?.blur_actor?.hide?.();
         } catch (e) { }
     }
 
@@ -470,7 +476,7 @@ export const PopupBlurSurface = class PopupBlurSurface {
             this.corner_effect = null;
         }
         if (this.static_blur)
-            this.destroy_static_actor();
+            this.destroy_static_actor(actor_already_destroyed);
         else
             this.destroy_dynamic_actor();
     }
@@ -490,8 +496,8 @@ export const PopupBlurSurface = class PopupBlurSurface {
         } catch (e) { }
     }
 
-    destroy_static_actor() {
-        this.static_actor?.destroy();
+    destroy_static_actor(actor_already_destroyed = false) {
+        this.static_actor?.destroy(actor_already_destroyed);
         this.static_actor = null;
         this.actor = null;
         this.blur_actor = null;

--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -107,6 +107,7 @@ export const PopupBlurSurface = class PopupBlurSurface {
             this.effects_manager,
             this.target,
             this.root_actor,
+            this.parent,
             () => this.get_corner_radius()
         );
         if (!this.static_actor.create())
@@ -313,10 +314,6 @@ export const PopupBlurSurface = class PopupBlurSurface {
         try {
             if (!this.is_owned_actor_destroyed())
                 this.actor?.show?.();
-            if (this.static_blur) {
-                this.static_actor?.refresh_corner();
-                this.static_actor?.blur_actor?.show?.();
-            }
         } catch (e) { }
     }
 
@@ -324,8 +321,6 @@ export const PopupBlurSurface = class PopupBlurSurface {
         try {
             if (!this.is_owned_actor_destroyed())
                 this.actor?.hide?.();
-            if (this.static_blur)
-                this.static_actor?.blur_actor?.hide?.();
         } catch (e) { }
     }
 

--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -42,7 +42,6 @@ export const PopupBlurSurface = class PopupBlurSurface {
         this.opacity = null;
         this.static_blur = settings.popup.STATIC_BLUR;
         this.static_actor = null;
-        this.corner_changed_id = 0;
         this.actor_destroyed = false;
         this.blur_actor_destroyed = false;
         this.destroyed = false;
@@ -98,7 +97,6 @@ export const PopupBlurSurface = class PopupBlurSurface {
                 corner_radius_getter: () => this.get_corner_radius(),
             }
         );
-        this.corner_effect = this.create_corner_effect();
         this.actor = this.blur_actor;
         return true;
     }
@@ -389,20 +387,6 @@ export const PopupBlurSurface = class PopupBlurSurface {
         this.static_actor?.update_settings();
     }
 
-    create_corner_effect() {
-        if (this.settings.ROUNDED_BLUR_FOUND || this.get_corner_radius() <= 0)
-            return null;
-        const corner_effect = this.effects_manager.new_corner_effect({
-            radius: this.get_corner_radius(),
-        });
-        this.blur_actor.add_effect(corner_effect);
-        this.corner_changed_id = this.settings.popup.settings.connect(
-            `changed::${this.corner_radius.key}`,
-            () => corner_effect.radius = this.get_corner_radius()
-        );
-        return corner_effect;
-    }
-
     get_corner_radius() {
         return this.settings.popup[this.corner_radius.property] ?? this.settings.popup.CORNER_RADIUS;
     }
@@ -461,20 +445,8 @@ export const PopupBlurSurface = class PopupBlurSurface {
         } catch (e) { }
         if (!actor_already_destroyed)
             this.style.restore_target_style();
-        if (this.corner_changed_id) {
-            try {
-                this.settings.popup.settings.disconnect(this.corner_changed_id);
-            } catch (e) { }
-            this.corner_changed_id = 0;
-        }
         this.fade = null;
         this.signals.disconnect_all();
-        if (this.corner_effect) {
-            try {
-                this.effects_manager.remove(this.corner_effect);
-            } catch (e) { }
-            this.corner_effect = null;
-        }
         if (this.static_blur)
             this.destroy_static_actor(actor_already_destroyed);
         else

--- a/src/components/popup/static_actor.js
+++ b/src/components/popup/static_actor.js
@@ -1,17 +1,17 @@
-import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { Pipeline } from '../../conveniences/pipeline.js';
-import * as utils from '../../conveniences/utils.js';
+import { transform_to_actor_space } from './surface_geometry.js';
 import { PopupBlurStaticCorner } from './static_corner.js';
 
 export const PopupBlurStaticActor = class PopupBlurStaticActor {
-    constructor(settings, effects_manager, target, root_actor, get_corner_radius) {
+    constructor(settings, effects_manager, target, root_actor, parent, get_corner_radius) {
         this.settings = settings;
         this.effects_manager = effects_manager;
         this.target = target;
         this.root_actor = root_actor;
+        this.parent = parent;
         this.get_corner_radius = get_corner_radius;
         this.static_corner = new PopupBlurStaticCorner(effects_manager, get_corner_radius);
         this.background_group = null;
@@ -25,8 +25,6 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         this.y = null;
         this.width = null;
         this.height = null;
-        this._geom_x = null;
-        this._geom_y = null;
         this.background_group_destroyed = false;
         this.blur_actor_destroyed = false;
     }
@@ -91,8 +89,6 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         );
         this.blur_actor_destroyed = false;
         this.connect_destroy(this.blur_actor, () => this.blur_actor_destroyed = true);
-        this.blur_actor.set_position(monitor.x, monitor.y);
-        this.blur_actor.offscreen_redirect = Clutter.OffscreenRedirect.NEVER;
         this.blur_actor.hide();
         this.bg_manager = bg_manager_list[0];
         this.pipeline = pipeline;
@@ -129,32 +125,41 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         if (!monitor)
             return false;
 
-        const x = target_x - monitor.x;
-        const y = target_y - monitor.y;
-        // Don't use panel's 1px clip inset — it overhangs the menu as a top line.
-        const offset = utils.subpixel_stage_offset();
-        const clip_x = Math.floor(x);
-        const clip_y = Math.floor(y);
-        const clip_w = Math.ceil(width);
-        const clip_h = Math.ceil(height);
+        const monitor_geometry = transform_to_actor_space(this.parent, monitor);
+        const target_geometry = transform_to_actor_space(this.parent, {
+            x: target_x,
+            y: target_y,
+            width,
+            height,
+        });
+        if (!monitor_geometry || !target_geometry)
+            return false;
+
+        const clip_x = Math.round(target_geometry.x - monitor_geometry.x);
+        const clip_y = Math.round(target_geometry.y - monitor_geometry.y);
+        const clip_width = Math.ceil(target_geometry.width);
+        const clip_height = Math.ceil(target_geometry.height);
 
         try {
-            if (this._geom_x !== x || this._geom_y !== y || this.width !== width || this.height !== height) {
-                this.blur_actor.set_clip(clip_x, clip_y, clip_w, clip_h);
+            if (this.blur_actor.x !== monitor_geometry.x || this.blur_actor.y !== monitor_geometry.y)
+                this.blur_actor.set_position(monitor_geometry.x, monitor_geometry.y);
+            if (
+                this.blur_actor.width !== monitor_geometry.width
+                || this.blur_actor.height !== monitor_geometry.height
+            )
+                this.blur_actor.set_size(monitor_geometry.width, monitor_geometry.height);
 
-                const background_actor = this.get_background_actor();
-                if (background_actor) {
-                    background_actor.x = x - clip_x;
-                    background_actor.y = offset + y - clip_y;
-                }
-
-                this._geom_x = x;
-                this._geom_y = y;
+            if (
+                this.x !== clip_x
+                || this.y !== clip_y
+                || this.width !== clip_width
+                || this.height !== clip_height
+            ) {
+                this.blur_actor.set_clip(clip_x, clip_y, clip_width, clip_height);
                 this.x = clip_x;
                 this.y = clip_y;
-                this.width = width;
-                this.height = height;
-                this.static_corner.set_tight_bounds(clip_x, clip_y, clip_w, clip_h);
+                this.width = clip_width;
+                this.height = clip_height;
             }
 
             this.blur_actor.show();
@@ -162,7 +167,7 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
             return false;
         }
 
-        return { x: clip_x, y: clip_y, width, height };
+        return { x: clip_x, y: clip_y, width: clip_width, height: clip_height };
     }
 
     has_opacity(opacity) {
@@ -193,9 +198,6 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
 
             if (!this.blur_actor_destroyed)
                 this.blur_actor?.get_children?.().forEach(child => child.opacity = opacity);
-
-            if (opacity > 0)
-                this.static_corner.update();
         } catch (e) { }
     }
 
@@ -257,12 +259,6 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         }
     }
 
-    refresh_corner() {
-        try {
-            this.static_corner.update();
-        } catch (e) { }
-    }
-
     update_settings() {
         try {
             this.static_corner.update();
@@ -272,7 +268,7 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
     update_pipeline() {
         try {
             this.bg_manager?._bms_pipeline.change_pipeline_to(this.settings.popup.PIPELINE);
-            this.static_corner.bind(this.pipeline, this.blur_actor);
+            this.static_corner.update();
         } catch (e) { }
     }
 
@@ -323,7 +319,5 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         this.y = null;
         this.width = null;
         this.height = null;
-        this._geom_x = null;
-        this._geom_y = null;
     }
 };

--- a/src/components/popup/static_actor.js
+++ b/src/components/popup/static_actor.js
@@ -1,7 +1,9 @@
+import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { Pipeline } from '../../conveniences/pipeline.js';
+import * as utils from '../../conveniences/utils.js';
 import { PopupBlurStaticCorner } from './static_corner.js';
 
 export const PopupBlurStaticActor = class PopupBlurStaticActor {
@@ -23,6 +25,8 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         this.y = null;
         this.width = null;
         this.height = null;
+        this._geom_x = null;
+        this._geom_y = null;
         this.background_group_destroyed = false;
         this.blur_actor_destroyed = false;
     }
@@ -88,6 +92,7 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         this.blur_actor_destroyed = false;
         this.connect_destroy(this.blur_actor, () => this.blur_actor_destroyed = true);
         this.blur_actor.set_position(monitor.x, monitor.y);
+        this.blur_actor.offscreen_redirect = Clutter.OffscreenRedirect.NEVER;
         this.blur_actor.hide();
         this.bg_manager = bg_manager_list[0];
         this.pipeline = pipeline;
@@ -124,21 +129,32 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         if (!monitor)
             return false;
 
-        const clip_x = Math.round(target_x - monitor.x);
-        const clip_y = Math.round(target_y - monitor.y);
+        const x = target_x - monitor.x;
+        const y = target_y - monitor.y;
+        // Don't use panel's 1px clip inset — it overhangs the menu as a top line.
+        const offset = utils.subpixel_stage_offset(Clutter);
+        const clip_x = Math.floor(x);
+        const clip_y = Math.floor(y);
+        const clip_w = Math.ceil(width);
+        const clip_h = Math.ceil(height);
 
         try {
-            if (
-                this.x !== clip_x
-                || this.y !== clip_y
-                || this.width !== width
-                || this.height !== height
-            ) {
-                this.blur_actor.set_clip(clip_x, clip_y, width, height);
+            if (this._geom_x !== x || this._geom_y !== y || this.width !== width || this.height !== height) {
+                this.blur_actor.set_clip(clip_x, clip_y, clip_w, clip_h);
+
+                const background_actor = this.get_background_actor();
+                if (background_actor) {
+                    background_actor.x = x - clip_x;
+                    background_actor.y = offset + y - clip_y;
+                }
+
+                this._geom_x = x;
+                this._geom_y = y;
                 this.x = clip_x;
                 this.y = clip_y;
                 this.width = width;
                 this.height = height;
+                this.static_corner.set_tight_bounds(clip_x, clip_y, clip_w, clip_h);
             }
 
             this.blur_actor.show();
@@ -177,6 +193,9 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
 
             if (!this.blur_actor_destroyed)
                 this.blur_actor?.get_children?.().forEach(child => child.opacity = opacity);
+
+            if (opacity > 0)
+                this.static_corner.update();
         } catch (e) { }
     }
 
@@ -238,6 +257,12 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         }
     }
 
+    refresh_corner() {
+        try {
+            this.static_corner.update();
+        } catch (e) { }
+    }
+
     update_settings() {
         try {
             this.static_corner.update();
@@ -247,22 +272,24 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
     update_pipeline() {
         try {
             this.bg_manager?._bms_pipeline.change_pipeline_to(this.settings.popup.PIPELINE);
-            this.static_corner.update();
+            this.static_corner.bind(this.pipeline, this.blur_actor);
         } catch (e) { }
     }
 
-    destroy() {
+    destroy(actor_already_destroyed = false) {
         const background_group = this.background_group;
-        this.destroy_background();
+        this.destroy_background(actor_already_destroyed);
         this.background_group = null;
 
+        // Always destroy our owned overlay — `actor_already_destroyed` is about
+        // the popup target, not this background group.
         try {
             if (!this.background_group_destroyed)
                 background_group?.destroy?.();
         } catch (e) { }
     }
 
-    destroy_background() {
+    destroy_background(actor_already_destroyed = false) {
         const bg_manager = this.bg_manager;
         const background_group = this.background_group;
         this.bg_manager = null;
@@ -275,18 +302,20 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
 
         if (bg_manager) {
             try {
-                bg_manager._bms_pipeline.destroy();
+                bg_manager._bms_pipeline?.destroy();
             } catch (e) { }
 
             try {
+                if (actor_already_destroyed || this.blur_actor_destroyed)
+                    bg_manager.backgroundActor = null;
                 bg_manager.destroy();
             } catch (e) { }
+        } else {
+            try {
+                if (!this.background_group_destroyed)
+                    background_group?.destroy_all_children?.();
+            } catch (e) { }
         }
-
-        try {
-            if (!this.background_group_destroyed)
-                background_group?.destroy_all_children?.();
-        } catch (e) { }
 
         this.monitor_index = null;
         this.background_opacity = null;
@@ -294,5 +323,7 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         this.y = null;
         this.width = null;
         this.height = null;
+        this._geom_x = null;
+        this._geom_y = null;
     }
 };

--- a/src/components/popup/static_actor.js
+++ b/src/components/popup/static_actor.js
@@ -132,7 +132,7 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         const x = target_x - monitor.x;
         const y = target_y - monitor.y;
         // Don't use panel's 1px clip inset — it overhangs the menu as a top line.
-        const offset = utils.subpixel_stage_offset(Clutter);
+        const offset = utils.subpixel_stage_offset();
         const clip_x = Math.floor(x);
         const clip_y = Math.floor(y);
         const clip_w = Math.ceil(width);

--- a/src/components/popup/static_corner.js
+++ b/src/components/popup/static_corner.js
@@ -1,3 +1,5 @@
+import * as uniforms from '../../conveniences/shader_uniforms.js';
+
 export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
     constructor(effects_manager, get_radius) {
         this.effects_manager = effects_manager;
@@ -5,6 +7,7 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         this.pipeline = null;
         this.actor = null;
         this.effect = null;
+        this.tight_bounds = null;
     }
 
     bind(pipeline, actor) {
@@ -20,7 +23,9 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         this.pipeline.apply_effect_overrides('corner');
 
         if (this.pipeline_has_corner_effect()) {
-            this.destroy_effect();
+            this.apply_tight_bounds_to_pipeline_corner();
+            this.destroy_external_effect();
+            this.invalidate_effects();
             return;
         }
 
@@ -28,11 +33,71 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
             this.effect = this.effects_manager.new_corner_effect({
                 radius: this.get_radius(),
             });
-            this.actor.add_effect(this.effect);
+            this.attach_external_effect_as_outermost();
+            this.apply_tight_bounds_to_effect(this.effect);
+            this.invalidate_effects();
             return;
         }
 
         this.effect.radius = this.get_radius();
+        this.apply_tight_bounds_to_effect(this.effect);
+        this.invalidate_effects();
+    }
+
+    set_tight_bounds(x, y, width, height) {
+        this.tight_bounds = { x, y, width, height };
+        this.update();
+    }
+
+    apply_tight_bounds_to_pipeline_corner() {
+        const corner = this.get_pipeline_corner_effect();
+        if (!corner || !this.tight_bounds)
+            return;
+
+        const { x, y, width, height } = this.tight_bounds;
+        corner.lock_actor_clip = true;
+        corner.clip = [
+            Math.floor(x),
+            Math.floor(y),
+            Math.ceil(width),
+            Math.ceil(height),
+        ];
+        corner.radius = this.get_radius();
+    }
+
+    apply_tight_bounds_to_effect(effect) {
+        if (!effect || !this.tight_bounds)
+            return;
+
+        const { x, y, width, height } = this.tight_bounds;
+        effect.lock_actor_clip = true;
+        effect.clip = [
+            Math.floor(x),
+            Math.floor(y),
+            Math.ceil(width),
+            Math.ceil(height),
+        ];
+    }
+
+    // Clutter treats the first-attached effect as outermost, and the blur is
+    // already attached by the time this runs. Re-attach everything so the
+    // corner mask ends up outermost regardless of attach order.
+    attach_external_effect_as_outermost() {
+        const existing_effects = this.pipeline?.effects ?? [];
+
+        existing_effects.forEach(effect => {
+            try {
+                this.actor.remove_effect(effect);
+            } catch (e) { }
+        });
+
+        this.actor.add_effect(this.effect);
+
+        existing_effects.forEach(effect => {
+            try {
+                this.actor.add_effect(effect);
+            } catch (e) { }
+        });
     }
 
     pipeline_has_corner_effect() {
@@ -40,7 +105,23 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         return this.pipeline.effects.some(effect => effect instanceof corner_class);
     }
 
-    destroy_effect() {
+    get_pipeline_corner_effect() {
+        const corner_class = this.effects_manager.SUPPORTED_EFFECTS.corner.class;
+        return this.pipeline.effects.find(effect => effect instanceof corner_class) ?? null;
+    }
+
+    invalidate_effects() {
+        try {
+            this.pipeline?.effects?.forEach(effect => {
+                uniforms.mark_dirty(effect);
+                effect.queue_repaint?.();
+            });
+            this.effect?.queue_repaint?.();
+            this.actor?.queue_redraw?.();
+        } catch (e) { }
+    }
+
+    destroy_external_effect() {
         if (!this.effect)
             return;
 
@@ -49,8 +130,9 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
     }
 
     destroy() {
-        this.destroy_effect();
+        this.destroy_external_effect();
         this.pipeline = null;
         this.actor = null;
+        this.tight_bounds = null;
     }
 };

--- a/src/components/popup/static_corner.js
+++ b/src/components/popup/static_corner.js
@@ -1,5 +1,3 @@
-import * as uniforms from '../../conveniences/shader_uniforms.js';
-
 export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
     constructor(effects_manager, get_radius) {
         this.effects_manager = effects_manager;
@@ -7,7 +5,6 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         this.pipeline = null;
         this.actor = null;
         this.effect = null;
-        this.tight_bounds = null;
     }
 
     bind(pipeline, actor) {
@@ -23,9 +20,7 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         this.pipeline.apply_effect_overrides('corner');
 
         if (this.pipeline_has_corner_effect()) {
-            this.apply_tight_bounds_to_pipeline_corner();
             this.destroy_external_effect();
-            this.invalidate_effects();
             return;
         }
 
@@ -34,54 +29,12 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
                 radius: this.get_radius(),
             });
             this.attach_external_effect_as_outermost();
-            this.apply_tight_bounds_to_effect(this.effect);
-            this.invalidate_effects();
             return;
         }
 
         this.effect.radius = this.get_radius();
-        this.apply_tight_bounds_to_effect(this.effect);
-        this.invalidate_effects();
     }
 
-    set_tight_bounds(x, y, width, height) {
-        this.tight_bounds = { x, y, width, height };
-        this.update();
-    }
-
-    apply_tight_bounds_to_pipeline_corner() {
-        const corner = this.get_pipeline_corner_effect();
-        if (!corner || !this.tight_bounds)
-            return;
-
-        const { x, y, width, height } = this.tight_bounds;
-        corner.lock_actor_clip = true;
-        corner.clip = [
-            Math.floor(x),
-            Math.floor(y),
-            Math.ceil(width),
-            Math.ceil(height),
-        ];
-        corner.radius = this.get_radius();
-    }
-
-    apply_tight_bounds_to_effect(effect) {
-        if (!effect || !this.tight_bounds)
-            return;
-
-        const { x, y, width, height } = this.tight_bounds;
-        effect.lock_actor_clip = true;
-        effect.clip = [
-            Math.floor(x),
-            Math.floor(y),
-            Math.ceil(width),
-            Math.ceil(height),
-        ];
-    }
-
-    // Clutter treats the first-attached effect as outermost, and the blur is
-    // already attached by the time this runs. Re-attach everything so the
-    // corner mask ends up outermost regardless of attach order.
     attach_external_effect_as_outermost() {
         const existing_effects = this.pipeline?.effects ?? [];
 
@@ -105,22 +58,6 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         return this.pipeline.effects.some(effect => effect instanceof corner_class);
     }
 
-    get_pipeline_corner_effect() {
-        const corner_class = this.effects_manager.SUPPORTED_EFFECTS.corner.class;
-        return this.pipeline.effects.find(effect => effect instanceof corner_class) ?? null;
-    }
-
-    invalidate_effects() {
-        try {
-            this.pipeline?.effects?.forEach(effect => {
-                uniforms.mark_dirty(effect);
-                effect.queue_repaint?.();
-            });
-            this.effect?.queue_repaint?.();
-            this.actor?.queue_redraw?.();
-        } catch (e) { }
-    }
-
     destroy_external_effect() {
         if (!this.effect)
             return;
@@ -133,6 +70,5 @@ export const PopupBlurStaticCorner = class PopupBlurStaticCorner {
         this.destroy_external_effect();
         this.pipeline = null;
         this.actor = null;
-        this.tight_bounds = null;
     }
 };

--- a/src/components/popup/surface_geometry.js
+++ b/src/components/popup/surface_geometry.js
@@ -1,5 +1,24 @@
 import St from 'gi://St';
 
+export function transform_to_actor_space(actor, { x, y, width, height }) {
+    try {
+        const [actor_x, actor_y] = actor.get_transformed_position();
+        const [actor_width, actor_height] = actor.get_size();
+        const [transformed_width, transformed_height] = actor.get_transformed_size();
+        const scale_x = actor_width > 0 ? transformed_width / actor_width : 1;
+        const scale_y = actor_height > 0 ? transformed_height / actor_height : 1;
+
+        return {
+            x: (x - actor_x) / scale_x,
+            y: (y - actor_y) / scale_y,
+            width: width / scale_x,
+            height: height / scale_y,
+        };
+    } catch (e) {
+        return null;
+    }
+}
+
 export const PopupBlurSurfaceGeometry = class PopupBlurSurfaceGeometry {
     get(actor, { use_content = true, use_margins = true } = {}) {
         const actor_geometry = this.get_transformed_actor(actor);

--- a/src/components/popup/surface_placement.js
+++ b/src/components/popup/surface_placement.js
@@ -1,6 +1,6 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-import { PopupBlurSurfaceGeometry } from './surface_geometry.js';
+import { PopupBlurSurfaceGeometry, transform_to_actor_space } from './surface_geometry.js';
 
 export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
     constructor(surface) {
@@ -48,12 +48,6 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
 
     get_unclipped_surface_geometry() {
         try {
-            let parent_x = 0;
-            let parent_y = 0;
-
-            if (this.surface.parent.get_transformed_position)
-                [parent_x, parent_y] = this.surface.parent.get_transformed_position();
-
             const geometry_actor = this.surface.get_geometry_actor();
             const geometry = this.geometry.get(geometry_actor, {
                 use_content: this.surface.should_use_content_geometry(),
@@ -63,8 +57,6 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
                 return null;
 
             return this.create_surface_geometry(
-                parent_x,
-                parent_y,
                 geometry.x,
                 geometry.y,
                 geometry.width,
@@ -75,16 +67,25 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
         }
     }
 
-    create_surface_geometry(parent_x, parent_y, target_x, target_y, width, height) {
+    create_surface_geometry(target_x, target_y, width, height) {
+        const local_geometry = transform_to_actor_space(this.surface.parent, {
+            x: target_x,
+            y: target_y,
+            width,
+            height,
+        });
+        if (!local_geometry)
+            return null;
+
         return {
-            parent_x,
-            parent_y,
             target_x,
             target_y,
-            x: Math.round(target_x - parent_x),
-            y: Math.round(target_y - parent_y),
-            width: Math.ceil(width),
-            height: Math.ceil(height),
+            target_width: width,
+            target_height: height,
+            x: Math.round(local_geometry.x),
+            y: Math.round(local_geometry.y),
+            width: Math.ceil(local_geometry.width),
+            height: Math.ceil(local_geometry.height),
         };
     }
 
@@ -92,8 +93,8 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
         let clipped = {
             x: geometry.target_x,
             y: geometry.target_y,
-            width: geometry.width,
-            height: geometry.height,
+            width: geometry.target_width,
+            height: geometry.target_height,
         };
 
         let actor = this.surface.get_geometry_actor();
@@ -113,8 +114,6 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
         }
 
         return this.create_surface_geometry(
-            geometry.parent_x,
-            geometry.parent_y,
             clipped.x,
             clipped.y,
             clipped.width,
@@ -126,8 +125,8 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
         const rect = {
             x: geometry.target_x,
             y: geometry.target_y,
-            width: geometry.width,
-            height: geometry.height,
+            width: geometry.target_width,
+            height: geometry.target_height,
         };
         const cached_monitor = this.get_cached_monitor();
         const match = cached_monitor
@@ -140,8 +139,6 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
         this.monitor_index = match.monitor_index;
 
         const surface_geometry = this.create_surface_geometry(
-            geometry.parent_x,
-            geometry.parent_y,
             match.intersection.x,
             match.intersection.y,
             match.intersection.width,
@@ -239,8 +236,8 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
             this.has_valid_geometry(geometry)
             && (
                 !this.has_cached_surface_geometry()
-                || this.surface_x !== geometry.target_x
-                || this.surface_y !== geometry.target_y
+                || this.surface_x !== geometry.x
+                || this.surface_y !== geometry.y
                 || this.surface_width !== geometry.width
                 || this.surface_height !== geometry.height
             )
@@ -248,8 +245,8 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
     }
 
     store_surface_geometry(geometry) {
-        this.surface_x = geometry.target_x;
-        this.surface_y = geometry.target_y;
+        this.surface_x = geometry.x;
+        this.surface_y = geometry.y;
         this.surface_width = geometry.width;
         this.surface_height = geometry.height;
     }
@@ -271,8 +268,8 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
             if (!this.update_static_geometry(
                 geometry.target_x,
                 geometry.target_y,
-                geometry.width,
-                geometry.height
+                geometry.target_width,
+                geometry.target_height
             ))
                 return false;
         } else {

--- a/src/conveniences/dummy_pipeline.js
+++ b/src/conveniences/dummy_pipeline.js
@@ -46,7 +46,7 @@ export const DummyPipeline = class DummyPipeline {
         this.build_effect({
             unscaled_radius: this.get_unscaled_radius(),
             brightness: this.get_brightness(),
-            corner_radius: this.corner_radius_getter(),
+            unscaled_corner_radius: this.corner_radius_getter(),
         });
 
         this.actor_destroy_id = this.actor.connect(
@@ -96,7 +96,7 @@ export const DummyPipeline = class DummyPipeline {
 
         this.effect.unscaled_radius = this.get_unscaled_radius();
         this.effect.brightness = this.get_brightness();
-        this.effect.corner_radius = this.corner_radius_getter();
+        this.effect.unscaled_corner_radius = this.corner_radius_getter();
     }
 
     get_unscaled_radius() {
@@ -135,7 +135,6 @@ export const DummyPipeline = class DummyPipeline {
 
     /// Note: exposed to public API.
     destroy() {
-        this.remove_effect();
         this.remove_pipeline_from_actor();
     }
 

--- a/src/conveniences/effects_manager.js
+++ b/src/conveniences/effects_manager.js
@@ -19,37 +19,45 @@ export const EffectsManager = class EffectsManager {
                     effect.set({
                         ...this.SUPPORTED_EFFECTS[effect_name].class.default_params, ...params
                     });
-                } else
+                } else {
                     effect = new this.SUPPORTED_EFFECTS[effect_name].class({
                         ...this.SUPPORTED_EFFECTS[effect_name].class.default_params, ...params
                     });
+                    this.connect_to_destroy(effect);
+                }
 
                 this.used.push(effect);
-                this.connect_to_destroy(effect);
                 return effect;
             };
         });
     }
 
     connect_to_destroy(effect) {
-        effect.old_actor = effect.get_actor();
-        if (effect.old_actor)
-            effect.old_actor_id = effect.old_actor.connect('destroy', _ => {
-                this.remove(effect, true);
-            });
+        const update_actor = () => {
+            const actor = effect.get_actor();
+            if (actor === effect._bms_actor)
+                return;
 
-        this.connections.connect(effect, 'notify::actor', _ => {
-            let actor = effect.get_actor();
+            this.disconnect_actor_destroy(effect);
+            effect._bms_actor = actor;
+            if (actor)
+                effect._bms_actor_destroy_id = actor.connect(
+                    'destroy', () => this.remove(effect, true)
+                );
+        };
 
-            if (effect.old_actor && actor != effect.old_actor)
-                effect.old_actor.disconnect(effect.old_actor_id);
+        this.connections.connect(effect, 'notify::actor', update_actor);
+        update_actor();
+    }
 
-            if (actor && actor != effect.old_actor) {
-                effect.old_actor_id = actor.connect('destroy', _ => {
-                    this.remove(effect, true);
-                });
-            }
-        });
+    disconnect_actor_destroy(effect) {
+        if (effect._bms_actor && effect._bms_actor_destroy_id) {
+            try {
+                effect._bms_actor.disconnect(effect._bms_actor_destroy_id);
+            } catch (e) { }
+        }
+        effect._bms_actor = null;
+        effect._bms_actor_destroy_id = null;
     }
 
     // IMPORTANT: do never call this in a mutable `this.used.forEach`
@@ -60,10 +68,7 @@ export const EffectsManager = class EffectsManager {
             } catch (e) {
                 this._warn(`could not remove the effect, continuing: ${e}`);
             }
-        if (effect.old_actor)
-            effect.old_actor.disconnect(effect.old_actor_id);
-        delete effect.old_actor;
-        delete effect.old_actor_id;
+        this.disconnect_actor_destroy(effect);
 
         let index = this.used.indexOf(effect);
         if (index >= 0) {

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -1,8 +1,10 @@
 import St from 'gi://St';
 import Meta from 'gi://Meta';
+import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Background from 'resource:///org/gnome/shell/ui/background.js';
 import * as uniforms from './shader_uniforms.js';
+import * as utils from './utils.js';
 
 /// A `Pipeline` object is a handy way to manage the effects attached to an actor. It only manages
 /// one actor at a time (so blurring multiple widgets will need multiple `Pipeline`), and is
@@ -48,7 +50,7 @@ export const Pipeline = class Pipeline {
         this.actor = new St.Widget({
             name: widget_name,
             x: use_absolute_position ? monitor.x : 0,
-            y: .5 + (use_absolute_position ? monitor.y : 0), // add 1 to correct z-position
+            y: utils.subpixel_stage_offset(Clutter) + (use_absolute_position ? monitor.y : 0),
             z_position: 1, // seems to fix the multi-monitor glitch
             width: monitor.width,
             height: monitor.height

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -1,6 +1,5 @@
 import St from 'gi://St';
 import Meta from 'gi://Meta';
-import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Background from 'resource:///org/gnome/shell/ui/background.js';
 import * as uniforms from './shader_uniforms.js';
@@ -50,7 +49,7 @@ export const Pipeline = class Pipeline {
         this.actor = new St.Widget({
             name: widget_name,
             x: use_absolute_position ? monitor.x : 0,
-            y: utils.subpixel_stage_offset(Clutter) + (use_absolute_position ? monitor.y : 0),
+            y: utils.subpixel_stage_offset() + (use_absolute_position ? monitor.y : 0),
             z_position: 1, // seems to fix the multi-monitor glitch
             width: monitor.width,
             height: monitor.height

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -18,6 +18,8 @@ export async function import_in_shell_only(module) {
     }
 }
 
+const Clutter = await import_in_shell_only('gi://Clutter');
+
 export function is_usable_blur_module(ns) {
     if (!ns)
         return false;
@@ -57,22 +59,18 @@ export const get_shader_source = (Shell, shader_filename, self_uri) => {
     }
 };
 
-export function shader_uses_snippet_api(Clutter) {
+export function shader_uses_snippet_api() {
     // Runtime detection: GNOME 51+ mutter exposes new_with_snippet and drops
     // set_shader_source. GNOME 46–50 only have the legacy shader-source path.
     return typeof Clutter?.ShaderEffect?.new_with_snippet === 'function';
 }
 
-export function subpixel_stage_offset(Clutter) {
-    return shader_uses_snippet_api(Clutter) ? 0 : 0.5;
+export function subpixel_stage_offset() {
+    return shader_uses_snippet_api() ? 0 : 0.5;
 }
 
-export function static_blur_clip_inset(Clutter) {
-    return shader_uses_snippet_api(Clutter) ? 1 : 0;
-}
-
-export function shader_effect_super_args(_source, _Clutter) {
-    return {};
+export function static_blur_clip_inset() {
+    return shader_uses_snippet_api() ? 1 : 0;
 }
 
 const _shader_snippets = new Map();
@@ -94,12 +92,8 @@ export function get_or_create_shader_snippet(key, Cogl, source) {
     return snippet;
 }
 
-export function get_shader_effect_base(Clutter, _Cogl, _gtype, _source) {
-    return Clutter.ShaderEffect;
-}
-
-export function register_shader_effect(meta, effect_class, _Cogl, _source, Clutter) {
-    if (shader_uses_snippet_api(Clutter) && typeof effect_class.prototype.vfunc_get_static_snippet !== 'function')
+export function register_shader_effect(meta, effect_class) {
+    if (shader_uses_snippet_api() && typeof effect_class.prototype.vfunc_get_static_snippet !== 'function')
         console.warn(`[Blur my Shell > effect]       ${meta.GTypeName} is missing its own vfunc_get_static_snippet() override, the shader will never be applied`);
 
     return GObject.registerClass(meta, effect_class);
@@ -208,8 +202,8 @@ export function create_fragment_shader_snippet(Cogl, source) {
     }
 }
 
-export function bind_shader_source(effect, source, Clutter) {
-    if (!source || !effect || effect._bms_shader_bound || shader_uses_snippet_api(Clutter))
+export function bind_shader_source(effect, source) {
+    if (!source || !effect || effect._bms_shader_bound || shader_uses_snippet_api())
         return;
 
     try {
@@ -229,17 +223,17 @@ export function bind_shader_source(effect, source, Clutter) {
     }
 }
 
-export function initialize_shader_effect(effect, source, Clutter) {
+export function initialize_shader_effect(effect, source) {
     if (!source || !effect || effect._bms_shader_bound)
         return;
 
-    if (shader_uses_snippet_api(Clutter)) {
+    if (shader_uses_snippet_api()) {
         bind_shader_texture_unit(effect);
         effect._bms_shader_bound = true;
         return;
     }
 
-    bind_shader_source(effect, source, Clutter);
+    bind_shader_source(effect, source);
 }
 
 function bind_shader_texture_unit(effect) {

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -1,4 +1,5 @@
 import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
 
 export const IS_IN_PREFERENCES = typeof global === 'undefined';
 
@@ -10,9 +11,24 @@ export async function import_in_shell_only(module) {
     if (IS_IN_PREFERENCES)
         return null;
     try {
-        return (await import(module)).default;
+        const imported = await import(module);
+        return imported.default ?? imported;
     } catch (e) {
         return null;
+    }
+}
+
+export function is_usable_blur_module(ns) {
+    if (!ns)
+        return false;
+    try {
+        const { BlurEffect } = ns;
+        if (typeof BlurEffect !== 'function' || !BlurEffect.$gtype)
+            return false;
+        GObject.type_name(BlurEffect.$gtype);
+        return true;
+    } catch (e) {
+        return false;
     }
 }
 
@@ -40,3 +56,167 @@ export const get_shader_source = (Shell, shader_filename, self_uri) => {
         return null;
     }
 };
+
+export function shader_uses_snippet_api(Clutter) {
+    // Runtime detection: GNOME 51+ mutter exposes new_with_snippet and drops
+    // set_shader_source. GNOME 46–50 only have the legacy shader-source path.
+    return typeof Clutter?.ShaderEffect?.new_with_snippet === 'function';
+}
+
+export function subpixel_stage_offset(Clutter) {
+    return shader_uses_snippet_api(Clutter) ? 0 : 0.5;
+}
+
+export function static_blur_clip_inset(Clutter) {
+    return shader_uses_snippet_api(Clutter) ? 1 : 0;
+}
+
+export function shader_effect_super_args(source, Clutter) {
+    if (shader_uses_snippet_api(Clutter) || !source)
+        return {};
+    return { shader: source };
+}
+
+const _shader_snippets = new Map();
+
+function get_or_create_shader_snippet(key, Cogl, source) {
+    if (!_shader_snippets.has(key)) {
+        const snippet = create_fragment_shader_snippet(Cogl, source);
+        if (!snippet)
+            console.warn(`[Blur my Shell > effect]       could not create shader snippet for ${key}`);
+        _shader_snippets.set(key, snippet);
+    }
+    return _shader_snippets.get(key) ?? null;
+}
+
+const _snippet_shader_bases = new Map();
+
+export function get_shader_effect_base(Clutter, Cogl, gtype, source) {
+    if (!shader_uses_snippet_api(Clutter))
+        return Clutter.ShaderEffect;
+
+    if (_snippet_shader_bases.has(gtype))
+        return _snippet_shader_bases.get(gtype);
+
+    const Base = GObject.registerClass({
+        GTypeName: `BmsSnippet${gtype}`,
+    }, class BmsSnippetShaderEffect extends Clutter.ShaderEffect {
+        vfunc_get_static_snippet() {
+            return get_or_create_shader_snippet(gtype, Cogl, source);
+        }
+    });
+
+    _snippet_shader_bases.set(gtype, Base);
+    return Base;
+}
+
+export function register_shader_effect(meta, effect_class, _Cogl, _source, _Clutter) {
+    return GObject.registerClass(meta, effect_class);
+}
+
+function split_fragment_shader(source) {
+    const main_index = source.search(/void\s+main\s*(?:\(\s*(?:void)?\s*\))?\s*\{/);
+    if (main_index < 0)
+        return null;
+
+    const declarations = source.slice(0, main_index).trim();
+    const brace_index = source.indexOf('{', main_index);
+    if (brace_index < 0)
+        return null;
+
+    let depth = 0;
+    for (let i = brace_index; i < source.length; i++) {
+        if (source[i] === '{')
+            depth++;
+        else if (source[i] === '}') {
+            depth--;
+            if (depth === 0) {
+                return {
+                    declarations,
+                    body: source.slice(brace_index + 1, i).trim(),
+                };
+            }
+        }
+    }
+
+    return null;
+}
+
+export function create_fragment_shader_snippet(Cogl, source) {
+    if (!Cogl || !source)
+        return null;
+
+    const parts = split_fragment_shader(source);
+    if (!parts) {
+        console.warn('[Blur my Shell > effect]       could not split shader source');
+        return null;
+    }
+
+    try {
+        const snippet = Cogl.Snippet.new(
+            Cogl.SnippetHook.FRAGMENT,
+            parts.declarations,
+            null
+        );
+        snippet.set_replace(parts.body);
+        return snippet;
+    } catch (e) {
+        console.warn(`[Blur my Shell > effect]       could not create shader snippet: ${e}`);
+        return null;
+    }
+}
+
+export function bind_shader_source(effect, source, Clutter) {
+    if (!source || !effect || effect._bms_shader_bound || shader_uses_snippet_api(Clutter))
+        return;
+
+    try {
+        if (typeof effect.set_shader_source === 'function') {
+            effect.set_shader_source(source);
+            effect._bms_shader_bound = true;
+            return;
+        }
+
+        const set_shader_source = Clutter?.ShaderEffect?.prototype?.set_shader_source;
+        if (typeof set_shader_source === 'function') {
+            set_shader_source.call(effect, source);
+            effect._bms_shader_bound = true;
+        }
+    } catch (e) {
+        console.warn(`[Blur my Shell > effect]       set_shader_source failed: ${e}`);
+    }
+}
+
+export function initialize_shader_effect(effect, source, Clutter) {
+    if (!source || !effect || effect._bms_shader_bound)
+        return;
+
+    if (shader_uses_snippet_api(Clutter)) {
+        bind_shader_texture_unit(effect);
+        effect._bms_shader_bound = true;
+        return;
+    }
+
+    bind_shader_source(effect, source, Clutter);
+}
+
+function bind_shader_texture_unit(effect) {
+    if (effect._bms_tex_uniform_bound)
+        return;
+
+    try {
+        if (typeof effect.set_uniform === 'function') {
+            effect.set_uniform('tex', GObject.TYPE_INT, 1, 0);
+            effect._bms_tex_uniform_bound = true;
+            return;
+        }
+
+        const int_value = new GObject.Value();
+        int_value.init(GObject.TYPE_INT);
+        int_value.set_int(0);
+        effect.set_uniform_value('tex', int_value);
+        effect._bms_tex_uniform_bound = true;
+    } catch (e) {
+        console.warn(`[Blur my Shell > effect]       could not bind tex uniform: ${e}`);
+    }
+}

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -77,38 +77,31 @@ export function shader_effect_super_args(_source, _Clutter) {
 
 const _shader_snippets = new Map();
 
-function get_or_create_shader_snippet(key, Cogl, source) {
-    if (!_shader_snippets.has(key)) {
-        const snippet = create_fragment_shader_snippet(Cogl, source);
-        if (!snippet)
-            console.warn(`[Blur my Shell > effect]       could not create shader snippet for ${key}`);
-        _shader_snippets.set(key, snippet);
+// `get_static_snippet` is an optional vfunc; GJS only wires it up if every
+// leaf effect class declares `vfunc_get_static_snippet()` itself (not
+// inherited). This just gets/builds the cached snippet for that class.
+export function get_or_create_shader_snippet(key, Cogl, source) {
+    if (_shader_snippets.has(key))
+        return _shader_snippets.get(key);
+
+    const snippet = create_fragment_shader_snippet(Cogl, source);
+    if (!snippet) {
+        console.warn(`[Blur my Shell > effect]       could not create shader snippet for ${key}`);
+        return null;
     }
-    return _shader_snippets.get(key) ?? null;
+
+    _shader_snippets.set(key, snippet);
+    return snippet;
 }
 
-const _snippet_shader_bases = new Map();
-
-export function get_shader_effect_base(Clutter, Cogl, gtype, source) {
-    if (!shader_uses_snippet_api(Clutter))
-        return Clutter.ShaderEffect;
-
-    if (_snippet_shader_bases.has(gtype))
-        return _snippet_shader_bases.get(gtype);
-
-    const Base = GObject.registerClass({
-        GTypeName: `BmsSnippet${gtype}`,
-    }, class BmsSnippetShaderEffect extends Clutter.ShaderEffect {
-        vfunc_get_static_snippet() {
-            return get_or_create_shader_snippet(gtype, Cogl, source);
-        }
-    });
-
-    _snippet_shader_bases.set(gtype, Base);
-    return Base;
+export function get_shader_effect_base(Clutter, _Cogl, _gtype, _source) {
+    return Clutter.ShaderEffect;
 }
 
-export function register_shader_effect(meta, effect_class, _Cogl, _source, _Clutter) {
+export function register_shader_effect(meta, effect_class, _Cogl, _source, Clutter) {
+    if (shader_uses_snippet_api(Clutter) && typeof effect_class.prototype.vfunc_get_static_snippet !== 'function')
+        console.warn(`[Blur my Shell > effect]       ${meta.GTypeName} is missing its own vfunc_get_static_snippet() override, the shader will never be applied`);
+
     return GObject.registerClass(meta, effect_class);
 }
 
@@ -140,6 +133,53 @@ function split_fragment_shader(source) {
     return null;
 }
 
+function adapt_glsl_bool_usages(source, bool_names) {
+    let adapted = source;
+
+    for (const name of bool_names) {
+        adapted = adapted.replace(
+            new RegExp(`\\bif\\s*\\(\\s*${name}\\s*\\)`, 'g'),
+            `if (${name} != 0)`
+        );
+        adapted = adapted.replace(
+            new RegExp(`\\b${name}\\s*\\?`, 'g'),
+            `${name} != 0 ?`
+        );
+        adapted = adapted.replace(
+            new RegExp(`\\b${name}\\s*&&`, 'g'),
+            `${name} != 0 &&`
+        );
+        adapted = adapted.replace(
+            new RegExp(`&&\\s*${name}\\b`, 'g'),
+            `&& ${name} != 0`
+        );
+        adapted = adapted.replace(
+            new RegExp(`\\|\\|\\s*${name}\\b`, 'g'),
+            `|| ${name} != 0`
+        );
+        adapted = adapted.replace(
+            new RegExp(`!${name}\\b`, 'g'),
+            `${name} == 0`
+        );
+    }
+
+    return adapted;
+}
+
+function adapt_bool_uniforms_for_snippet(declarations, body) {
+    const bool_names = [...declarations.matchAll(/uniform bool (\w+);/g)].map(match => match[1]);
+    if (!bool_names.length)
+        return { declarations, body };
+
+    const adapted_declarations = adapt_glsl_bool_usages(
+        declarations.replace(/uniform bool (\w+);/g, 'uniform int $1;'),
+        bool_names
+    );
+    const adapted_body = adapt_glsl_bool_usages(body, bool_names);
+
+    return { declarations: adapted_declarations, body: adapted_body };
+}
+
 export function create_fragment_shader_snippet(Cogl, source) {
     if (!Cogl || !source)
         return null;
@@ -151,12 +191,16 @@ export function create_fragment_shader_snippet(Cogl, source) {
     }
 
     try {
+        const { declarations, body } = adapt_bool_uniforms_for_snippet(
+            parts.declarations,
+            parts.body
+        );
         const snippet = Cogl.Snippet.new(
             Cogl.SnippetHook.FRAGMENT,
-            parts.declarations,
+            declarations,
             null
         );
-        snippet.set_replace(parts.body);
+        snippet.set_replace(body);
         return snippet;
     } catch (e) {
         console.warn(`[Blur my Shell > effect]       could not create shader snippet: ${e}`);

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -71,10 +71,8 @@ export function static_blur_clip_inset(Clutter) {
     return shader_uses_snippet_api(Clutter) ? 1 : 0;
 }
 
-export function shader_effect_super_args(source, Clutter) {
-    if (shader_uses_snippet_api(Clutter) || !source)
-        return {};
-    return { shader: source };
+export function shader_effect_super_args(_source, _Clutter) {
+    return {};
 }
 
 const _shader_snippets = new Map();

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -93,7 +93,9 @@ export function get_or_create_shader_snippet(key, Cogl, source) {
 }
 
 export function register_shader_effect(meta, effect_class) {
-    if (shader_uses_snippet_api() && typeof effect_class.prototype.vfunc_get_static_snippet !== 'function')
+    if (!shader_uses_snippet_api())
+        delete effect_class.prototype.vfunc_get_static_snippet;
+    else if (typeof effect_class.prototype.vfunc_get_static_snippet !== 'function')
         console.warn(`[Blur my Shell > effect]       ${meta.GTypeName} is missing its own vfunc_get_static_snippet() override, the shader will never be applied`);
 
     return GObject.registerClass(meta, effect_class);

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -19,6 +19,9 @@ export async function import_in_shell_only(module) {
 }
 
 const Clutter = await import_in_shell_only('gi://Clutter');
+const Cogl = await import_in_shell_only('gi://Cogl');
+const USES_SHADER_SNIPPET_API =
+    typeof Clutter?.ShaderEffect?.new_with_snippet === 'function';
 
 export function is_usable_blur_module(ns) {
     if (!ns)
@@ -59,30 +62,21 @@ export const get_shader_source = (Shell, shader_filename, self_uri) => {
     }
 };
 
-export function shader_uses_snippet_api() {
-    // Runtime detection: GNOME 51+ mutter exposes new_with_snippet and drops
-    // set_shader_source. GNOME 46–50 only have the legacy shader-source path.
-    return typeof Clutter?.ShaderEffect?.new_with_snippet === 'function';
-}
-
 export function subpixel_stage_offset() {
-    return shader_uses_snippet_api() ? 0 : 0.5;
+    return USES_SHADER_SNIPPET_API ? 0 : 0.5;
 }
 
 export function static_blur_clip_inset() {
-    return shader_uses_snippet_api() ? 1 : 0;
+    return USES_SHADER_SNIPPET_API ? 1 : 0;
 }
 
 const _shader_snippets = new Map();
 
-// `get_static_snippet` is an optional vfunc; GJS only wires it up if every
-// leaf effect class declares `vfunc_get_static_snippet()` itself (not
-// inherited). This just gets/builds the cached snippet for that class.
-export function get_or_create_shader_snippet(key, Cogl, source) {
+function get_or_create_shader_snippet(key, source) {
     if (_shader_snippets.has(key))
         return _shader_snippets.get(key);
 
-    const snippet = create_fragment_shader_snippet(Cogl, source);
+    const snippet = create_fragment_shader_snippet(source);
     if (!snippet) {
         console.warn(`[Blur my Shell > effect]       could not create shader snippet for ${key}`);
         return null;
@@ -92,11 +86,14 @@ export function get_or_create_shader_snippet(key, Cogl, source) {
     return snippet;
 }
 
-export function register_shader_effect(meta, effect_class) {
-    if (!shader_uses_snippet_api())
-        delete effect_class.prototype.vfunc_get_static_snippet;
-    else if (typeof effect_class.prototype.vfunc_get_static_snippet !== 'function')
-        console.warn(`[Blur my Shell > effect]       ${meta.GTypeName} is missing its own vfunc_get_static_snippet() override, the shader will never be applied`);
+export function register_shader_effect(meta, effect_class, source) {
+    if (USES_SHADER_SNIPPET_API) {
+        Object.defineProperty(effect_class.prototype, 'vfunc_get_static_snippet', {
+            value() {
+                return get_or_create_shader_snippet(meta.GTypeName, source);
+            },
+        });
+    }
 
     return GObject.registerClass(meta, effect_class);
 }
@@ -129,54 +126,7 @@ function split_fragment_shader(source) {
     return null;
 }
 
-function adapt_glsl_bool_usages(source, bool_names) {
-    let adapted = source;
-
-    for (const name of bool_names) {
-        adapted = adapted.replace(
-            new RegExp(`\\bif\\s*\\(\\s*${name}\\s*\\)`, 'g'),
-            `if (${name} != 0)`
-        );
-        adapted = adapted.replace(
-            new RegExp(`\\b${name}\\s*\\?`, 'g'),
-            `${name} != 0 ?`
-        );
-        adapted = adapted.replace(
-            new RegExp(`\\b${name}\\s*&&`, 'g'),
-            `${name} != 0 &&`
-        );
-        adapted = adapted.replace(
-            new RegExp(`&&\\s*${name}\\b`, 'g'),
-            `&& ${name} != 0`
-        );
-        adapted = adapted.replace(
-            new RegExp(`\\|\\|\\s*${name}\\b`, 'g'),
-            `|| ${name} != 0`
-        );
-        adapted = adapted.replace(
-            new RegExp(`!${name}\\b`, 'g'),
-            `${name} == 0`
-        );
-    }
-
-    return adapted;
-}
-
-function adapt_bool_uniforms_for_snippet(declarations, body) {
-    const bool_names = [...declarations.matchAll(/uniform bool (\w+);/g)].map(match => match[1]);
-    if (!bool_names.length)
-        return { declarations, body };
-
-    const adapted_declarations = adapt_glsl_bool_usages(
-        declarations.replace(/uniform bool (\w+);/g, 'uniform int $1;'),
-        bool_names
-    );
-    const adapted_body = adapt_glsl_bool_usages(body, bool_names);
-
-    return { declarations: adapted_declarations, body: adapted_body };
-}
-
-export function create_fragment_shader_snippet(Cogl, source) {
+function create_fragment_shader_snippet(source) {
     if (!Cogl || !source)
         return null;
 
@@ -187,16 +137,12 @@ export function create_fragment_shader_snippet(Cogl, source) {
     }
 
     try {
-        const { declarations, body } = adapt_bool_uniforms_for_snippet(
-            parts.declarations,
-            parts.body
-        );
         const snippet = Cogl.Snippet.new(
             Cogl.SnippetHook.FRAGMENT,
-            declarations,
+            parts.declarations,
             null
         );
-        snippet.set_replace(body);
+        snippet.set_replace(parts.body);
         return snippet;
     } catch (e) {
         console.warn(`[Blur my Shell > effect]       could not create shader snippet: ${e}`);
@@ -205,7 +151,7 @@ export function create_fragment_shader_snippet(Cogl, source) {
 }
 
 export function bind_shader_source(effect, source) {
-    if (!source || !effect || effect._bms_shader_bound || shader_uses_snippet_api())
+    if (!source || !effect || effect._bms_shader_bound || USES_SHADER_SNIPPET_API)
         return;
 
     try {
@@ -229,7 +175,7 @@ export function initialize_shader_effect(effect, source) {
     if (!source || !effect || effect._bms_shader_bound)
         return;
 
-    if (shader_uses_snippet_api()) {
+    if (USES_SHADER_SNIPPET_API) {
         bind_shader_texture_unit(effect);
         effect._bms_shader_bound = true;
         return;

--- a/src/conveniences/utils.js
+++ b/src/conveniences/utils.js
@@ -70,27 +70,11 @@ export function static_blur_clip_inset() {
     return USES_SHADER_SNIPPET_API ? 1 : 0;
 }
 
-const _shader_snippets = new Map();
-
-function get_or_create_shader_snippet(key, source) {
-    if (_shader_snippets.has(key))
-        return _shader_snippets.get(key);
-
-    const snippet = create_fragment_shader_snippet(source);
-    if (!snippet) {
-        console.warn(`[Blur my Shell > effect]       could not create shader snippet for ${key}`);
-        return null;
-    }
-
-    _shader_snippets.set(key, snippet);
-    return snippet;
-}
-
 export function register_shader_effect(meta, effect_class, source) {
     if (USES_SHADER_SNIPPET_API) {
         Object.defineProperty(effect_class.prototype, 'vfunc_get_static_snippet', {
             value() {
-                return get_or_create_shader_snippet(meta.GTypeName, source);
+                return create_fragment_shader_snippet(source);
             },
         });
     }
@@ -150,57 +134,13 @@ function create_fragment_shader_snippet(source) {
     }
 }
 
-export function bind_shader_source(effect, source) {
-    if (!source || !effect || effect._bms_shader_bound || USES_SHADER_SNIPPET_API)
+export function initialize_shader_effect(effect, source) {
+    if (!source || !effect || USES_SHADER_SNIPPET_API)
         return;
 
     try {
-        if (typeof effect.set_shader_source === 'function') {
-            effect.set_shader_source(source);
-            effect._bms_shader_bound = true;
-            return;
-        }
-
-        const set_shader_source = Clutter?.ShaderEffect?.prototype?.set_shader_source;
-        if (typeof set_shader_source === 'function') {
-            set_shader_source.call(effect, source);
-            effect._bms_shader_bound = true;
-        }
+        effect.set_shader_source(source);
     } catch (e) {
         console.warn(`[Blur my Shell > effect]       set_shader_source failed: ${e}`);
-    }
-}
-
-export function initialize_shader_effect(effect, source) {
-    if (!source || !effect || effect._bms_shader_bound)
-        return;
-
-    if (USES_SHADER_SNIPPET_API) {
-        bind_shader_texture_unit(effect);
-        effect._bms_shader_bound = true;
-        return;
-    }
-
-    bind_shader_source(effect, source);
-}
-
-function bind_shader_texture_unit(effect) {
-    if (effect._bms_tex_uniform_bound)
-        return;
-
-    try {
-        if (typeof effect.set_uniform === 'function') {
-            effect.set_uniform('tex', GObject.TYPE_INT, 1, 0);
-            effect._bms_tex_uniform_bound = true;
-            return;
-        }
-
-        const int_value = new GObject.Value();
-        int_value.init(GObject.TYPE_INT);
-        int_value.set_int(0);
-        effect.set_uniform_value('tex', int_value);
-        effect._bms_tex_uniform_bound = true;
-    } catch (e) {
-        console.warn(`[Blur my Shell > effect]       could not bind tex uniform: ${e}`);
     }
 }

--- a/src/effects/color.js
+++ b/src/effects/color.js
@@ -99,6 +99,11 @@ const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect exte
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("ColorEffect", Cogl, SHADER_SOURCE);
+        }
+
         get red() {
             return this._red;
         }

--- a/src/effects/color.js
+++ b/src/effects/color.js
@@ -5,8 +5,10 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'color.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     color: [0.0, 0.0, 0.0, 0.0],
     blend_mode: 0,
@@ -14,9 +16,7 @@ const DEFAULT_PARAMS = {
 };
 
 
-export const ColorEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const COLOR_EFFECT_META = {
         GTypeName: "ColorEffect",
         Properties: {
             'red': GObject.ParamSpec.double(
@@ -68,12 +68,19 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
                 1.0,
             )
         }
-        // Normal (0), Multiply (1), Screen (2), Overlay (3), Darken (4), Lighten (5), Plus darker (6), Plus lighter (7), Color dodge (8),
-        // Color burn (9), Hard light (10), Soft light (11), Difference (12), Exclusion (13), Hue (14), Saturation (15), Color (16),
-        // Luminosity (17)
-    }, class ColorEffect extends Clutter.ShaderEffect {
+};
+
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "ColorEffect", SHADER_SOURCE);
+
+const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect extends SHADER_BASE {
+
         constructor(params) {
-            super();
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             this._red = null;
             this._green = null;
@@ -81,11 +88,6 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             this._blend = null;
             this._blend_mode = null;
             this._opacity_factor = null;
-
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
 
             // set params; utils.setup_params doesn't work here with color
             this.color = 'color' in params ? params.color : this.constructor.default_params.color;
@@ -194,4 +196,8 @@ export const ColorEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const ColorEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(COLOR_EFFECT_META, ColorEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/color.js
+++ b/src/effects/color.js
@@ -70,16 +70,12 @@ const COLOR_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "ColorEffect", SHADER_SOURCE);
-
-const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect extends SHADER_BASE {
+const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             this._red = null;
@@ -205,4 +201,4 @@ const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect exte
 
 export const ColorEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(COLOR_EFFECT_META, ColorEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(COLOR_EFFECT_META, ColorEffectClass);

--- a/src/effects/color.js
+++ b/src/effects/color.js
@@ -5,7 +5,6 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'color.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -93,11 +92,6 @@ const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect exte
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("ColorEffect", Cogl, SHADER_SOURCE);
         }
 
         get red() {
@@ -201,4 +195,4 @@ const ColorEffectClass = utils.IS_IN_PREFERENCES ? null : class ColorEffect exte
 
 export const ColorEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(COLOR_EFFECT_META, ColorEffectClass);
+    : utils.register_shader_effect(COLOR_EFFECT_META, ColorEffectClass, SHADER_SOURCE);

--- a/src/effects/corner.glsl
+++ b/src/effects/corner.glsl
@@ -5,9 +5,9 @@ uniform sampler2D tex;
 uniform float radius;
 uniform float width;
 uniform float height;
-uniform bool corners_top;
-uniform bool corners_bottom;
-uniform bool straight_corners;
+uniform int corners_top;
+uniform int corners_bottom;
+uniform int straight_corners;
 
 uniform float clip_x0;
 uniform float clip_y0;
@@ -69,11 +69,11 @@ float rounded_rect_coverage(vec2 p, vec4 bounds, float clip_radius) {
     float center_top = bounds.y + clip_radius;
     float center_bottom = bounds.w - clip_radius;
 
-    if (straight_corners)
+    if (straight_corners != 0)
         return 1.0;
-    else if (corners_top && p.y < center_top)
+    else if (corners_top != 0 && p.y < center_top)
         center.y = center_top + 2.;
-    else if (corners_bottom && p.y > center_bottom)
+    else if (corners_bottom != 0 && p.y > center_bottom)
         center.y = center_bottom - 1.;
     else
         return 1.0;

--- a/src/effects/corner.js
+++ b/src/effects/corner.js
@@ -5,8 +5,10 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'corner.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     radius: 12, width: 0, height: 0,
     corners_top: true, corners_bottom: true,
@@ -14,9 +16,7 @@ const DEFAULT_PARAMS = {
 };
 
 
-export const CornerEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const CORNER_EFFECT_META = {
         GTypeName: "CornerEffect",
         Properties: {
             'radius': GObject.ParamSpec.double(
@@ -58,19 +58,24 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
                 true,
             ),
         }
-    }, class CornerEffect extends Clutter.ShaderEffect {
+};
+
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "CornerEffect", SHADER_SOURCE);
+
+const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect extends SHADER_BASE {
+
         constructor(params) {
-            super();
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             this._clip_x0 = null;
             this._clip_y0 = null;
             this._clip_width = null;
             this._clip_height = null;
-
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
 
             utils.setup_params(this, params);
             this.straight_corners = false;
@@ -219,4 +224,8 @@ export const CornerEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const CornerEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(CORNER_EFFECT_META, CornerEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/corner.js
+++ b/src/effects/corner.js
@@ -12,7 +12,11 @@ const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.met
 const DEFAULT_PARAMS = {
     radius: 12, width: 0, height: 0,
     corners_top: true, corners_bottom: true,
-    clip: [0, 0, -1, -1]
+    clip: [0, 0, -1, -1],
+    lock_actor_clip: false,
+    // Reset on reuse: `EffectsManager` pools `CornerEffect` instances, and a
+    // pooled instance could otherwise keep rendering square (see corner.glsl).
+    straight_corners: false,
 };
 
 
@@ -57,6 +61,13 @@ const CORNER_EFFECT_META = {
                 GObject.ParamFlags.READWRITE,
                 true,
             ),
+            'lock-actor-clip': GObject.ParamSpec.boolean(
+                `lock-actor-clip`,
+                `Lock Actor Clip`,
+                `When true, clip bounds are managed manually and are not synced from the actor clip rect`,
+                GObject.ParamFlags.READWRITE,
+                false,
+            ),
         }
 };
 
@@ -71,14 +82,12 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
 
             utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
 
-
             this._clip_x0 = null;
             this._clip_y0 = null;
             this._clip_width = null;
             this._clip_height = null;
 
             utils.setup_params(this, params);
-            this.straight_corners = false;
 
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
             theme_context.connectObject('notify::scale-factor', _ => this.update_radius(), this);
@@ -86,6 +95,11 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
 
         static get default_params() {
             return DEFAULT_PARAMS;
+        }
+
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("CornerEffect", Cogl, SHADER_SOURCE);
         }
 
         get radius() {
@@ -176,6 +190,45 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
             }
         }
 
+        get lock_actor_clip() {
+            return this._lock_actor_clip;
+        }
+
+        set lock_actor_clip(value) {
+            if (this._lock_actor_clip === value)
+                return;
+
+            this._lock_actor_clip = value;
+
+            const actor = this.get_actor();
+            if (!actor)
+                return;
+
+            if (value)
+                this.detach_actor_clip_sync(actor);
+            else
+                this.sync_actor_clip(actor);
+        }
+
+        detach_actor_clip_sync(actor = this.get_actor()) {
+            if (!actor || !this._actor_connection_clip_rect_id)
+                return;
+
+            try {
+                actor.disconnect(this._actor_connection_clip_rect_id);
+            } catch (e) { }
+
+            this._actor_connection_clip_rect_id = null;
+        }
+
+        sync_actor_clip(actor) {
+            this.detach_actor_clip_sync(actor);
+            this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
+            this._actor_connection_clip_rect_id = actor.connect('notify::clip-rect', _ => {
+                this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
+            });
+        }
+
         get clip() {
             return [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
         }
@@ -194,10 +247,7 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
                 let old_actor = this.get_actor();
                 old_actor?.disconnect(this._actor_connection_size_id);
             }
-            if (this._actor_connection_clip_rect_id) {
-                let old_actor = this.get_actor();
-                old_actor?.disconnect(this._actor_connection_clip_rect_id);
-            }
+            this.detach_actor_clip_sync();
 
             if (actor) {
                 this.width = actor.width;
@@ -207,14 +257,11 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
                     this.height = actor.height;
                 });
 
-                this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
-                this._actor_connection_clip_rect_id = actor.connect('notify::clip-rect', _ => {
-                    this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
-                });
+                if (!this._lock_actor_clip)
+                    this.sync_actor_clip(actor);
             }
             else {
                 this._actor_connection_size_id = null;
-                this._actor_connection_clip_rect_id = null;
             }
 
             super.vfunc_set_actor(actor);

--- a/src/effects/corner.js
+++ b/src/effects/corner.js
@@ -71,16 +71,12 @@ const CORNER_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "CornerEffect", SHADER_SOURCE);
-
-const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect extends SHADER_BASE {
+const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
             this._clip_x0 = null;
             this._clip_y0 = null;
@@ -275,4 +271,4 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
 
 export const CornerEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(CORNER_EFFECT_META, CornerEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(CORNER_EFFECT_META, CornerEffectClass);

--- a/src/effects/corner.js
+++ b/src/effects/corner.js
@@ -12,7 +12,6 @@ const DEFAULT_PARAMS = {
     radius: 12, width: 0, height: 0,
     corners_top: true, corners_bottom: true,
     clip: [0, 0, -1, -1],
-    lock_actor_clip: false,
     // Reset on reuse: `EffectsManager` pools `CornerEffect` instances, and a
     // pooled instance could otherwise keep rendering square (see corner.glsl).
     straight_corners: false,
@@ -59,13 +58,6 @@ const CORNER_EFFECT_META = {
                 `Round bottom corners`,
                 GObject.ParamFlags.READWRITE,
                 true,
-            ),
-            'lock-actor-clip': GObject.ParamSpec.boolean(
-                `lock-actor-clip`,
-                `Lock Actor Clip`,
-                `When true, clip bounds are managed manually and are not synced from the actor clip rect`,
-                GObject.ParamFlags.READWRITE,
-                false,
             ),
         }
 };
@@ -180,26 +172,6 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
             }
         }
 
-        get lock_actor_clip() {
-            return this._lock_actor_clip;
-        }
-
-        set lock_actor_clip(value) {
-            if (this._lock_actor_clip === value)
-                return;
-
-            this._lock_actor_clip = value;
-
-            const actor = this.get_actor();
-            if (!actor)
-                return;
-
-            if (value)
-                this.detach_actor_clip_sync(actor);
-            else
-                this.sync_actor_clip(actor);
-        }
-
         detach_actor_clip_sync(actor = this.get_actor()) {
             if (!actor || !this._actor_connection_clip_rect_id)
                 return;
@@ -247,8 +219,7 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
                     this.height = actor.height;
                 });
 
-                if (!this._lock_actor_clip)
-                    this.sync_actor_clip(actor);
+                this.sync_actor_clip(actor);
             }
             else {
                 this._actor_connection_size_id = null;

--- a/src/effects/corner.js
+++ b/src/effects/corner.js
@@ -5,7 +5,6 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'corner.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -91,11 +90,6 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("CornerEffect", Cogl, SHADER_SOURCE);
         }
 
         get radius() {
@@ -271,4 +265,4 @@ const CornerEffectClass = utils.IS_IN_PREFERENCES ? null : class CornerEffect ex
 
 export const CornerEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(CORNER_EFFECT_META, CornerEffectClass);
+    : utils.register_shader_effect(CORNER_EFFECT_META, CornerEffectClass, SHADER_SOURCE);

--- a/src/effects/derivative.js
+++ b/src/effects/derivative.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'derivative.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     operation: 0, opacity_factor: 1, width: 0, height: 0
 };
 
 
-export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const DERIVATIVE_EFFECT_META = {
         GTypeName: "DerivativeEffect",
         Properties: {
             'operation': GObject.ParamSpec.int(
@@ -49,14 +49,19 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
                 0.0,
             )
         }
-    }, class DerivativeEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "DerivativeEffect", SHADER_SOURCE);
+
+const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -146,4 +151,8 @@ export const DerivativeEffect = utils.IS_IN_PREFERENCES ?
 
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const DerivativeEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(DERIVATIVE_EFFECT_META, DerivativeEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/derivative.js
+++ b/src/effects/derivative.js
@@ -51,16 +51,12 @@ const DERIVATIVE_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "DerivativeEffect", SHADER_SOURCE);
-
-const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeEffect extends SHADER_BASE {
+const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -160,4 +156,4 @@ const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeE
 
 export const DerivativeEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(DERIVATIVE_EFFECT_META, DerivativeEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(DERIVATIVE_EFFECT_META, DerivativeEffectClass);

--- a/src/effects/derivative.js
+++ b/src/effects/derivative.js
@@ -70,6 +70,11 @@ const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeE
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("DerivativeEffect", Cogl, SHADER_SOURCE);
+        }
+
         get operation() {
             return this._operation;
         }

--- a/src/effects/derivative.js
+++ b/src/effects/derivative.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'derivative.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -64,11 +63,6 @@ const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeE
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("DerivativeEffect", Cogl, SHADER_SOURCE);
         }
 
         get operation() {
@@ -156,4 +150,4 @@ const DerivativeEffectClass = utils.IS_IN_PREFERENCES ? null : class DerivativeE
 
 export const DerivativeEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(DERIVATIVE_EFFECT_META, DerivativeEffectClass);
+    : utils.register_shader_effect(DERIVATIVE_EFFECT_META, DerivativeEffectClass, SHADER_SOURCE);

--- a/src/effects/downscale.js
+++ b/src/effects/downscale.js
@@ -78,6 +78,11 @@ const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEff
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("DownscaleEffect", Cogl, SHADER_SOURCE);
+        }
+
         get divider() {
             return this._divider;
         }

--- a/src/effects/downscale.js
+++ b/src/effects/downscale.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'downscale.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     divider: 8, downsampling_mode: 0, opacity_factor: 1, width: 0, height: 0
 };
 
 
-export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const DOWNSCALE_EFFECT_META = {
         GTypeName: "DownscaleEffect",
         Properties: {
             'divider': GObject.ParamSpec.int(
@@ -57,14 +57,19 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
                 0.0,
             )
         }
-    }, class DownscaleEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "DownscaleEffect", SHADER_SOURCE);
+
+const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -167,4 +172,8 @@ export const DownscaleEffect = utils.IS_IN_PREFERENCES ?
 
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const DownscaleEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(DOWNSCALE_EFFECT_META, DownscaleEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/downscale.js
+++ b/src/effects/downscale.js
@@ -59,16 +59,12 @@ const DOWNSCALE_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "DownscaleEffect", SHADER_SOURCE);
-
-const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEffect extends SHADER_BASE {
+const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -181,4 +177,4 @@ const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEff
 
 export const DownscaleEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(DOWNSCALE_EFFECT_META, DownscaleEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(DOWNSCALE_EFFECT_META, DownscaleEffectClass);

--- a/src/effects/downscale.js
+++ b/src/effects/downscale.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'downscale.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -72,11 +71,6 @@ const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEff
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("DownscaleEffect", Cogl, SHADER_SOURCE);
         }
 
         get divider() {
@@ -177,4 +171,4 @@ const DownscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class DownscaleEff
 
 export const DownscaleEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(DOWNSCALE_EFFECT_META, DownscaleEffectClass);
+    : utils.register_shader_effect(DOWNSCALE_EFFECT_META, DownscaleEffectClass, SHADER_SOURCE);

--- a/src/effects/gaussian_blur.js
+++ b/src/effects/gaussian_blur.js
@@ -68,16 +68,12 @@ const GAUSSIAN_BLUR_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "GaussianBlurEffect", SHADER_SOURCE);
-
-const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianBlurEffect extends SHADER_BASE {
+const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianBlurEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -229,4 +225,4 @@ const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianB
 
 export const GaussianBlurEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(GAUSSIAN_BLUR_EFFECT_META, GaussianBlurEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(GAUSSIAN_BLUR_EFFECT_META, GaussianBlurEffectClass);

--- a/src/effects/gaussian_blur.js
+++ b/src/effects/gaussian_blur.js
@@ -96,6 +96,11 @@ const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianB
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("GaussianBlurEffect", Cogl, SHADER_SOURCE);
+        }
+
         get radius() {
             return this._radius;
         }

--- a/src/effects/gaussian_blur.js
+++ b/src/effects/gaussian_blur.js
@@ -5,17 +5,17 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'gaussian_blur.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     radius: 30, brightness: .6,
     width: 0, height: 0, direction: 0, chained_effect: null
 };
 
 
-export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const GAUSSIAN_BLUR_EFFECT_META = {
         GTypeName: "GaussianBlurEffect",
         Properties: {
             'radius': GObject.ParamSpec.double(
@@ -66,14 +66,19 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
                 GObject.Object,
             ),
         }
-    }, class GaussianBlurEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "GaussianBlurEffect", SHADER_SOURCE);
+
+const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianBlurEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
 
@@ -215,4 +220,8 @@ export const GaussianBlurEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const GaussianBlurEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(GAUSSIAN_BLUR_EFFECT_META, GaussianBlurEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/gaussian_blur.js
+++ b/src/effects/gaussian_blur.js
@@ -5,7 +5,6 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'gaussian_blur.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -90,11 +89,6 @@ const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianB
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("GaussianBlurEffect", Cogl, SHADER_SOURCE);
         }
 
         get radius() {
@@ -225,4 +219,4 @@ const GaussianBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class GaussianB
 
 export const GaussianBlurEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(GAUSSIAN_BLUR_EFFECT_META, GaussianBlurEffectClass);
+    : utils.register_shader_effect(GAUSSIAN_BLUR_EFFECT_META, GaussianBlurEffectClass, SHADER_SOURCE);

--- a/src/effects/hsl_to_rgb.js
+++ b/src/effects/hsl_to_rgb.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'hsl_to_rgb.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     opacity_factor: 1
 };
 
 
-export const HslToRgbEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const HSL_TO_RGB_EFFECT_META = {
         GTypeName: "HslToRgbEffect",
         Properties: {
             'opacity_factor': GObject.ParamSpec.double(
@@ -25,14 +25,19 @@ export const HslToRgbEffect = utils.IS_IN_PREFERENCES ?
                 1.0,
             ),
         }
-    }, class HslToRgbEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "HslToRgbEffect", SHADER_SOURCE);
+
+const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -57,4 +62,8 @@ export const HslToRgbEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const HslToRgbEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(HSL_TO_RGB_EFFECT_META, HslToRgbEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/hsl_to_rgb.js
+++ b/src/effects/hsl_to_rgb.js
@@ -46,6 +46,11 @@ const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffec
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("HslToRgbEffect", Cogl, SHADER_SOURCE);
+        }
+
         get opacity_factor() {
             return this._opacity_factor;
         }

--- a/src/effects/hsl_to_rgb.js
+++ b/src/effects/hsl_to_rgb.js
@@ -27,16 +27,12 @@ const HSL_TO_RGB_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "HslToRgbEffect", SHADER_SOURCE);
-
-const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffect extends SHADER_BASE {
+const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -71,4 +67,4 @@ const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffec
 
 export const HslToRgbEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(HSL_TO_RGB_EFFECT_META, HslToRgbEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(HSL_TO_RGB_EFFECT_META, HslToRgbEffectClass);

--- a/src/effects/hsl_to_rgb.js
+++ b/src/effects/hsl_to_rgb.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'hsl_to_rgb.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -42,11 +41,6 @@ const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffec
             return DEFAULT_PARAMS;
         }
 
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("HslToRgbEffect", Cogl, SHADER_SOURCE);
-        }
-
         get opacity_factor() {
             return this._opacity_factor;
         }
@@ -67,4 +61,4 @@ const HslToRgbEffectClass = utils.IS_IN_PREFERENCES ? null : class HslToRgbEffec
 
 export const HslToRgbEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(HSL_TO_RGB_EFFECT_META, HslToRgbEffectClass);
+    : utils.register_shader_effect(HSL_TO_RGB_EFFECT_META, HslToRgbEffectClass, SHADER_SOURCE);

--- a/src/effects/luminosity.js
+++ b/src/effects/luminosity.js
@@ -67,16 +67,12 @@ const LUMINOSITY_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "LuminosityEffect", SHADER_SOURCE);
-
-const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityEffect extends SHADER_BASE {
+const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -178,4 +174,4 @@ const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityE
 
 export const LuminosityEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(LUMINOSITY_EFFECT_META, LuminosityEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(LUMINOSITY_EFFECT_META, LuminosityEffectClass);

--- a/src/effects/luminosity.js
+++ b/src/effects/luminosity.js
@@ -86,6 +86,11 @@ const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityE
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("LuminosityEffect", Cogl, SHADER_SOURCE);
+        }
+
         get brightness_shift() {
             return this._brightness;
         }

--- a/src/effects/luminosity.js
+++ b/src/effects/luminosity.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'luminosity.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     brightness_shift: 0., brightness_multiplicator: 1., contrast: 1., contrast_center: 0.5, saturation_multiplicator: 1., opacity_factor: 1.
 };
 
 
-export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const LUMINOSITY_EFFECT_META = {
         GTypeName: "LuminosityEffect",
         Properties: {
             'brightness_shift': GObject.ParamSpec.double(
@@ -65,14 +65,19 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
                 1.0,
             ),
         }
-    }, class LuminosityEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "LuminosityEffect", SHADER_SOURCE);
+
+const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -164,4 +169,8 @@ export const LuminosityEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const LuminosityEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(LUMINOSITY_EFFECT_META, LuminosityEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/luminosity.js
+++ b/src/effects/luminosity.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'luminosity.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -80,11 +79,6 @@ const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityE
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("LuminosityEffect", Cogl, SHADER_SOURCE);
         }
 
         get brightness_shift() {
@@ -174,4 +168,4 @@ const LuminosityEffectClass = utils.IS_IN_PREFERENCES ? null : class LuminosityE
 
 export const LuminosityEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(LUMINOSITY_EFFECT_META, LuminosityEffectClass);
+    : utils.register_shader_effect(LUMINOSITY_EFFECT_META, LuminosityEffectClass, SHADER_SOURCE);

--- a/src/effects/monte_carlo_blur.glsl
+++ b/src/effects/monte_carlo_blur.glsl
@@ -4,8 +4,8 @@ uniform int iterations;
 uniform float brightness;
 uniform float width;
 uniform float height;
-uniform bool use_base_pixel;
-uniform bool prefer_closer_pixels;
+uniform int use_base_pixel;
+uniform int prefer_closer_pixels;
 
 float srand(vec2 a) {
     return sin(dot(a, vec2(1233.224, 1743.335)));
@@ -35,14 +35,14 @@ void main() {
         dir = vec2(cos(rv.y), sin(rv.y));
         new_uv = uv + rv.x * dir * p;
         if (new_uv.x > 2. / width && new_uv.y > 2. / height && new_uv.x < 1. - 3. / width && new_uv.y < 1. - 3. / height) {
-            strength = prefer_closer_pixels ? ((iterations - i) * (iterations - i)) : 1;
+            strength = prefer_closer_pixels != 0 ? ((iterations - i) * (iterations - i)) : 1;
             c += float(strength) * texture2D(tex, new_uv);
             count += strength;
         }
     }
 
-    if (count == 0 || use_base_pixel) {
-        strength = prefer_closer_pixels ? ((iterations + 1) * (iterations + 1)) : 1;
+    if (count == 0 || use_base_pixel != 0) {
+        strength = prefer_closer_pixels != 0 ? ((iterations + 1) * (iterations + 1)) : 1;
         c += float(strength) * texture2D(tex, uv);
         count += strength;
     }

--- a/src/effects/monte_carlo_blur.js
+++ b/src/effects/monte_carlo_blur.js
@@ -76,16 +76,12 @@ const MONTE_CARLO_BLUR_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "MonteCarloBlurEffect", SHADER_SOURCE);
-
-const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCarloBlurEffect extends SHADER_BASE {
+const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCarloBlurEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -226,4 +222,4 @@ const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCa
 
 export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(MONTE_CARLO_BLUR_EFFECT_META, MonteCarloBlurEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(MONTE_CARLO_BLUR_EFFECT_META, MonteCarloBlurEffectClass);

--- a/src/effects/monte_carlo_blur.js
+++ b/src/effects/monte_carlo_blur.js
@@ -5,8 +5,10 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'monte_carlo_blur.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     radius: 2., iterations: 5, brightness: .6,
     width: 0, height: 0, use_base_pixel: true,
@@ -14,9 +16,7 @@ const DEFAULT_PARAMS = {
 };
 
 
-export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const MONTE_CARLO_BLUR_EFFECT_META = {
         GTypeName: "MonteCarloBlurEffect",
         Properties: {
             'radius': GObject.ParamSpec.double(
@@ -74,14 +74,19 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
                 true,
             ),
         }
-    }, class MonteCarloBlurEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "MonteCarloBlurEffect", SHADER_SOURCE);
+
+const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCarloBlurEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
 
@@ -212,4 +217,8 @@ export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(MONTE_CARLO_BLUR_EFFECT_META, MonteCarloBlurEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/monte_carlo_blur.js
+++ b/src/effects/monte_carlo_blur.js
@@ -104,6 +104,11 @@ const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCa
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("MonteCarloBlurEffect", Cogl, SHADER_SOURCE);
+        }
+
         get radius() {
             return this._radius;
         }

--- a/src/effects/monte_carlo_blur.js
+++ b/src/effects/monte_carlo_blur.js
@@ -5,7 +5,6 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'monte_carlo_blur.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -98,11 +97,6 @@ const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCa
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("MonteCarloBlurEffect", Cogl, SHADER_SOURCE);
         }
 
         get radius() {
@@ -222,4 +216,4 @@ const MonteCarloBlurEffectClass = utils.IS_IN_PREFERENCES ? null : class MonteCa
 
 export const MonteCarloBlurEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(MONTE_CARLO_BLUR_EFFECT_META, MonteCarloBlurEffectClass);
+    : utils.register_shader_effect(MONTE_CARLO_BLUR_EFFECT_META, MonteCarloBlurEffectClass, SHADER_SOURCE);

--- a/src/effects/native_dynamic_gaussian_blur.js
+++ b/src/effects/native_dynamic_gaussian_blur.js
@@ -3,12 +3,10 @@ import GObject from 'gi://GObject';
 import * as utils from '../conveniences/utils.js';
 const St = await utils.import_in_shell_only('gi://St');
 
-let BlurOrShell = await utils.import_in_shell_only('gi://Blur');
-let IS_BLUR_MODULE = true;
-if (BlurOrShell === null) {
-    BlurOrShell = await utils.import_in_shell_only('gi://Shell');
-    IS_BLUR_MODULE = false;
-}
+const BlurModule = await utils.import_in_shell_only('gi://Blur');
+const Shell = await utils.import_in_shell_only('gi://Shell');
+const BlurOrShell = utils.is_usable_blur_module(BlurModule) ? BlurModule : Shell;
+const IS_BLUR_MODULE = BlurOrShell === BlurModule;
 
 
 const DEFAULT_PARAMS = {

--- a/src/effects/native_dynamic_gaussian_blur.js
+++ b/src/effects/native_dynamic_gaussian_blur.js
@@ -6,11 +6,16 @@ const St = await utils.import_in_shell_only('gi://St');
 const BlurModule = await utils.import_in_shell_only('gi://Blur');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const BlurOrShell = utils.is_usable_blur_module(BlurModule) ? BlurModule : Shell;
-const IS_BLUR_MODULE = BlurOrShell === BlurModule;
+const SUPPORTS_CORNER_RADIUS = Boolean(
+    BlurOrShell?.BlurEffect?.list_properties?.()
+        .some(property => property.name === 'corner-radius')
+);
 
 
 const DEFAULT_PARAMS = {
-    unscaled_radius: 30, brightness: 0.6
+    unscaled_radius: 30,
+    brightness: 0.6,
+    unscaled_corner_radius: 0,
 };
 
 
@@ -25,21 +30,22 @@ export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
                 normalized_params.unscaled_radius = normalized_params.radius;
             delete normalized_params.radius;
 
-            const { unscaled_radius, brightness, corner_radius, ...parent_params } = normalized_params;
+            if (!('unscaled_corner_radius' in normalized_params) && 'corner_radius' in normalized_params)
+                normalized_params.unscaled_corner_radius = normalized_params.corner_radius;
             delete normalized_params.corner_radius;
-            const unscaled_corner_radius = corner_radius ?? 0;
-            normalized_params.unscaled_corner_radius = unscaled_corner_radius;
-            if (IS_BLUR_MODULE)
-                super({ ...parent_params, mode: BlurOrShell.BlurMode.BACKGROUND, ...{ 'corner_radius': unscaled_corner_radius } });
-            else
-                super({ ...parent_params, mode: BlurOrShell.BlurMode.BACKGROUND });
+
+            const parent_params = { ...normalized_params };
+            delete parent_params.unscaled_radius;
+            delete parent_params.brightness;
+            delete parent_params.unscaled_corner_radius;
+            super({ ...parent_params, mode: BlurOrShell.BlurMode.BACKGROUND });
 
             this._theme_context = St.ThemeContext.get_for_stage(global.stage);
             this._theme_context.connectObject(
                 'notify::scale-factor',
                 _ => {
                     this.radius = Math.max(0, this.unscaled_radius * this._theme_context.scale_factor);
-                    if (IS_BLUR_MODULE)
+                    if (SUPPORTS_CORNER_RADIUS)
                         this.corner_radius = this.unscaled_corner_radius * this._theme_context.scale_factor;
                 },
                 this
@@ -53,7 +59,7 @@ export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
         }
 
         static get supports_corner_radius() {
-            return IS_BLUR_MODULE;
+            return SUPPORTS_CORNER_RADIUS;
         }
 
         get unscaled_radius() {
@@ -71,7 +77,7 @@ export const NativeDynamicBlurEffect = utils.IS_IN_PREFERENCES ?
 
         set unscaled_corner_radius(value) {
             this._unscaled_corner_radius = value;
-            if (IS_BLUR_MODULE)
+            if (SUPPORTS_CORNER_RADIUS)
                 this.corner_radius = value * this._theme_context.scale_factor;
         }
     });

--- a/src/effects/noise.js
+++ b/src/effects/noise.js
@@ -43,16 +43,12 @@ const NOISE_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "NoiseEffect", SHADER_SOURCE);
-
-const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect extends SHADER_BASE {
+const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -113,4 +109,4 @@ const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect exte
 
 export const NoiseEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(NOISE_EFFECT_META, NoiseEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(NOISE_EFFECT_META, NoiseEffectClass);

--- a/src/effects/noise.js
+++ b/src/effects/noise.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'noise.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     noise: 0.4, lightness: 0.4, opacity_factor: 1
 };
 
 
-export const NoiseEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const NOISE_EFFECT_META = {
         GTypeName: "NoiseEffect",
         Properties: {
             'noise': GObject.ParamSpec.double(
@@ -41,14 +41,19 @@ export const NoiseEffect = utils.IS_IN_PREFERENCES ?
                 1.0,
             ),
         }
-    }, class NoiseEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "NoiseEffect", SHADER_SOURCE);
+
+const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -99,4 +104,8 @@ export const NoiseEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const NoiseEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(NOISE_EFFECT_META, NoiseEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/noise.js
+++ b/src/effects/noise.js
@@ -62,6 +62,11 @@ const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect exte
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("NoiseEffect", Cogl, SHADER_SOURCE);
+        }
+
         get noise() {
             return this._noise;
         }

--- a/src/effects/noise.js
+++ b/src/effects/noise.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'noise.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -58,11 +57,6 @@ const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect exte
             return DEFAULT_PARAMS;
         }
 
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("NoiseEffect", Cogl, SHADER_SOURCE);
-        }
-
         get noise() {
             return this._noise;
         }
@@ -109,4 +103,4 @@ const NoiseEffectClass = utils.IS_IN_PREFERENCES ? null : class NoiseEffect exte
 
 export const NoiseEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(NOISE_EFFECT_META, NoiseEffectClass);
+    : utils.register_shader_effect(NOISE_EFFECT_META, NoiseEffectClass, SHADER_SOURCE);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -6,7 +6,6 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'refraction.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -232,11 +231,6 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("RefractionEffect", Cogl, SHADER_SOURCE);
         }
 
         get strength() {
@@ -733,4 +727,4 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
 
 export const RefractionEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(REFRACTION_EFFECT_META, RefractionEffectClass);
+    : utils.register_shader_effect(REFRACTION_EFFECT_META, RefractionEffectClass, SHADER_SOURCE);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -241,6 +241,11 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("RefractionEffect", Cogl, SHADER_SOURCE);
+        }
+
         get strength() {
             return this._strength;
         }

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -6,8 +6,10 @@ import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'refraction.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const CLIP_STABILIZE_EPSILON = 1.0;
 const MAX_BLUR_RADIUS = 48.0;
 
@@ -34,9 +36,7 @@ const DEFAULT_PARAMS = {
     clip: [0, 0, -1, -1]
 };
 
-export const RefractionEffect = utils.IS_IN_PREFERENCES
-    ? { default_params: DEFAULT_PARAMS }
-    : new GObject.registerClass({
+const REFRACTION_EFFECT_META = {
         GTypeName: "RefractionEffect",
         Properties: {
             'strength': GObject.ParamSpec.double(
@@ -199,10 +199,21 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 1.0,
             ),
         }
-    }, class RefractionEffect extends Clutter.ShaderEffect {
+};
+
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "RefractionEffect", SHADER_SOURCE);
+
+const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionEffect extends SHADER_BASE {
+
         constructor(params) {
             const { webcam_gloss, webcam_device, ...parent_params } = params;
-            super(parent_params);
+            super({
+                ...parent_params,
+                ...utils.shader_effect_super_args(SHADER_SOURCE, Clutter),
+            });
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
 
             this._clip_x0 = null;
             this._clip_y0 = null;
@@ -217,10 +228,6 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             this._clip_settle_timeout_id = null;
 
             utils.setup_params(this, params);
-
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
 
             this._theme_context = St.ThemeContext.get_for_stage(global.stage);
             this._theme_context.connectObject(
@@ -724,4 +731,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             if (super.vfunc_dispose)
                 super.vfunc_dispose();
         }
-    });
+};
+
+export const RefractionEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(REFRACTION_EFFECT_META, RefractionEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -201,19 +201,12 @@ const REFRACTION_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "RefractionEffect", SHADER_SOURCE);
-
-const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionEffect extends SHADER_BASE {
+const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
             const { webcam_gloss, webcam_device, ...parent_params } = params;
-            super({
-                ...parent_params,
-                ...utils.shader_effect_super_args(SHADER_SOURCE, Clutter),
-            });
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            super({ ...parent_params });
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
             this._clip_x0 = null;
             this._clip_y0 = null;
@@ -740,4 +733,4 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
 
 export const RefractionEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(REFRACTION_EFFECT_META, RefractionEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(REFRACTION_EFFECT_META, RefractionEffectClass);

--- a/src/effects/rgb_to_hsl.js
+++ b/src/effects/rgb_to_hsl.js
@@ -46,6 +46,11 @@ const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffec
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("RgbToHslEffect", Cogl, SHADER_SOURCE);
+        }
+
         get opacity_factor() {
             return this._opacity_factor;
         }

--- a/src/effects/rgb_to_hsl.js
+++ b/src/effects/rgb_to_hsl.js
@@ -27,16 +27,12 @@ const RGB_TO_HSL_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "RgbToHslEffect", SHADER_SOURCE);
-
-const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffect extends SHADER_BASE {
+const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -71,4 +67,4 @@ const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffec
 
 export const RgbToHslEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(RGB_TO_HSL_EFFECT_META, RgbToHslEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(RGB_TO_HSL_EFFECT_META, RgbToHslEffectClass);

--- a/src/effects/rgb_to_hsl.js
+++ b/src/effects/rgb_to_hsl.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'rgb_to_hsl.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     opacity_factor: 1
 };
 
 
-export const RgbToHslEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const RGB_TO_HSL_EFFECT_META = {
         GTypeName: "RgbToHslEffect",
         Properties: {
             'opacity_factor': GObject.ParamSpec.double(
@@ -25,14 +25,19 @@ export const RgbToHslEffect = utils.IS_IN_PREFERENCES ?
                 1.0,
             ),
         }
-    }, class RgbToHslEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "RgbToHslEffect", SHADER_SOURCE);
+
+const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -57,4 +62,8 @@ export const RgbToHslEffect = utils.IS_IN_PREFERENCES ?
             uniforms.upload_uniforms(this);
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const RgbToHslEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(RGB_TO_HSL_EFFECT_META, RgbToHslEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/rgb_to_hsl.js
+++ b/src/effects/rgb_to_hsl.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'rgb_to_hsl.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -42,11 +41,6 @@ const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffec
             return DEFAULT_PARAMS;
         }
 
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("RgbToHslEffect", Cogl, SHADER_SOURCE);
-        }
-
         get opacity_factor() {
             return this._opacity_factor;
         }
@@ -67,4 +61,4 @@ const RgbToHslEffectClass = utils.IS_IN_PREFERENCES ? null : class RgbToHslEffec
 
 export const RgbToHslEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(RGB_TO_HSL_EFFECT_META, RgbToHslEffectClass);
+    : utils.register_shader_effect(RGB_TO_HSL_EFFECT_META, RgbToHslEffectClass, SHADER_SOURCE);

--- a/src/effects/upscale.js
+++ b/src/effects/upscale.js
@@ -4,16 +4,16 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
+const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'upscale.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
 const DEFAULT_PARAMS = {
     factor: 8, opacity_factor: 1, width: 0, height: 0
 };
 
 
-export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
-    { default_params: DEFAULT_PARAMS } :
-    new GObject.registerClass({
+const UPSCALE_EFFECT_META = {
         GTypeName: "UpscaleEffect",
         Properties: {
             'factor': GObject.ParamSpec.int(
@@ -49,14 +49,19 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
                 0.0,
             )
         }
-    }, class UpscaleEffect extends Clutter.ShaderEffect {
-        constructor(params) {
-            super();
+};
 
-            // set shader source
-            this._source = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
-            if (this._source)
-                this.set_shader_source(this._source);
+const SHADER_BASE = utils.IS_IN_PREFERENCES
+    ? null
+    : utils.get_shader_effect_base(Clutter, Cogl, "UpscaleEffect", SHADER_SOURCE);
+
+const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect extends SHADER_BASE {
+
+        constructor(params) {
+            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+
 
             utils.setup_params(this, params);
         }
@@ -147,4 +152,8 @@ export const UpscaleEffect = utils.IS_IN_PREFERENCES ?
 
             super.vfunc_paint_target(paint_node, paint_context);
         }
-    });
+};
+
+export const UpscaleEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(UPSCALE_EFFECT_META, UpscaleEffectClass, Cogl, SHADER_SOURCE, Clutter);

--- a/src/effects/upscale.js
+++ b/src/effects/upscale.js
@@ -70,6 +70,11 @@ const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect 
             return DEFAULT_PARAMS;
         }
 
+        // Declared here (not inherited) so GJS wires up this optional vfunc.
+        vfunc_get_static_snippet() {
+            return utils.get_or_create_shader_snippet("UpscaleEffect", Cogl, SHADER_SOURCE);
+        }
+
         get factor() {
             return this._factor;
         }

--- a/src/effects/upscale.js
+++ b/src/effects/upscale.js
@@ -51,16 +51,12 @@ const UPSCALE_EFFECT_META = {
         }
 };
 
-const SHADER_BASE = utils.IS_IN_PREFERENCES
-    ? null
-    : utils.get_shader_effect_base(Clutter, Cogl, "UpscaleEffect", SHADER_SOURCE);
-
-const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect extends SHADER_BASE {
+const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            super(utils.shader_effect_super_args(SHADER_SOURCE, Clutter));
+            super();
 
-            utils.initialize_shader_effect(this, SHADER_SOURCE, Clutter);
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
 
 
             utils.setup_params(this, params);
@@ -161,4 +157,4 @@ const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect 
 
 export const UpscaleEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(UPSCALE_EFFECT_META, UpscaleEffectClass, Cogl, SHADER_SOURCE, Clutter);
+    : utils.register_shader_effect(UPSCALE_EFFECT_META, UpscaleEffectClass);

--- a/src/effects/upscale.js
+++ b/src/effects/upscale.js
@@ -4,7 +4,6 @@ import * as utils from '../conveniences/utils.js';
 import * as uniforms from '../conveniences/shader_uniforms.js';
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
-const Cogl = await utils.import_in_shell_only('gi://Cogl');
 
 const SHADER_FILENAME = 'upscale.glsl';
 const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
@@ -64,11 +63,6 @@ const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect 
 
         static get default_params() {
             return DEFAULT_PARAMS;
-        }
-
-        // Declared here (not inherited) so GJS wires up this optional vfunc.
-        vfunc_get_static_snippet() {
-            return utils.get_or_create_shader_snippet("UpscaleEffect", Cogl, SHADER_SOURCE);
         }
 
         get factor() {
@@ -157,4 +151,4 @@ const UpscaleEffectClass = utils.IS_IN_PREFERENCES ? null : class UpscaleEffect 
 
 export const UpscaleEffect = utils.IS_IN_PREFERENCES
     ? { default_params: DEFAULT_PARAMS }
-    : utils.register_shader_effect(UPSCALE_EFFECT_META, UpscaleEffectClass);
+    : utils.register_shader_effect(UPSCALE_EFFECT_META, UpscaleEffectClass, SHADER_SOURCE);

--- a/src/extension.js
+++ b/src/extension.js
@@ -6,7 +6,7 @@ import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { update_from_old_settings } from './conveniences/settings_updater.js';
-import { import_in_shell_only} from './conveniences/utils.js';
+import { import_in_shell_only, is_usable_blur_module } from './conveniences/utils.js';
 import { PipelinesManager } from './conveniences/pipelines_manager.js';
 import { EffectsManager } from './conveniences/effects_manager.js';
 import { Connections } from './conveniences/connections.js';
@@ -255,7 +255,7 @@ export default class BlurMyShell extends Extension {
     /// the preferences and instruct the user to install it to have native rounded
     /// corners in dynamic blur.
     _update_rounded_blur_found() {
-        if (BlurModule === null) {
+        if (!is_usable_blur_module(BlurModule)) {
             this._settings.ROUNDED_BLUR_FOUND = false;
             this._log("using original implementation for the native blur effect")
         } else {

--- a/src/extension.js
+++ b/src/extension.js
@@ -6,7 +6,6 @@ import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { update_from_old_settings } from './conveniences/settings_updater.js';
-import { import_in_shell_only, is_usable_blur_module } from './conveniences/utils.js';
 import { PipelinesManager } from './conveniences/pipelines_manager.js';
 import { EffectsManager } from './conveniences/effects_manager.js';
 import { Connections } from './conveniences/connections.js';
@@ -23,8 +22,7 @@ import { CoverflowAltTabBlur } from './components/coverflow_alt_tab.js';
 import { ApplicationsBlur } from './components/applications.js';
 import { ScreenshotBlur } from './components/screenshot.js';
 import { PopupBlur } from './components/popup.js';
-
-const BlurModule = await import_in_shell_only('gi://Blur');
+import { NativeDynamicBlurEffect } from './effects/native_dynamic_gaussian_blur.js';
 
 
 /// The main extension class, created when the GNOME Shell is loaded.
@@ -85,7 +83,7 @@ export default class BlurMyShell extends Extension {
         if (this._settings.lockscreen.BLUR && !this._lockscreen_blur.enabled)
             this._lockscreen_blur.enable();
 
-        // update whether or not the external rounded corners library was found
+        // update whether or not the active blur effect supports rounded corners
         this._update_rounded_blur_found();
 
         // ensure we take the correct action for the current session mode
@@ -183,6 +181,11 @@ export default class BlurMyShell extends Extension {
         this._screenshot_blur = null;
         this._popup = null;
 
+        this._effects_manager.destroy_all();
+        this._pipelines_manager.destroy();
+        this._effects_manager = null;
+        this._pipelines_manager = null;
+
         // make sure no settings change can re-enable them
         this._settings.disconnect_all_settings();
 
@@ -251,16 +254,14 @@ export default class BlurMyShell extends Extension {
         }
     }
 
-    /// Verify whether or not the gi://Blur library was found, in order to inform
-    /// the preferences and instruct the user to install it to have native rounded
-    /// corners in dynamic blur.
+    /// Verify whether the active native blur effect supports rounded corners.
     _update_rounded_blur_found() {
-        if (!is_usable_blur_module(BlurModule)) {
+        if (!NativeDynamicBlurEffect.supports_corner_radius) {
             this._settings.ROUNDED_BLUR_FOUND = false;
             this._log("using original implementation for the native blur effect")
         } else {
             this._settings.ROUNDED_BLUR_FOUND = true;
-            this._log("using external library for the native blur effect")
+            this._log("using native rounded corners for the blur effect")
         }
     }
 


### PR DESCRIPTION
GNOME 51 removes `CoglProgram`/`CoglShader` and ports `Clutter.ShaderEffect` to `Cogl.Snippet`, dropping `set_shader_source` in favor of `get_static_snippet()`:

- [mutter !5094 — Get rid of CoglProgram/CoglShader](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/5094)
- [gnome-shell !4241 — Use ClutterShaderEffect instead of GLSLEffect](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/4241)

Without this change, the extension fails to load on Shell 51 with `get_static_snippet` errors.

(For clarity: [mutter !5071](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/5071) `ext-background-effect-v1` is a separate compositor protocol for client surfaces and cannot be used here because BMS runs inside Shell and Shell performs special blurring.)

## Summary

- Adds runtime dual-path shader support for GNOME 51 (`Cogl.Snippet` + `vfunc_get_static_snippet`) while preserving the legacy `set_shader_source` path for Shell 46–50
- Centralizes shader registration and only installs the snippet vfunc when the runtime supports it, so GNOME 46–50 never see an unknown virtual function
- Fixes a 1px unblurred seam on static panel blur with snippet offscreen buffers (integer positioning + clip inset on 51 only)
- Cleans up pooled-effect actor lifecycle handling and releases managed effects when the extension is disabled
- Detects native `corner-radius` support from the active blur implementation, including the compatibility typelib and future Shell implementations

## Technical notes

- API detection uses `Clutter.ShaderEffect.new_with_snippet` at runtime, not `metadata.json` or `PACKAGE_VERSION`
- GNOME 50 panel behavior is unchanged (`subpixel_stage_offset = 0.5`, `static_blur_clip_inset = 0`)
- Dash-to-dock keeps its original vertical alignment on 50; only receives clip inset on 51
- Dynamic rounded blur uses the native blur property when available; static rounded blur remains built into BMS
