### PR TITLE
Use Meta.LaterType.IDLE to defer update for certain blur surface

### DIFF
--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -1,5 +1,4 @@
 import Meta from 'gi://Meta';
-import GLib from 'gi://GLib';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
 
@@ -34,7 +33,7 @@ class DashInfos {
         this.bg_manager = bg_manager;
         this.paint_signals = paint_signals;
         this.settings = dash_blur.settings;
-        this.old_style = this.dash._background.style;
+        this.old_style = this.dash._background?.style;
 
         this.updateId = 0;
 
@@ -44,8 +43,8 @@ class DashInfos {
             this.dash_blur.connect('remove-dashes', () => this.remove_dash_blur()),
             this.dash_blur.connect('override-style', () => this.override_style()),
             this.dash_blur.connect('remove-style', () => this.remove_style()),
-            this.dash_blur.connect('show', () => this.background_group.show()),
-            this.dash_blur.connect('hide', () => this.background_group.hide()),
+            this.dash_blur.connect('show', () => this.background_group?.show()),
+            this.dash_blur.connect('hide', () => this.background_group?.hide()),
             this.dash_blur.connect('update-size', () => this.schedule_update()),
             this.dash_blur.connect('change-blur-type', () => this.change_blur_type()),
             this.dash_blur.connect('update-pipeline', () => this.update_pipeline())
@@ -53,21 +52,35 @@ class DashInfos {
     }
 
     schedule_update() {
-        if (this.updateId) {
-            GLib.source_remove(this.updateId);
-            this.updateId = 0;
-        }
+        const laters = global.compositor?.get_laters?.();
 
-        this.updateId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-            this.updateId = 0;
-            this.update_size();
-            return GLib.SOURCE_REMOVE;
-        });
+        this.clear_pending_idles();
+
+        if (laters) {
+            // Modern GNOME Shell (GNOME 44+)
+            this.updateId = laters.add(Meta.LaterType.IDLE, () => {
+                this.updateId = 0;
+                this.update_size();
+                return false;
+            });
+        } else {
+            // Legacy fallback (GNOME 43 and older)
+            this.updateId = Meta.later_add(Meta.LaterType.IDLE, () => {
+                this.updateId = 0;
+                this.update_size();
+                return false
+            });
+        }
     }
 
     clear_pending_idles() {
         if (this.updateId) {
-            GLib.source_remove(this.updateId);
+            const laters = global.compositor?.get_laters?.();
+            if (laters) {
+                laters.remove(this.updateId);
+            } else {
+                Meta.later_remove(this.updateId);
+            }
             this.updateId = 0;
         }
     }
@@ -100,7 +113,8 @@ class DashInfos {
     }
 
     remove_style() {
-        this.dash._background.style = this.old_style;
+        if (this.dash?._background)
+            this.dash._background.style = this.old_style;
 
         DASH_STYLES.forEach(
             style => {
@@ -130,9 +144,13 @@ class DashInfos {
     change_blur_type() {
         this.destroy_dash();
 
+        let blur_result = this.dash_blur.add_blur(this.dash);
+        if (!blur_result)
+            return;
+
         let [
             background, background_group, bg_manager, paint_signals
-        ] = this.dash_blur.add_blur(this.dash);
+        ] = blur_result;
 
         this.background = background;
         this.background_group = background_group;
@@ -141,7 +159,7 @@ class DashInfos {
 
         this.dash.get_parent().insert_child_at_index(this.background_group, 0);
 
-        this.update_size();
+        this.schedule_update();
     }
 
     update_pipeline() {

--- a/src/components/popup/surface_signals.js
+++ b/src/components/popup/surface_signals.js
@@ -1,5 +1,5 @@
+import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import GLib from 'gi://GLib';
 
 const SURFACE_SIGNALS = [
     'notify::allocation',
@@ -27,7 +27,6 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         this.signal_ids = [];
         this.signal_actors = new WeakSet();
         this.destroyed_actors = new WeakSet();
-        this.pendingIdles = new Set();
     }
 
     connect_actor(actor) {
@@ -45,17 +44,25 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
                     if (is_excluded_from_deferring_surface) {
                         this.surface.queue_update();
                     } else {
-                        if (this.pendingIdles.size > 0)
-                            return;
-
-                        let updateId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-                            this.pendingIdles.delete(updateId);
-                            this.surface.queue_update();
-                            return GLib.SOURCE_REMOVE;
-                        });
-
-                        if (updateId)
-                            this.pendingIdles.add(updateId);
+                        const laters = global.compositor?.get_laters?.();
+                        
+                        this.clear_pending_idles();
+                        
+                        if (laters) {
+                            // Modern GNOME Shell (GNOME 44+)
+                            this.updateId = laters.add(Meta.LaterType.IDLE, () => {
+                                this.updateId = 0;
+                                this.surface.queue_update();
+                                return false;
+                            });
+                        } else {
+                            // Legacy fallback (GNOME 43 and older)
+                            this.updateId = Meta.later_add(Meta.LaterType.IDLE, () => {
+                                this.updateId = 0;
+                                this.surface.queue_update();
+                                return false
+                            });
+                        }
                     }
                 });
                 this.signal_ids.push([actor, id, signal]);
@@ -113,15 +120,20 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         });
     }
 
-    disconnect_all() {
-        if (this.pendingIdles.size > 0) {
-            for (const updateId of this.pendingIdles) {
-                if (updateId) {
-                    GLib.source_remove(updateId);
-                }
+    clear_pending_idles() {
+        if (this.updateId) {
+            const laters = global.compositor?.get_laters?.();
+            if (laters) {
+                laters.remove(this.updateId);
+            } else {
+                Meta.later_remove(this.updateId);
             }
-            this.pendingIdles.clear();
-        };
+            this.updateId = 0;
+        }
+    }
+
+    disconnect_all() {
+        this.clear_pending_idles();
         this.signal_ids.forEach(([signal_actor, signal_id]) => {
             if (this.destroyed_actors.has(signal_actor))
                 return;


### PR DESCRIPTION
This PR add the use of ``Meta.LaterType.IDLE`` for dash-to-dock and popup-blur to defer blur surface update, replace the use of ``GLib.PRIORITY_DEFAULT_IDLE``.

### What has changed

- For popup blur, nothing changes.
- For dash-to-dock, this (kinda) fixed the issue of switching between dynamic and static blur result in blur breaking for the dock. Note that kinda means that it will still break, but it's much more usable than before, also one less import.

