### PR TITLE
fix(panel): multi-monitor vertical layout proximity detection

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -603,10 +603,10 @@ export const PanelBlur = class PanelBlur {
                     // if so, and if in the same monitor, then it overlaps
                     if (same_monitor
                         &&
-                        // check if panel is on top
-                        ((panel_top === 0 && window_vertical_pos < panel_bottom + 5 * scale) ||
+                        // check if panel is on top (relative to the monitor's Y origin)
+                        ((panel_top === actors.monitor.y && window_vertical_pos < panel_bottom + 5 * scale) ||
                         // check if panel is at the bottom
-                        (panel_top > 0 && window_vertical_bottom > panel_top - 5 * scale))
+                        (panel_top > actors.monitor.y && window_vertical_bottom > panel_top - 5 * scale))
                     )
                         window_overlap_panel = true;
                 });


### PR DESCRIPTION
When a secondary monitor is positioned physically above the primary monitor, the primary monitor's Y-origin is pushed down the coordinate plane (e.g., Y = 1080). The update_visibility logic in panel.js hardcoded panel_top === 0 to detect top panels. Consequently, top panels on lower monitors were evaluated as panel_top > 0 (treating them as bottom panels). This caused the "Disable when a window is near" feature to trigger false positive intersections for almost all windows on the primary display.

Fix: Replaced the hardcoded 0 with actors.monitor.y to dynamically respect the panel's position relative to its specific monitor's bounding box, resolving Issue #865 without breaking side-by-side or single monitor configurations.