### PR TITLE
Some optimizations to Quick Settings blurring

### DIFF
--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -155,9 +155,15 @@ export const PopupBlurSurface = class PopupBlurSurface {
         return sibling_index >= 0 && actor_index < sibling_index;
     }
     
-    is_excluded_from_deferring_surface() {
-        return this.style.has_any_style_class(this.target, ['datemenu-popover','modal-dialog','quick-settings'])
-            || this.style.has_any_style_class(this.root_actor, ['datemenu-popover','modal-dialog','quick-settings']);
+
+    is_quick_settings() {
+        return this.style.has_any_style_class(this.target, ['quick-toggle-menu','quick-settings'])
+            || this.style.has_any_style_class(this.root_actor, ['quick-toggle-menu','quick-settings']);
+    }
+
+    is_heavy_surface() {
+        return this.style.has_any_style_class(this.target, ['datemenu-popover','quick-settings','modal-dialog'])
+            || this.style.has_any_style_class(this.root_actor, ['datemenu-popover','quick-settings','modal-dialog']);
     }
 
     update() {

--- a/src/components/popup/surface_signals.js
+++ b/src/components/popup/surface_signals.js
@@ -21,6 +21,24 @@ const SURFACE_SIGNALS = [
     'style-changed',
 ];
 
+const ANCESTOR_SIGNALS = [
+    'notify::allocation',
+    'notify::position',
+    'notify::size',
+    'notify::x',
+    'notify::y',
+    'notify::width',
+    'notify::height',
+    'notify::clip-rect',
+    'notify::visible',
+    'notify::mapped',
+    'notify::translation-x',
+    'notify::translation-y',
+    'notify::scale-x',
+    'notify::scale-y',
+    'notify::pseudo-class',
+];
+
 export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
     constructor(surface) {
         this.surface = surface;
@@ -29,30 +47,34 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         this.destroyed_actors = new WeakSet();
     }
 
-    connect_actor(actor) {
+    connect_actor(actor, is_ancestor = false) {
         if (!actor || this.signal_actors.has(actor))
             return;
 
         this.signal_actors.add(actor);
         this.track_destroy(actor);
 
-        const is_excluded_from_deferring_surface = this.surface.is_excluded_from_deferring_surface();
+        const is_heavy_surface = this.surface.is_heavy_surface();
+        const signals_to_use = is_ancestor ? ANCESTOR_SIGNALS : SURFACE_SIGNALS;
 
-        SURFACE_SIGNALS.forEach(signal => {
+        signals_to_use.forEach(signal => {
             try {
-                let id = actor.connect(signal, () => {
-                    if (is_excluded_from_deferring_surface) {
+            let id = actor.connect(signal, () => {
+                this.clear_pending_idles();
+                const is_visibility_change = signal === 'notify::visible' || signal === 'notify::mapped';
+                if (is_heavy_surface || is_visibility_change) {
+                    this.surface.queue_update();
+                    return;
+                }
+                else {
+                    this.updateId = global.compositor.get_laters().add(Meta.LaterType.IDLE, () => {
+                        this.updateId = 0;
                         this.surface.queue_update();
-                    } else {
-                        this.clear_pending_idles();
-                        this.updateId = global.compositor.get_laters().add(Meta.LaterType.IDLE, () => {
-                            this.updateId = 0;
-                            this.surface.queue_update();
-                            return false;
-                        });
-                    }
-                });
-                this.signal_ids.push([actor, id, signal]);
+                        return false;
+                    });
+                }
+            });
+            this.signal_ids.push([actor, id, signal]);
             } catch (e) { }
         });
     }
@@ -72,7 +94,7 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         }
 
         while (actor && actor !== this.surface.parent) {
-            this.connect_actor(actor);
+            this.connect_actor(actor, true);
             try {
                 actor = actor.get_parent?.();
             } catch (e) {

--- a/src/components/popup/surface_transitions.js
+++ b/src/components/popup/surface_transitions.js
@@ -79,8 +79,10 @@ export const PopupBlurSurfaceTransitions = class PopupBlurSurfaceTransitions {
         const seen = new WeakSet();
         actors.forEach(actor => seen.add(actor));
 
-        this.add_descendants(actors, seen, this.surface.target);
-        this.add_descendants(actors, seen, this.surface.root_actor);
+        if (!this.surface.is_quick_settings()) {
+            this.add_descendants(actors, seen, this.surface.target);
+            this.add_descendants(actors, seen, this.surface.root_actor);
+        }
 
         return actors;
     }


### PR DESCRIPTION
**NOTE:** This is tested with optimization found in https://github.com/aunetx/blur-my-shell/pull/920

This PR introduces a few optimization to mostly further speedup Quick Settings blurring (though some of them can be apply to general popup blur as well)

- Cut down the amount of signal connect to Quick settings and `datemenu-popover` specifically (again)
- Fixed the issue where `quick-toggle-menu` can last for some time after it was dismissed

Originally this was going to come with an update throttler and interpolation via Clutter's `AnimationMode` but I feel like it introduce way too much complexity and didn't actually fix the problem.

Now does it actually speedup quick settings, not sure, I tested it on my computer and it seems to be quite smooth on battery, but on older hardware, idk