### PR TITLE
Fix(panel): Stop GNOME Wellbeing breaks (and overlays) from killing dynamic panel blur

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -573,7 +573,13 @@ export const PanelBlur = class PanelBlur {
         const windows = workspace.list_windows().filter(meta_window =>
             meta_window.showing_on_its_workspace()
             && !meta_window.is_hidden()
-            && meta_window.get_window_type() !== Meta.WindowType.DESKTOP
+            // Whitelist only standard application windows.
+            // This prevents system overlays from disabling panel blur.
+            && [
+                Meta.WindowType.NORMAL,
+                Meta.WindowType.DIALOG,
+                Meta.WindowType.MODAL_DIALOG
+            ].includes(meta_window.get_window_type())
             // exclude Desktop Icons NG
             && meta_window.get_gtk_application_id() !== "com.rastersoft.ding"
             && meta_window.get_gtk_application_id() !== "com.desktop.ding"


### PR DESCRIPTION
The problem:
When GNOME 48+ triggers a Wellbeing break (like the eyesight screen dimming), the dynamic panel blur suddenly vanishes. This happens because the `update_visibility()` logic in `panel.js` was relying on a dangerously broad blacklist—basically saying "ignore the desktop layer, but treat everything else as an overlapping window." Because the Wellbeing break acts as a full-screen system overlay, the extension thought a massive window was touching the panel and triggered the "Disable when a window is near" fallback.

The fix:
Fixes #928 
We're ditching the fragile blacklist approach and moving to a strict whitelist. The proximity detection loop now explicitly only tracks real application windows: `Meta.WindowType.NORMAL`, `DIALOG`, and `MODAL_DIALOG`. System-level overlays are now completely ignored by the math.

Why this is better:
This harmonizes the panel code with the architecture already used in `applications.js`. More importantly, it stops us from having to play whack-a-mole. Whenever GNOME 50 or Mutter introduces new Wayland OSDs or system layers in the future, this whitelist guarantees they won't accidentally break panel transparency.