### PR TITLE
Removal of GNOME 42 and older detection path and fix panel not blurring with Disable with Overview on Startup

### DIFF
--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -52,35 +52,17 @@ class DashInfos {
     }
 
     schedule_update() {
-        const laters = global.compositor?.get_laters?.();
-
         this.clear_pending_idles();
-
-        if (laters) {
-            // Modern GNOME Shell (GNOME 44+)
-            this.updateId = laters.add(Meta.LaterType.IDLE, () => {
-                this.updateId = 0;
-                this.update_size();
-                return false;
-            });
-        } else {
-            // Legacy fallback (GNOME 43 and older)
-            this.updateId = Meta.later_add(Meta.LaterType.IDLE, () => {
-                this.updateId = 0;
-                this.update_size();
-                return false
-            });
-        }
+        this.updateId = global.compositor.get_laters().add(Meta.LaterType.IDLE, () => {
+            this.updateId = 0;
+            this.update_size();
+            return false;
+        });
     }
 
     clear_pending_idles() {
         if (this.updateId) {
-            const laters = global.compositor?.get_laters?.();
-            if (laters) {
-                laters.remove(this.updateId);
-            } else {
-                Meta.later_remove(this.updateId);
-            }
+            global.compositor.get_laters().remove(this.updateId);
             this.updateId = 0;
         }
     }

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -721,13 +721,10 @@ export const PanelBlur = class PanelBlur {
 
     panel_hide_blur_startup(){
         if (this._first_boot) {
-            if (this.settings.panel.UNBLUR_IN_OVERVIEW) {
+            if (this.settings.panel.UNBLUR_IN_OVERVIEW && Main.overview.visible) {
                 this.hide();
-                this._first_boot = false
             }
-            else {
-                this._first_boot = false
-            }
+            this._first_boot = false;
         }
     }
 

--- a/src/components/popup/surface_signals.js
+++ b/src/components/popup/surface_signals.js
@@ -44,25 +44,12 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
                     if (is_excluded_from_deferring_surface) {
                         this.surface.queue_update();
                     } else {
-                        const laters = global.compositor?.get_laters?.();
-                        
                         this.clear_pending_idles();
-                        
-                        if (laters) {
-                            // Modern GNOME Shell (GNOME 44+)
-                            this.updateId = laters.add(Meta.LaterType.IDLE, () => {
-                                this.updateId = 0;
-                                this.surface.queue_update();
-                                return false;
-                            });
-                        } else {
-                            // Legacy fallback (GNOME 43 and older)
-                            this.updateId = Meta.later_add(Meta.LaterType.IDLE, () => {
-                                this.updateId = 0;
-                                this.surface.queue_update();
-                                return false
-                            });
-                        }
+                        this.updateId = global.compositor.get_laters().add(Meta.LaterType.IDLE, () => {
+                            this.updateId = 0;
+                            this.surface.queue_update();
+                            return false;
+                        });
                     }
                 });
                 this.signal_ids.push([actor, id, signal]);
@@ -122,12 +109,7 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
 
     clear_pending_idles() {
         if (this.updateId) {
-            const laters = global.compositor?.get_laters?.();
-            if (laters) {
-                laters.remove(this.updateId);
-            } else {
-                Meta.later_remove(this.updateId);
-            }
+            global.compositor.get_laters().remove(this.updateId);
             this.updateId = 0;
         }
     }


### PR DESCRIPTION
This remove the unnecessary GNOME 45 and older detection path for ``Meta.LaterType.IDLE``, and fixed the issue where the panel not blurring when the extension is enabled while not in Overview