### PR TITLE
Fix Liquid Glass fade to black in Popup blur

### DIFF
--- a/src/components/popup/static_actor.js
+++ b/src/components/popup/static_actor.js
@@ -68,6 +68,7 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
                     upscale: () => this.get_texture_effect_overrides(),
                     pixelize: () => this.get_texture_effect_overrides(),
                     derivative: () => this.get_texture_effect_overrides(),
+                    refraction: () => this.get_texture_effect_overrides(),
                     color: params => this.get_color_effect_overrides(params),
                     luminosity: () => this.get_luminosity_effect_overrides(),
                     noise: params => this.get_noise_effect_overrides(params),

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -20,6 +20,7 @@ uniform float clip_x0;
 uniform float clip_y0;
 uniform float clip_width;
 uniform float clip_height;
+uniform float opacity_factor;
 
 const float PI = 3.14159265;
 const float REFRACTIVE_INDEX = 1.52;
@@ -361,9 +362,9 @@ void main() {
     lch.y = max(0.0, lch.y - highlight * 4.0);
 
     vec3 shapedHighlight = lchToSrgb(lch);
-    bgColor.rgb = mix(bgColor.rgb, shapedHighlight, clamp(highlight * 0.48, 0.0, 1.0));
-    bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22);
-    bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
+    bgColor.rgb = mix(bgColor.rgb, shapedHighlight, clamp(highlight * 0.48, 0.0, 1.0) * opacity_factor);
+    bgColor.rgb = mix(bgColor.rgb, vec3(0.92, 0.96, 1.0), tint * 0.22 * opacity_factor);
+    bgColor.rgb *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20 * opacity_factor;
 
-    cogl_color_out = vec4(clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity, edgeOpacity);
+    cogl_color_out = vec4(clamp(bgColor.rgb, 0.0, 1.0) * edgeOpacity, edgeOpacity * opacity_factor);
 }

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -2,6 +2,7 @@ import GObject from 'gi://GObject';
 import GLib from 'gi://GLib';
 
 import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
 const St = await utils.import_in_shell_only('gi://St');
 const Shell = await utils.import_in_shell_only('gi://Shell');
 const Clutter = await utils.import_in_shell_only('gi://Clutter');
@@ -29,6 +30,7 @@ const DEFAULT_PARAMS = {
     chained_effect: null,
     width: 0,
     height: 0,
+    opacity_factor: 1.0,
     clip: [0, 0, -1, -1]
 };
 
@@ -187,6 +189,14 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                 GObject.ParamFlags.READWRITE,
                 0.0, Number.MAX_SAFE_INTEGER,
                 0.0,
+            ),
+            'opacity_factor': GObject.ParamSpec.double(
+                `opacity_factor`,
+                `Opacity factor`,
+                `Opacity factor`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                1.0,
             ),
         }
     }, class RefractionEffect extends Clutter.ShaderEffect {
@@ -480,6 +490,21 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
             this.update_scaled_uniforms();
         }
 
+        get opacity_factor() {
+            return this._opacity_factor;
+        }
+
+        set opacity_factor(value) {
+            if (this._opacity_factor !== value) {
+                this._opacity_factor = value;
+
+                uniforms.set_uniform(this, 'opacity_factor', parseFloat(this._opacity_factor));
+
+                if (this.chained_effect)
+                    this.chained_effect.opacity_factor = value;
+            }
+        }
+
         _stabilized_clip(previous_clip) {
             if (this._clip_width < 0 || this._clip_height < 0) {
                 this._stable_clip_x0 = null;
@@ -662,7 +687,8 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
                         height: this.height,
                         clip: this.clip,
                         blur_direction: 1,
-                        private_pass: 1
+                        private_pass: 1,
+                        opacity_factor: this._opacity_factor
                     };
 
                     this.chained_effect = new RefractionEffect(chained_params);
@@ -674,6 +700,7 @@ export const RefractionEffect = utils.IS_IN_PREFERENCES
         }
 
         vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
             this.set_uniform_value('blur_direction', this.blur_direction);
             this.set_uniform_value('private_pass', this.private_pass);
 


### PR DESCRIPTION
This PR fix the issue where Liquid Glass texture effect fade to black in Popup Blur instead of properly fade out like other effect

https://github.com/user-attachments/assets/ace19b79-d202-4918-89c2-4a08f2b85878


