### PR TITLE
Fix static blur edge on bottom panels

### DIFF
--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -389,12 +389,19 @@ export const PanelBlur = class PanelBlur {
 
             let x = p_x + p_p_x - monitor.x + g_x;
             let y = p_y + p_p_y - monitor.y + g_y;
+            let is_horizontal = geometry_width >= geometry_height;
+            let distance_to_top = Math.abs(y);
+            let distance_to_bottom = Math.abs(
+                monitor.height - (y + geometry_height)
+            );
+            let is_bottom_panel = is_horizontal &&
+                distance_to_bottom < distance_to_top;
 
             background.set_clip(
                 x,
-                y - 1,
+                is_bottom_panel ? y - 1 : y,
                 geometry_width,
-                geometry_height + 1
+                is_bottom_panel ? geometry_height + 1 : geometry_height
             );
             background.x = g_x - x;
             background.y = .5 + g_y - y;

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -390,7 +390,12 @@ export const PanelBlur = class PanelBlur {
             let x = p_x + p_p_x - monitor.x + g_x;
             let y = p_y + p_p_y - monitor.y + g_y;
 
-            background.set_clip(x, y, geometry_width, geometry_height);
+            background.set_clip(
+                x,
+                y - 1,
+                geometry_width,
+                geometry_height + 1
+            );
             background.x = g_x - x;
             background.y = .5 + g_y - y;
         } else {


### PR DESCRIPTION
## Summary

- extend the static panel blur clip upward by one pixel
- leave dynamic blur unchanged

## Problem

Static panel blur can leave a one-pixel unblurred strip along the workspace-facing edge of a bottom panel. Dynamic blur does not show the strip.

The static background is clipped exactly to the panel geometry. Expanding the clip upward by one pixel removes the rasterized edge without changing panel placement, size, or work-area geometry.

## Validation

- reproduced with Simple Taskbar on GNOME Shell 50.1
- confirmed that changing the background offset did not resolve the strip
- confirmed that expanding the static clip upward by one pixel removed it
- reverted the test to reproduce the original strip
- ran `make build`

Dash to Panel can show a similar, less visible edge, but the manual validation for this change was performed with Simple Taskbar.
