### PR TITLE
Gradient for Blur on Window proximity

### DIFF
--- a/resources/ui/panel.ui
+++ b/resources/ui/panel.ui
@@ -202,6 +202,35 @@ Background on Window Proximity: Solid color background when a window is near the
               </object>
             </child>
 
+            <child>
+              <object class="AdwActionRow" id="gradient_panel_row">
+                <property name="title" translatable="yes">Gradient background</property>
+                <property name="subtitle" translatable="yes">Apply a gradient effect to the panel background.</property>
+                <property name="activatable-widget">gradient_panel</property>
+
+                <child>
+                  <object class="GtkSwitch" id="gradient_panel">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+
+            <child>
+              <object class="AdwActionRow" id="gradient_panel_mode_row">
+                <property name="title" translatable="yes">Gradient direction</property>
+                <property name="subtitle" translatable="yes">Change the direction of the gradient background.</property>
+                <property name="activatable-widget">gradient_panel_mode</property>
+
+                <child>
+                  <object class="GtkDropDown" id="gradient_panel_mode">
+                    <property name="valign">center</property>
+                    <property name="model">gradient_panel_mode_model</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+
           </object>
         </child>
 
@@ -273,6 +302,13 @@ Background on Window Proximity: Solid color background when a window is near the
     <items>
       <item translatable="yes">Blur on Window Proximity</item>
       <item translatable="yes">Background on Window Proximity</item>
+    </items>
+  </object>
+
+  <object class="GtkStringList" id="gradient_panel_mode_model">
+    <items>
+      <item translatable="yes">Top</item>
+      <item translatable="yes">Bottom</item>
     </items>
   </object>
 

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -287,6 +287,16 @@
             <default>1</default>
             <summary>Enum to select the override mode (0 Blur on Window Proximity, 1 Background on Window Proximity). Required "override-background-dynamically" to be enabled.</summary>
         </key>
+        <!-- GRADIENT PANEL -->
+        <key type="b" name="gradient-panel">
+            <default>false</default>
+            <summary>Boolean, whether to enable the gradient panel effect</summary>
+        </key>
+        <!-- GRADIENT PANEL MODE -->
+        <key type="i" name="gradient-panel-mode">
+            <default>0</default>
+            <summary>Enum to select the gradient panel mode (0 Top, 1 Bottom). Required "gradient-panel" to be enabled.</summary>
+        </key>
     </schema>
 
     <!-- DASH TO DOCK -->

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -16,6 +16,11 @@ const PANEL_STYLES = [
     "contrasted-panel"
 ];
 
+const GRADIENT_PANEL_STYLES = [
+    "gradient-panel",
+    "gradient-panel-reverse"
+];
+
 // global listener, so we don't miss the panel destruction event
 let isMainPanelAlive = true;
 Main.panel.connect('destroy', () => isMainPanelAlive = false);
@@ -623,44 +628,55 @@ export const PanelBlur = class PanelBlur {
     set_should_override_panel(actors, should_override) {
         let panel = actors.widgets.panel;
 
-        PANEL_STYLES.forEach(style => panel.remove_style_class_name(style));
-
         if (this.settings.panel.OVERRIDE_BACKGROUND) {
             if (this.settings.panel.OVERRIDE_BACKGROUND_DYNAMICALLY) {
-                // This is an invert of the above behavior, 
-                // Blur and all styling is hidden when "should_override" is true. 
                 if (this.settings.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_MODE == 0) {
-                    panel.add_style_class_name(
-                        PANEL_STYLES[this.settings.panel.STYLE_PANEL]
-                    );
+                    // This is an invert of the above behavior, 
+                    // Blur and all styling is hidden when "should_override" is true. 
                     if (!should_override) {
-                        actors.widgets.background.show();
+                        this.proximity_show(actors, panel);
                     }
                     else {
-                        actors.widgets.background.hide();
+                        this.proximity_hide(actors, panel);
                     };
                 }
                 if (this.settings.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_MODE == 1) {
-                    PANEL_STYLES.forEach(style => panel.remove_style_class_name(style));
                     if (should_override) {
-                        panel.add_style_class_name(
-                            PANEL_STYLES[this.settings.panel.STYLE_PANEL]
-                        );
+                        this.update_panel_style_class(panel, PANEL_STYLES[this.settings.panel.STYLE_PANEL]);
+                    } else {
+                        this.update_panel_style_class(panel, null); // Clear custom styles
                     }
                 }
             }
             else {
-                panel.add_style_class_name(
-                    PANEL_STYLES[this.settings.panel.STYLE_PANEL]
-                );
+                this.update_panel_style_class(panel, PANEL_STYLES[this.settings.panel.STYLE_PANEL]);
             }
-        };
+        }
+        else {
+            this.update_panel_style_class(panel, null);
+        }
 
         // update the classname if the panel to have or have not light text
         this.update_light_text_classname(!should_override);
     }
 
-    panel_hide_blur_dynamically(){
+    update_panel_style_class(panel, target_class) {
+        const ALL_STYLES = [...PANEL_STYLES, ...GRADIENT_PANEL_STYLES];
+
+        // Remove all managed classes EXCEPT the target class we are moving to
+        ALL_STYLES.forEach(style => {
+            if (style !== target_class) {
+                panel.remove_style_class_name(style);
+            }
+        });
+
+        // Add the target class if specified and not already present
+        if (target_class && !panel.has_style_class_name(target_class)) {
+            panel.add_style_class_name(target_class);
+        }
+    }
+
+    panel_hide_blur_dynamically() {
         if (this.settings.panel.OVERRIDE_BACKGROUND && this.settings.panel.OVERRIDE_BACKGROUND_DYNAMICALLY) {
             if (this.settings.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_MODE == 0) {
                 this.hide()
@@ -670,6 +686,31 @@ export const PanelBlur = class PanelBlur {
         else {
             this.show()
         }
+    }
+
+    proximity_hide(actors, panel) {
+        let target_style = null;
+        if (this.settings.panel.GRADIENT_PANEL) {
+            if (!Main.overview.visible) {
+                target_style = GRADIENT_PANEL_STYLES[this.settings.panel.GRADIENT_PANEL_MODE];
+            }
+            else {
+                target_style = this.settings.panel.UNBLUR_IN_OVERVIEW
+                                ? PANEL_STYLES[0]
+                                : GRADIENT_PANEL_STYLES[this.settings.panel.GRADIENT_PANEL_MODE];
+            }
+        }
+        else {
+            target_style = PANEL_STYLES[this.settings.panel.STYLE_PANEL];
+        }
+
+        this.update_panel_style_class(panel, target_style);
+        actors.widgets.background.hide();
+    }
+
+    proximity_show(actors, panel) {
+        this.update_panel_style_class(panel, PANEL_STYLES[this.settings.panel.STYLE_PANEL]);
+        actors.widgets.background.show();
     }
 
     panel_hide_blur_startup(){

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -39,6 +39,8 @@ export const KEYS = [
             { type: Type.I, name: "style-panel" },
             { type: Type.B, name: "override-background-dynamically" },
             { type: Type.I, name: "override-background-dynamically-mode" },
+            { type: Type.B, name: "gradient-panel" },
+            { type: Type.I, name: "gradient-panel-mode" },
         ]
     },
     {

--- a/src/extension.js
+++ b/src/extension.js
@@ -434,8 +434,10 @@ export default class BlurMyShell extends Extension {
 
         // panel override background toggled on/off
         this._settings.panel.OVERRIDE_BACKGROUND_changed(() => {
-            if (this._settings.panel.BLUR)
+            if (this._settings.panel.BLUR) {
                 this._panel_blur.connect_to_windows_and_overview();
+                this._panel_blur.reset();
+            }
         });
 
         // panel style changed
@@ -456,6 +458,18 @@ export default class BlurMyShell extends Extension {
             if (this._settings.panel.BLUR) {
                 this._panel_blur.connect_to_windows_and_overview();
                 this._panel_blur.reset();
+            }
+        });
+
+        this._settings.panel.GRADIENT_PANEL_changed(() => {
+            if (this._settings.panel.BLUR) {
+                this._panel_blur.update_visibility() ;
+            }
+        });
+
+        this._settings.panel.GRADIENT_PANEL_MODE_changed(() => {
+            if (this._settings.panel.BLUR) {
+                this._panel_blur.update_visibility();
             }
         });
 

--- a/src/preferences/panel.js
+++ b/src/preferences/panel.js
@@ -26,6 +26,10 @@ export const Panel = GObject.registerClass({
         'override_background_dynamically',
         'override_background_dynamically_mode_row',
         'override_background_dynamically_mode',
+        'gradient_panel_row',
+        'gradient_panel',
+        'gradient_panel_mode_row',
+        'gradient_panel_mode',
         'hidetopbar_compatibility',
         'dtp_blur_original_panel'
     ],
@@ -94,7 +98,21 @@ export const Panel = GObject.registerClass({
             this._override_background_dynamically_mode, 'selected',
             Gio.SettingsBindFlags.DEFAULT
         );
+        this.preferences.panel.settings.bind(
+            'gradient-panel', this._gradient_panel, 'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.preferences.panel.settings.bind(
+            'gradient-panel-mode', this._gradient_panel_mode, 'selected',
+            Gio.SettingsBindFlags.DEFAULT
+        );
         this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_changed(
+            () => this.proximity_option_changed()
+        );
+        this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_MODE_changed(
+            () => this.proximity_option_changed()
+        );
+        this.preferences.panel.GRADIENT_PANEL_changed(
             () => this.proximity_option_changed()
         );
         this.preferences.hidetopbar.settings.bind(
@@ -109,6 +127,8 @@ export const Panel = GObject.registerClass({
 
     proximity_option_changed() {
         this._override_background_dynamically_mode_row.set_visible(this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY);
+        this._gradient_panel_row.set_visible(this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY && this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_MODE == 0);
+        this._gradient_panel_mode_row.set_visible(this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY && this.preferences.panel.GRADIENT_PANEL && this.preferences.panel.OVERRIDE_BACKGROUND_DYNAMICALLY_MODE == 0);
     }
 
     change_blur_mode(is_static_blur, first_run) {

--- a/src/styles/panel.css
+++ b/src/styles/panel.css
@@ -3,6 +3,7 @@
 /*
 * `.transparent-panel`
 */
+
 #panel.transparent-panel {
     background: transparent !important;
     transition-duration: 500ms;
@@ -31,6 +32,34 @@
 */
 #panel.contrasted-panel {
     background-color: transparent !important;
+    box-shadow: none !important;
+    transition-duration: 500ms;
+}
+
+/*
+* `.gradient-panel`
+*/
+/* Internal use */
+
+#panel.gradient-panel {
+    background-color: transparent !important;
+    background-gradient-direction: vertical !important;
+    background-gradient-start: rgba(0,0,0,0.5) !important;
+    background-gradient-end: rgba(0,0,0,0) !important;
+    box-shadow: none !important;
+    transition-duration: 500ms;
+}
+
+/*
+* `.gradient-panel-reverse`
+*/
+/* Internal use */
+
+#panel.gradient-panel-reverse {
+    background-color: transparent !important;
+    background-gradient-direction: vertical !important;
+    background-gradient-start: rgba(0,0,0,0) !important;
+    background-gradient-end: rgba(0,0,0,0.5) !important;
     box-shadow: none !important;
     transition-duration: 500ms;
 }
@@ -66,4 +95,3 @@
 .contrasted-panel .clock {
     margin: 0 !important;
 }
-


### PR DESCRIPTION
Add gradient for Blur on Window Proximity for better visibility

<img width="1920" height="183" alt="image" src="https://github.com/user-attachments/assets/0761c78f-2cb1-455c-8df9-b19e02dafdd9" />

Without gradient it looks like this on bright wallpaper
<img width="1920" height="156" alt="Screenshot From 2026-07-10 17-43-40" src="https://github.com/user-attachments/assets/126013dc-53e6-4331-be16-c51a355a0df5" />

Can be enable / disable in Settings (Default to Off)

<img width="690" height="626" alt="image" src="https://github.com/user-attachments/assets/23400196-bd66-47f1-99db-ba909d9bb4f1" />

Still figuring out how to make the panel stop flashing black for a few seconds when changing style class, if anyone can help me find the solution then I appreciate it!