### PR TITLE
Unblock Popup blur for Lockscreen

### DIFF
--- a/src/components/popup/index.js
+++ b/src/components/popup/index.js
@@ -55,6 +55,7 @@ export const PopupBlur = class PopupBlur {
             'changed::gtk-theme',
             () => this.update_background()
         );
+        
         this.connections.connect(
             Main.sessionMode,
             'updated',
@@ -69,6 +70,8 @@ export const PopupBlur = class PopupBlur {
         this.track_container(Main.uiGroup);
         (Main.osdWindowManager?._osdWindows ?? []).forEach(window => this.track_container(window));
         this.track_container(Main.layoutManager?.modalDialogGroup);
+        this.track_container(Main.layoutManager?.screenShieldGroup);
+        this.track_container(Main.layoutManager?.unlockDialogGroup);
         this.track_container(Main.messageTray?._bannerBin);
         this.track_quick_settings();
         this.track_container(global.window_group);
@@ -270,7 +273,10 @@ export const PopupBlur = class PopupBlur {
             if (!parent)
                 break;
 
-            if (parent === Main.uiGroup || parent === Main.layoutManager?.uiGroup)
+            if (parent === Main.layoutManager?.unlockDialogGroup ||
+                parent === Main.layoutManager?.screenShieldGroup ||
+                parent === Main.uiGroup || 
+                parent === Main.layoutManager?.uiGroup)
                 return { parent, sibling: actor };
 
             if (parent === global.window_group)

--- a/src/extension.js
+++ b/src/extension.js
@@ -207,7 +207,7 @@ export default class BlurMyShell extends Extension {
     _disable_user_session() {
         this._log("disabling user session mode...");
 
-        // disable every component except lockscreen blur
+        // disable every component except lockscreen blur and popup blur
         this._panel_blur.disable();
         this._dash_to_dock_blur.disable();
         this._overview_blur.disable();
@@ -216,7 +216,6 @@ export default class BlurMyShell extends Extension {
         this._coverflow_alt_tab_blur.disable();
         this._applications_blur.disable();
         this._screenshot_blur.disable();
-        this._popup.disable();
 
         // remove the clipped redraws flag
         this._reenable_clipped_redraws();


### PR DESCRIPTION
This simply remove the block for popup blur to work on the lockscreen (`unlock-dialog`)

<img width="1920" height="1200" alt="Screenshot From 2026-08-01 17-04-09" src="https://github.com/user-attachments/assets/63fcb6df-a738-44f0-8d49-81020bef6e8f" />
