### PR TITLE
Add "quick-settings" to defer exclusion list

### DIFF
--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -157,8 +157,8 @@ export const PopupBlurSurface = class PopupBlurSurface {
     }
     
     is_excluded_from_deferring_surface() {
-        return this.style.has_any_style_class(this.target, ['datemenu-popover','modal-dialog'])
-            || this.style.has_any_style_class(this.root_actor, ['datemenu-popover','modal-dialog']);
+        return this.style.has_any_style_class(this.target, ['datemenu-popover','modal-dialog','quick-settings'])
+            || this.style.has_any_style_class(this.root_actor, ['datemenu-popover','modal-dialog','quick-settings']);
     }
 
     update() {


### PR DESCRIPTION
This is a hot fix that add "quick-settings" to the defer exclusion list

Downside is that quick settings is now a little bit less smooth when device is in low power mode but it fixes the issue of animation jankiness like like "datemenu-popover" (those two are really heavy in its expanding animation somehow)