### PR TITLE
Respect unblur in overview on startup

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -674,8 +674,13 @@ export const PanelBlur = class PanelBlur {
 
     panel_hide_blur_startup(){
         if (this._first_boot) {
-            this.hide();
-            this._first_boot = false
+            if (this.settings.panel.UNBLUR_IN_OVERVIEW) {
+                this.hide();
+                this._first_boot = false
+            }
+            else {
+                this._first_boot = false
+            }
         }
     }
 


### PR DESCRIPTION
Partially fix https://github.com/aunetx/blur-my-shell/issues/921, `panel_hide_blur_startup()` now respect Unblur in overview and fix the issue where the panel blur keep being disable until state change with that option disabled 