### PR TITLE
fix: apply paint signal workaround to appfolder dialogs at all hack levels except 2

### DIFF
--- a/src/components/appfolders.js
+++ b/src/components/appfolders.js
@@ -206,7 +206,7 @@ export const AppFoldersBlur = class AppFoldersBlur {
             //
             // [1]: https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/2857
 
-            if (this.settings.HACKS_LEVEL === 1) {
+            if (this.settings.HACKS_LEVEL !== 2) {
                 this.paint_signals.disconnect_all_for_actor(icon._dialog);
                 this.paint_signals.connect(icon._dialog, blur_effect);
             } else {


### PR DESCRIPTION
## What
The Shell.BlurEffect has a known bug (GNOME #2857) where it does not repaint when shadows are underneath it. This causes visual artifacts (tearing/flickering) during the app folder open/close zoom animation. The paint signal workaround that forces blur repaints was previously only applied when HACKS_LEVEL=1, leaving HACKS_LEVEL=0 (High Performance mode) with artifacts. This fix extends the workaround to all levels except 2 (where clipped redraws are disabled entirely, which already resolves the repaint issue).

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #933