### PR TITLE
refactor: streamline runtime lifecycle and settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install: build remove
 
 pot:
 	find resources/ui -iname "*.ui" -printf "%p\n" | sort | \
-		xargs xgettext --output=po/$(UUID).pot src/effects/effects.js \
+		xargs xgettext --output=po/$(UUID).pot src/effects/effects.js src/effects/effect_groups.js \
 		--from-code=utf-8 --package-name=$(UUID)
 
 	rm po/LINGUAS

--- a/src/components/appfolders.js
+++ b/src/components/appfolders.js
@@ -5,8 +5,6 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { adjustAnimationTime } from 'resource:///org/gnome/shell/misc/animationUtils.js';
 
 import { PaintSignals } from '../conveniences/paint_signals.js';
-// TODO drop Tweener in favour of Clutter's `ease` (will need to extend the blur effect for it)
-const Tweener = imports.tweener.tweener;
 
 // TODO: Drop GNOME 46 backwards compatibility
 const transparent = Clutter.Color ?
@@ -30,6 +28,39 @@ let original_zoomAndFadeOut = null;
 let sigma;
 let brightness;
 
+function stop_blur_animation(dialog) {
+    dialog._bms_blur_timeline?.stop();
+    dialog._bms_blur_timeline = null;
+}
+
+function animate_blur(dialog, blur_effect, target, mode) {
+    stop_blur_animation(dialog);
+
+    const duration = adjustAnimationTime(FOLDER_DIALOG_ANIMATION_TIME);
+    if (duration === 0) {
+        blur_effect.set(target);
+        return;
+    }
+
+    const start_radius = blur_effect.radius;
+    const start_brightness = blur_effect.brightness;
+    const timeline = Clutter.Timeline.new_for_actor(dialog, duration);
+    timeline.set_progress_mode(mode);
+    timeline.connect('new-frame', () => {
+        const progress = timeline.get_progress();
+        blur_effect.radius = start_radius + (target.radius - start_radius) * progress;
+        blur_effect.brightness = start_brightness
+            + (target.brightness - start_brightness) * progress;
+    });
+    timeline.connect('completed', () => {
+        blur_effect.set(target);
+        if (dialog._bms_blur_timeline === timeline)
+            dialog._bms_blur_timeline = null;
+    });
+    dialog._bms_blur_timeline = timeline;
+    timeline.start();
+}
+
 let _zoomAndFadeIn = function () {
     let [sourceX, sourceY] =
         this._source.get_transformed_position();
@@ -50,13 +81,11 @@ let _zoomAndFadeIn = function () {
 
     blur_effect.radius = 0;
     blur_effect.brightness = 1.0;
-    Tweener.addTween(blur_effect,
-        {
-            radius: sigma * 2,
-            brightness: brightness,
-            time: adjustAnimationTime(FOLDER_DIALOG_ANIMATION_TIME / 1000),
-            transition: 'easeOutQuad'
-        }
+    animate_blur(
+        this,
+        blur_effect,
+        { radius: sigma * 2, brightness },
+        Clutter.AnimationMode.EASE_OUT_QUAD
     );
 
     this.child.ease({
@@ -94,13 +123,11 @@ let _zoomAndFadeOut = function () {
     this.set_background_color(transparent);
 
     let blur_effect = this.get_effect("appfolder-blur");
-    Tweener.addTween(blur_effect,
-        {
-            radius: 0,
-            brightness: 1.0,
-            time: adjustAnimationTime(FOLDER_DIALOG_ANIMATION_TIME / 1000),
-            transition: 'easeInQuad'
-        }
+    animate_blur(
+        this,
+        blur_effect,
+        { radius: 0, brightness: 1.0 },
+        Clutter.AnimationMode.EASE_IN_QUAD
     );
 
     this.child.ease({
@@ -172,15 +199,19 @@ export const AppFoldersBlur = class AppFoldersBlur {
                 original_zoomAndFadeOut = icon._dialog._zoomAndFadeOut;
             }
 
-            let blur_effect = new Shell.BlurEffect({
-                name: "appfolder-blur",
-                radius: sigma * 2,
-                brightness: brightness,
-                mode: Shell.BlurMode.BACKGROUND
-            });
-
-            icon._dialog.remove_effect_by_name("appfolder-blur");
-            icon._dialog.add_effect(blur_effect);
+            let blur_effect = icon._dialog.get_effect('appfolder-blur');
+            if (!blur_effect) {
+                blur_effect = new Shell.BlurEffect({
+                    name: 'appfolder-blur',
+                    radius: sigma * 2,
+                    brightness,
+                    mode: Shell.BlurMode.BACKGROUND,
+                });
+                icon._dialog.add_effect(blur_effect);
+            } else {
+                stop_blur_animation(icon._dialog);
+                blur_effect.set({ radius: sigma * 2, brightness });
+            }
 
             DIALOGS_STYLES.forEach(
                 style => icon._dialog._viewBox.remove_style_class_name(style)
@@ -218,13 +249,24 @@ export const AppFoldersBlur = class AppFoldersBlur {
     set_sigma(s) {
         sigma = s;
         if (this.settings.appfolder.BLUR)
-            this.blur_appfolders();
+            this.update_blur_effects({ radius: sigma * 2 });
     }
 
     set_brightness(b) {
         brightness = b;
         if (this.settings.appfolder.BLUR)
-            this.blur_appfolders();
+            this.update_blur_effects({ brightness });
+    }
+
+    update_blur_effects(params) {
+        const appDisplay = Main.overview._overview.controls._appDisplay;
+        appDisplay._folderIcons.forEach(icon => {
+            if (!icon._dialog)
+                return;
+
+            stop_blur_animation(icon._dialog);
+            icon._dialog.get_effect('appfolder-blur')?.set(params);
+        });
     }
 
     disable() {
@@ -248,6 +290,7 @@ export const AppFoldersBlur = class AppFoldersBlur {
 
         appDisplay._folderIcons.forEach(icon => {
             if (icon._dialog) {
+                stop_blur_animation(icon._dialog);
                 icon._dialog.remove_effect_by_name("appfolder-blur");
                 DIALOGS_STYLES.forEach(
                     s => icon._dialog._viewBox.remove_style_class_name(s)

--- a/src/components/appfolders.js
+++ b/src/components/appfolders.js
@@ -2,7 +2,6 @@ import Shell from 'gi://Shell';
 import Clutter from 'gi://Clutter';
 import Cogl from 'gi://Cogl';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import { adjustAnimationTime } from 'resource:///org/gnome/shell/misc/animationUtils.js';
 
 import { PaintSignals } from '../conveniences/paint_signals.js';
 
@@ -28,37 +27,24 @@ let original_zoomAndFadeOut = null;
 let sigma;
 let brightness;
 
+const BLUR_RADIUS_PROPERTY = '@effects.appfolder-blur.radius';
+const BLUR_BRIGHTNESS_PROPERTY = '@effects.appfolder-blur.brightness';
+
 function stop_blur_animation(dialog) {
-    dialog._bms_blur_timeline?.stop();
-    dialog._bms_blur_timeline = null;
+    dialog.remove_transition(BLUR_RADIUS_PROPERTY);
+    dialog.remove_transition(BLUR_BRIGHTNESS_PROPERTY);
 }
 
-function animate_blur(dialog, blur_effect, target, mode) {
+function animate_blur(dialog, target, mode) {
     stop_blur_animation(dialog);
-
-    const duration = adjustAnimationTime(FOLDER_DIALOG_ANIMATION_TIME);
-    if (duration === 0) {
-        blur_effect.set(target);
-        return;
-    }
-
-    const start_radius = blur_effect.radius;
-    const start_brightness = blur_effect.brightness;
-    const timeline = Clutter.Timeline.new_for_actor(dialog, duration);
-    timeline.set_progress_mode(mode);
-    timeline.connect('new-frame', () => {
-        const progress = timeline.get_progress();
-        blur_effect.radius = start_radius + (target.radius - start_radius) * progress;
-        blur_effect.brightness = start_brightness
-            + (target.brightness - start_brightness) * progress;
+    dialog.ease_property(BLUR_RADIUS_PROPERTY, target.radius, {
+        duration: FOLDER_DIALOG_ANIMATION_TIME,
+        mode,
     });
-    timeline.connect('completed', () => {
-        blur_effect.set(target);
-        if (dialog._bms_blur_timeline === timeline)
-            dialog._bms_blur_timeline = null;
+    dialog.ease_property(BLUR_BRIGHTNESS_PROPERTY, target.brightness, {
+        duration: FOLDER_DIALOG_ANIMATION_TIME,
+        mode,
     });
-    dialog._bms_blur_timeline = timeline;
-    timeline.start();
 }
 
 let _zoomAndFadeIn = function () {
@@ -83,7 +69,6 @@ let _zoomAndFadeIn = function () {
     blur_effect.brightness = 1.0;
     animate_blur(
         this,
-        blur_effect,
         { radius: sigma * 2, brightness },
         Clutter.AnimationMode.EASE_OUT_QUAD
     );
@@ -122,10 +107,8 @@ let _zoomAndFadeOut = function () {
 
     this.set_background_color(transparent);
 
-    let blur_effect = this.get_effect("appfolder-blur");
     animate_blur(
         this,
-        blur_effect,
         { radius: 0, brightness: 1.0 },
         Clutter.AnimationMode.EASE_IN_QUAD
     );
@@ -273,6 +256,7 @@ export const AppFoldersBlur = class AppFoldersBlur {
         this._log("removing blur from appfolders");
 
         let appDisplay = Main.overview._overview.controls._appDisplay;
+        this.paint_signals.disconnect_all();
 
         if (original_zoomAndFadeIn != null) {
             appDisplay._folderIcons.forEach(icon => {

--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -187,7 +187,7 @@ class DashInfos {
                 return;
             }
 
-            let dash_box = this.get_dash_position(this.dash_container, this.dash_background);
+            let dash_box = this.get_dash_position(this.dash_container);
             if (!dash_box)
                 return;
 
@@ -217,16 +217,18 @@ class DashInfos {
         }
     }
 
-    get_dash_position(dash_container, dash_background) {
+    get_dash_position(dash_container) {
         let monitor = Main.layoutManager.findMonitorForActor(this.dash_container);
-            if (!monitor) return;
+        if (!monitor)
+            return;
 
         let dash_box = dash_container._slider.get_child();
         if (!dash_box)
             return null;
 
         let parent = this.background_group?.get_parent();
-            if (!parent) return;
+        if (!parent)
+            return;
 
         let [parent_stage_x, parent_stage_y] = parent.get_transformed_position();
         let [bg_stage_x, bg_stage_y] = this.dash_background.get_transformed_position();

--- a/src/components/popup/targets.js
+++ b/src/components/popup/targets.js
@@ -4,7 +4,6 @@ const POPUP_CHILD_STYLE_CLASSES = ['osd-window', 'resize-popup', 'switcher-list'
 const POPUP_DESCENDANT_TARGET_STYLE_CLASSES = ['switcher-list'];
 
 export const POPUP_BACKGROUND_STYLES = ['bms-popup-background-transparent', 'bms-popup-background-light', 'bms-popup-background-dark'];
-export const POPUP_BACKGROUND_STYLE_AUTO = 3;
 export const DEFAULT_CORNER_RADIUS = { key: 'corner-radius', property: 'CORNER_RADIUS' };
 export const POPUP_CORNER_RADII = [
     {

--- a/src/conveniences/connections.js
+++ b/src/conveniences/connections.js
@@ -1,108 +1,86 @@
 import GObject from 'gi://GObject';
 
-/// An object to easily manage signals.
+function supports_destroy_signal(object) {
+    const gtype = object?.constructor?.$gtype;
+    return gtype && GObject.signal_lookup('destroy', gtype) !== 0;
+}
+
 export const Connections = class Connections {
     constructor() {
-        this.buffer = [];
+        this.records = new Map();
     }
 
-    /// Adds a connection.
-    ///
-    /// Takes as arguments:
-    /// - an actor, which fires the signal
-    /// - signal(s) (string or array of strings), which are watched for
-    /// - a callback, which is called when the signal is fired
-    connect(actor, signals, handler) {
-        if (signals instanceof Array) {
-            signals.forEach(signal => {
-                let id = actor.connect(signal, handler);
-                this.process_connection(actor, id);
-            });
-        } else {
-            let id = actor.connect(signals, handler);
-            this.process_connection(actor, id);
+    connect(object, signals, handler) {
+        const names = Array.isArray(signals) ? signals : [signals];
+        const record = this.get_record(object);
+        const ids = [];
+
+        for (const signal of names) {
+            const id = object.connect(signal, handler);
+            record.ids.add(id);
+            ids.push(id);
         }
-
+        return Array.isArray(signals) ? ids : ids[0];
     }
 
-    /// Process the given actor and id.
-    ///
-    /// This makes sure that the signal is disconnected when the actor is
-    /// destroyed, and that the signal can be managed through other Connections
-    /// methods.
-    process_connection(actor, id) {
-        let infos = {
-            actor: actor,
-            id: id
+    get_record(object) {
+        let record = this.records.get(object);
+        if (record)
+            return record;
+
+        record = {
+            ids: new Set(),
+            destroy_id: null,
         };
+        this.records.set(object, record);
 
-        // remove the signal when the actor is destroyed
-        if (
-            actor.connect &&
-            (
-                !(actor instanceof GObject.Object) ||
-                GObject.signal_lookup('destroy', actor)
-            )
-        ) {
-            let destroy_id = actor.connect('destroy', () => {
-                try {
-                    actor.disconnect(id);
-                } catch (e) { }
-
-                try {
-                    actor.disconnect(destroy_id);
-                } catch (e) { }
-
-                let index = this.buffer.indexOf(infos);
-                if (index >= 0) {
-                    this.buffer.splice(index, 1);
-                }
+        if (supports_destroy_signal(object))
+            record.destroy_id = object.connect('destroy', () => {
+                this.records.delete(object);
+                record.ids.clear();
+                record.destroy_id = null;
             });
-            infos.destroy_id = destroy_id;
-        }
 
-        this.buffer.push(infos);
+        return record;
     }
 
-    /// Disconnects every connection found for an actor.
-    disconnect_all_for(actor) {
-        // get every connection stored for the actor
-        let actor_connections = this.buffer.filter(
-            infos => infos.actor === actor
-        );
+    disconnect_all_for(object) {
+        const record = this.records.get(object);
+        if (!record)
+            return;
 
-        // remove each of them
-        actor_connections.forEach(connection => {
-            // disconnect
-            try {
-                connection.actor.disconnect(connection.id);
-                if ('destroy_id' in connection)
-                    connection.actor.disconnect(connection.destroy_id);
-            } catch (e) {
-                this._warn(`error removing connection: ${e}; continuing`);
-            }
-
-            // remove from buffer
-            let index = this.buffer.indexOf(connection);
-            this.buffer.splice(index, 1);
-        });
+        this.records.delete(object);
+        for (const id of record.ids)
+            this.raw_disconnect(object, id);
+        if (record.destroy_id)
+            this.raw_disconnect(object, record.destroy_id);
     }
 
-    /// Disconnect every connection for each actor.
     disconnect_all() {
-        this.buffer.forEach(connection => {
-            // disconnect
-            try {
-                connection.actor.disconnect(connection.id);
-                if ('destroy_id' in connection)
-                    connection.actor.disconnect(connection.destroy_id);
-            } catch (e) {
-                this._warn(`error removing connection: ${e}; continuing`);
-            }
-        });
+        for (const object of [...this.records.keys()])
+            this.disconnect_all_for(object);
+    }
 
-        // reset buffer
-        this.buffer = [];
+    disconnect(object, id) {
+        const record = this.records.get(object);
+        if (record)
+            record.ids.delete(id);
+
+        this.raw_disconnect(object, id);
+
+        if (record && record.ids.size === 0) {
+            this.records.delete(object);
+            if (record.destroy_id)
+                this.raw_disconnect(object, record.destroy_id);
+        }
+    }
+
+    raw_disconnect(object, id) {
+        try {
+            object.disconnect(id);
+        } catch (error) {
+            this._warn(`error removing connection: ${error}; continuing`);
+        }
     }
 
     _warn(str) {

--- a/src/conveniences/connections.js
+++ b/src/conveniences/connections.js
@@ -76,7 +76,16 @@ export const Connections = class Connections {
     }
 
     raw_disconnect(object, id) {
+        if (!id)
+            return;
+
         try {
+            if (
+                object instanceof GObject.Object
+                && !GObject.signal_handler_is_connected(object, id)
+            )
+                return;
+
             object.disconnect(id);
         } catch (error) {
             this._warn(`error removing connection: ${error}; continuing`);

--- a/src/conveniences/effects_manager.js
+++ b/src/conveniences/effects_manager.js
@@ -4,7 +4,7 @@ import { get_supported_effects } from '../effects/effects.js';
 export const EffectsManager = class EffectsManager {
     constructor(connections) {
         this.connections = connections;
-        this.used = [];
+        this.used = new Set();
         this.SUPPORTED_EFFECTS = get_supported_effects();
 
         Object.keys(this.SUPPORTED_EFFECTS).forEach(effect_name => {
@@ -15,7 +15,7 @@ export const EffectsManager = class EffectsManager {
             this['new_' + effect_name + '_effect'] = function (params) {
                 let effect;
                 if (this[effect_name + '_effects'].length > 0) {
-                    effect = this[effect_name + '_effects'].splice(0, 1)[0];
+                    effect = this[effect_name + '_effects'].pop();
                     effect.set({
                         ...this.SUPPORTED_EFFECTS[effect_name].class.default_params, ...params
                     });
@@ -26,7 +26,7 @@ export const EffectsManager = class EffectsManager {
                     this.connect_to_destroy(effect);
                 }
 
-                this.used.push(effect);
+                this.used.add(effect);
                 return effect;
             };
         });
@@ -60,7 +60,6 @@ export const EffectsManager = class EffectsManager {
         effect._bms_actor_destroy_id = null;
     }
 
-    // IMPORTANT: do never call this in a mutable `this.used.forEach`
     remove(effect, actor_already_destroyed = false) {
         if (!actor_already_destroyed)
             try {
@@ -70,10 +69,7 @@ export const EffectsManager = class EffectsManager {
             }
         this.disconnect_actor_destroy(effect);
 
-        let index = this.used.indexOf(effect);
-        if (index >= 0) {
-            this.used.splice(index, 1);
-
+        if (this.used.delete(effect)) {
             Object.keys(this.SUPPORTED_EFFECTS).forEach(effect_name => {
                 if (effect instanceof this.SUPPORTED_EFFECTS[effect_name].class)
                     this[effect_name + '_effects'].push(effect);

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -64,11 +64,5 @@ const PaintCallbackEffect = GObject.registerClass(
             this._callback?.();
             super.vfunc_paint(node, paint_context, paint_flags);
         }
-
-        vfunc_dispose() {
-            this._callback = null;
-            if (super.vfunc_dispose)
-                super.vfunc_dispose();
-        }
     }
 );

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -1,95 +1,74 @@
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 
+const PAINTS_BETWEEN_REPAINTS = 2;
 
 export const PaintSignals = class PaintSignals {
     constructor(connections) {
-        this.buffer = [];
+        this.entries = new Map();
         this.connections = connections;
     }
 
     connect(actor, blur_effect) {
-        let paint_effect = new EmitPaintSignal();
-        let infos = {
-            actor: actor,
-            paint_effect: paint_effect
-        };
-        let counter = 0;
+        this.disconnect_all_for_actor(actor);
 
-        actor.add_effect(paint_effect);
-        this.connections.connect(paint_effect, 'update-blur', () => {
+        let paints_to_skip = 0;
+        const paint_effect = new PaintCallbackEffect();
+        paint_effect.set_callback(() => {
+            if (paints_to_skip > 0) {
+                paints_to_skip--;
+                return;
+            }
+
+            paints_to_skip = PAINTS_BETWEEN_REPAINTS;
             try {
-                // checking if blur_effect.queue_repaint() has been recently called
-                if (counter === 0) {
-                    counter = 2;
-                    blur_effect.queue_repaint();
-                }
-                else counter--;
+                blur_effect.queue_repaint();
             } catch (e) { }
         });
 
-        // remove the actor from buffer when it is destroyed
-        if (
-            actor.connect &&
-            (
-                !(actor instanceof GObject.Object) ||
-                GObject.signal_lookup('destroy', actor)
-            )
-        )
-            this.connections.connect(actor, 'destroy', () => {
-                const immutable_buffer = [...this.buffer];
-                immutable_buffer.forEach(infos => {
-                    if (infos.actor === actor) {
-                        // remove from buffer
-                        let index = this.buffer.indexOf(infos);
-                        this.buffer.splice(index, 1);
-                    }
-                });
-            });
-
-        this.buffer.push(infos);
+        actor.add_effect(paint_effect);
+        const destroy_id = this.connections.connect(actor, 'destroy', () => {
+            paint_effect.set_callback(null);
+            this.entries.delete(actor);
+        });
+        this.entries.set(actor, { paint_effect, destroy_id });
     }
 
     disconnect_all_for_actor(actor) {
-        const immutable_buffer = [...this.buffer];
-        immutable_buffer.forEach(infos => {
-            if (infos.actor === actor) {
-                this.connections.disconnect_all_for(infos.paint_effect);
-                try {
-                    infos.actor.remove_effect(infos.paint_effect);
-                } catch (e) { }
+        const entry = this.entries.get(actor);
+        if (!entry)
+            return;
 
-                // remove from buffer
-                let index = this.buffer.indexOf(infos);
-                this.buffer.splice(index, 1);
-            }
-        });
+        this.entries.delete(actor);
+        entry.paint_effect.set_callback(null);
+        this.connections.disconnect(actor, entry.destroy_id);
+        try {
+            actor.remove_effect(entry.paint_effect);
+        } catch (e) { }
     }
 
     disconnect_all() {
-        this.buffer.forEach(infos => {
-            this.connections.disconnect_all_for(infos.paint_effect);
-            try {
-                infos.actor.remove_effect(infos.paint_effect);
-            } catch (e) { }
-        });
-
-        this.buffer = [];
+        for (const actor of [...this.entries.keys()])
+            this.disconnect_all_for_actor(actor);
     }
 };
 
-export const EmitPaintSignal = GObject.registerClass({
-    GTypeName: 'EmitPaintSignal',
-    Signals: {
-        'update-blur': {
-            param_types: []
-        },
-    }
-},
-    class EmitPaintSignal extends Clutter.Effect {
+const PaintCallbackEffect = GObject.registerClass(
+    { GTypeName: 'BmsPaintCallbackEffect' },
+    class PaintCallbackEffect extends Clutter.Effect {
+        set_callback(callback) {
+            this._callback = callback;
+        }
+
         vfunc_paint(node, paint_context, paint_flags) {
-            this.emit("update-blur");
+            this._callback?.();
             super.vfunc_paint(node, paint_context, paint_flags);
+        }
+
+        vfunc_dispose() {
+            this._callback = null;
+            if (super.vfunc_dispose)
+                super.vfunc_dispose();
         }
     }
 );

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -45,6 +45,8 @@ export const Pipeline = class Pipeline {
     ) {
         let monitor = Main.layoutManager.monitors[monitor_index];
 
+        this.remove_pipeline_from_actor();
+
         // create the new actor
         this.actor = new St.Widget({
             name: widget_name,
@@ -55,9 +57,6 @@ export const Pipeline = class Pipeline {
             height: monitor.height
         });
 
-        // remove the effects, wether or not we attach the pipeline to the actor: if they are fired
-        // while the actor has changed, this could go bad
-        this.remove_all_effects();
         if (this.pipeline_id)
             this.attach_pipeline_to_actor(this.actor);
 
@@ -119,13 +118,13 @@ export const Pipeline = class Pipeline {
 
     /// Attach a Pipeline object with `pipeline_id` already set to an actor.
     attach_pipeline_to_actor(actor) {
-        // set the actor
-        if (actor)
-            this.actor = actor;
-        else {
+        if (!actor) {
             this.remove_pipeline_from_actor();
             return;
         }
+
+        this.disconnect_actor_signals();
+        this.actor = actor;
 
         // attach the pipeline
         let pipeline = this.pipelines_manager.pipelines[this.pipeline_id];
@@ -149,13 +148,23 @@ export const Pipeline = class Pipeline {
 
     remove_pipeline_from_actor() {
         this.remove_all_effects();
-        if (this.actor && this.actor_destroy_id)
-            this.actor.disconnect(this.actor_destroy_id);
-        if (this.actor && this.child_added_id)
-            this.actor.disconnect(this.child_added_id);
+        this.disconnect_actor_signals();
+        this.actor = null;
+    }
+
+    disconnect_actor_signals() {
+        if (this.actor && this.actor_destroy_id) {
+            try {
+                this.actor.disconnect(this.actor_destroy_id);
+            } catch (e) { }
+        }
+        if (this.actor && this.child_added_id) {
+            try {
+                this.actor.disconnect(this.child_added_id);
+            } catch (e) { }
+        }
         this.actor_destroy_id = null;
         this.child_added_id = null;
-        this.actor = null;
     }
 
     /// Update the effects from the given pipeline object, the hard way.
@@ -346,7 +355,6 @@ export const Pipeline = class Pipeline {
     /// Resets the `Pipeline` object to a sane state, removing every effect and signal.
     /// Note: exposed to public API.
     destroy() {
-        this.remove_all_effects();
         this.remove_connections();
         this.remove_pipeline_from_actor();
         this.pipeline_id = null;

--- a/src/conveniences/pipeline.js
+++ b/src/conveniences/pipeline.js
@@ -123,7 +123,7 @@ export const Pipeline = class Pipeline {
             return;
         }
 
-        this.disconnect_actor_signals();
+        this.disconnect_actor_destroy();
         this.actor = actor;
 
         // attach the pipeline
@@ -148,22 +148,26 @@ export const Pipeline = class Pipeline {
 
     remove_pipeline_from_actor() {
         this.remove_all_effects();
-        this.disconnect_actor_signals();
+        this.disconnect_actor_destroy();
+        this.disconnect_child_added();
         this.actor = null;
     }
 
-    disconnect_actor_signals() {
+    disconnect_actor_destroy() {
         if (this.actor && this.actor_destroy_id) {
             try {
                 this.actor.disconnect(this.actor_destroy_id);
             } catch (e) { }
         }
+        this.actor_destroy_id = null;
+    }
+
+    disconnect_child_added() {
         if (this.actor && this.child_added_id) {
             try {
                 this.actor.disconnect(this.child_added_id);
             } catch (e) { }
         }
-        this.actor_destroy_id = null;
         this.child_added_id = null;
     }
 

--- a/src/conveniences/pipeline_settings.js
+++ b/src/conveniences/pipeline_settings.js
@@ -1,0 +1,136 @@
+import GLib from 'gi://GLib';
+
+function is_plain_object(value) {
+    return value !== null
+        && typeof value === 'object'
+        && value.constructor === Object;
+}
+
+function unpack_string(value, label) {
+    const unpacked = value?.deep_unpack?.();
+    if (typeof unpacked !== 'string')
+        throw new Error(`${label} is not a string`);
+
+    return unpacked;
+}
+
+function unpack_effect(effect_variant) {
+    const effect = effect_variant?.deep_unpack?.();
+    if (!is_plain_object(effect))
+        throw new Error('effect is not an object');
+    if (!('type' in effect))
+        throw new Error('effect has no type');
+    if (!('id' in effect))
+        throw new Error('effect has no id');
+
+    const params = 'params' in effect ? effect.params.deep_unpack() : {};
+    if (!is_plain_object(params))
+        throw new Error('effect params is not an object');
+
+    return {
+        type: unpack_string(effect.type, 'effect type'),
+        id: unpack_string(effect.id, 'effect id'),
+        params: Object.fromEntries(
+            Object.entries(params).map(([key, value]) => [key, value.deep_unpack()])
+        ),
+    };
+}
+
+export function unpack_pipelines(value) {
+    const unpacked = value.deep_unpack();
+    if (!is_plain_object(unpacked))
+        throw new Error('pipelines is not an object');
+
+    const pipelines = {};
+    for (const [pipeline_id, pipeline] of Object.entries(unpacked)) {
+        if (!is_plain_object(pipeline))
+            throw new Error(`pipeline ${pipeline_id} is not an object`);
+        if (!('name' in pipeline))
+            throw new Error(`pipeline ${pipeline_id} has no name`);
+        if (!('effects' in pipeline))
+            throw new Error(`pipeline ${pipeline_id} has no effects`);
+
+        const effects = pipeline.effects.deep_unpack();
+        if (!Array.isArray(effects))
+            throw new Error(`pipeline ${pipeline_id} effects is not an array`);
+
+        pipelines[pipeline_id] = {
+            name: unpack_string(pipeline.name, `pipeline ${pipeline_id} name`),
+            effects: effects.map(unpack_effect),
+        };
+    }
+
+    return pipelines;
+}
+
+function pack_param(value, label) {
+    if (typeof value === 'boolean')
+        return GLib.Variant.new_boolean(value);
+    if (typeof value === 'number')
+        return Number.isInteger(value)
+            ? GLib.Variant.new_int32(value)
+            : GLib.Variant.new_double(value);
+    if (typeof value === 'string')
+        return GLib.Variant.new_string(value);
+    if (
+        Array.isArray(value)
+        && value.length === 4
+        && value.every(component => typeof component === 'number')
+    )
+        return new GLib.Variant('(dddd)', value);
+
+    throw new Error(`${label} has an unsupported type`);
+}
+
+function pack_effect(effect, label) {
+    if (!is_plain_object(effect))
+        throw new Error(`${label} is not an object`);
+    if (typeof effect.type !== 'string')
+        throw new Error(`${label} type is not a string`);
+    if (typeof effect.id !== 'string')
+        throw new Error(`${label} id is not a string`);
+
+    const params = effect.params ?? {};
+    if (!is_plain_object(params))
+        throw new Error(`${label} params is not an object`);
+
+    const packed_params = Object.fromEntries(
+        Object.entries(params).map(([key, value]) => [
+            key,
+            pack_param(value, `${label} parameter ${key}`),
+        ])
+    );
+
+    return new GLib.Variant('a{sv}', {
+        type: GLib.Variant.new_string(effect.type),
+        id: GLib.Variant.new_string(effect.id),
+        params: new GLib.Variant('a{sv}', packed_params),
+    });
+}
+
+export function pack_pipelines(pipelines) {
+    if (!is_plain_object(pipelines))
+        throw new Error('pipelines is not an object');
+
+    const packed = {};
+    for (const [pipeline_id, pipeline] of Object.entries(pipelines)) {
+        if (!is_plain_object(pipeline))
+            throw new Error(`pipeline ${pipeline_id} is not an object`);
+        if (typeof pipeline.name !== 'string')
+            throw new Error(`pipeline ${pipeline_id} name is not a string`);
+        if (!Array.isArray(pipeline.effects))
+            throw new Error(`pipeline ${pipeline_id} effects is not an array`);
+
+        packed[pipeline_id] = {
+            name: GLib.Variant.new_string(pipeline.name),
+            effects: new GLib.Variant(
+                'av',
+                pipeline.effects.map((effect, index) =>
+                    pack_effect(effect, `pipeline ${pipeline_id} effect ${index}`)
+                )
+            ),
+        };
+    }
+
+    return new GLib.Variant('a{sa{sv}}', packed);
+}

--- a/src/conveniences/pipelines_manager.js
+++ b/src/conveniences/pipelines_manager.js
@@ -1,4 +1,22 @@
+import GLib from 'gi://GLib';
+
 const Signals = imports.signals;
+
+function new_id(prefix) {
+    return `${prefix}_${GLib.uuid_string_random()}`;
+}
+
+function clone_effect(effect) {
+    return {
+        ...effect,
+        params: Object.fromEntries(
+            Object.entries(effect.params ?? {}).map(([key, value]) => [
+                key,
+                Array.isArray(value) ? [...value] : value,
+            ])
+        ),
+    };
+}
 
 /// The `PipelinesManager` object permits to store the list of pipelines and their effects in
 /// memory. It is meant to *always* be in sync with the `org.gnome.shell.extensions.blur-my-shell`'s
@@ -36,10 +54,8 @@ export class PipelinesManager {
     }
 
     create_pipeline(name, effects = []) {
-        // select a random id for the pipeline
-        let id = "pipeline_" + ("" + Math.random()).slice(2, 16);
-        // add a random ID for each effect, to help tracking them
-        effects.forEach(effect => effect.id = "effect_" + ("" + Math.random()).slice(2, 16));
+        const id = new_id('pipeline');
+        effects.forEach(effect => effect.id = new_id('effect'));
 
         this.pipelines[id] = { name, effects };
         this.settings.PIPELINES = this.pipelines;
@@ -54,8 +70,10 @@ export class PipelinesManager {
             return;
         }
         const pipeline = this.pipelines[id];
-        this.create_pipeline(pipeline.name + " - duplicate", [...pipeline.effects]);
-        this.settings.PIPELINES = this.pipelines;
+        this.create_pipeline(
+            `${pipeline.name} - duplicate`,
+            pipeline.effects.map(clone_effect)
+        );
     }
 
     delete_pipeline(id) {
@@ -89,7 +107,7 @@ export class PipelinesManager {
             this._warn(`could not rename pipeline, id ${id} does not exist`);
             return;
         }
-        this.pipelines[id].name = name.slice();
+        this.pipelines[id].name = name;
         this.settings.PIPELINES = this.pipelines;
         this._emit(id + '::pipeline-renamed', name);
         this._emit('pipeline-names-changed');
@@ -98,8 +116,18 @@ export class PipelinesManager {
     on_pipeline_update() {
         const old_pipelines = this.pipelines;
         this.pipelines = this.settings.PIPELINES;
+        const old_ids = Object.keys(old_pipelines);
+        const new_ids = Object.keys(this.pipelines);
+        const list_changed = old_ids.length !== new_ids.length
+            || old_ids.some(id => !(id in this.pipelines));
+        let names_changed = false;
 
-        for (var pipeline_id in old_pipelines) {
+        for (const pipeline_id of new_ids) {
+            if (!(pipeline_id in old_pipelines))
+                this._emit('pipeline-created', pipeline_id, this.pipelines[pipeline_id]);
+        }
+
+        for (const pipeline_id of old_ids) {
             // if we find a pipeline that does not exist anymore, signal it
             if (!(pipeline_id in this.pipelines)) {
                 this._emit(pipeline_id + '::pipeline-destroyed');
@@ -108,6 +136,11 @@ export class PipelinesManager {
 
             const old_pipeline = old_pipelines[pipeline_id];
             const new_pipeline = this.pipelines[pipeline_id];
+
+            if (old_pipeline.name !== new_pipeline.name) {
+                this._emit(pipeline_id + '::pipeline-renamed', new_pipeline.name);
+                names_changed = true;
+            }
 
             // verify if both pipelines have effects in the same order
             // if they have, then check for their parameters
@@ -144,6 +177,11 @@ export class PipelinesManager {
             else
                 this._emit(pipeline_id + '::pipeline-updated', new_pipeline);
         }
+
+        if (list_changed)
+            this._emit('pipeline-list-changed');
+        if (names_changed)
+            this._emit('pipeline-names-changed');
     }
 
     destroy() {

--- a/src/conveniences/settings.js
+++ b/src/conveniences/settings.js
@@ -1,4 +1,5 @@
 import GLib from 'gi://GLib';
+import { pack_pipelines, unpack_pipelines } from './pipeline_settings.js';
 const Signals = imports.signals;
 
 /// An enum non-extensively describing the type of gsettings key.
@@ -122,171 +123,20 @@ export const Settings = class Settings {
                     case Type.PIPELINES:
                         Object.defineProperty(component, property_name, {
                             get() {
-                                let pips = component_settings.get_value(key.name).deep_unpack();
-                                Object.keys(pips).forEach(pipeline_id => {
-                                    let pipeline = pips[pipeline_id];
-
-                                    if (!('name' in pipeline)) {
-                                        this._warn('impossible to get pipelines, pipeline has not name, resetting');
-                                        component[property_name + '_reset']();
-                                        return component[property_name];
-                                    }
-                                    let name = pipeline.name.deep_unpack();
-                                    if (typeof name !== 'string') {
-                                        this._warn('impossible to get pipelines, pipeline name is not a string, resetting');
-                                        component[property_name + '_reset']();
-                                        return component[property_name];
-                                    }
-
-                                    if (!('effects' in pipeline)) {
-                                        this._warn('impossible to get pipelines, pipeline has not effects, resetting');
-                                        component[property_name + '_reset']();
-                                        return component[property_name];
-                                    }
-                                    let effects = pipeline.effects.deep_unpack();
-                                    if (!Array.isArray(effects)) {
-                                        this._warn('impossible to get pipelines, pipeline effects is not an array, resetting');
-                                        component[property_name + '_reset']();
-                                        return component[property_name];
-                                    }
-
-                                    effects = effects.map(effect => effect.deep_unpack());
-                                    effects.forEach(effect => {
-                                        if (!('type' in effect)) {
-                                            this._warn('impossible to get pipelines, effect has not type, resetting');
-                                            component[property_name + '_reset']();
-                                            return component[property_name];
-                                        }
-                                        let type = effect.type.deep_unpack();
-                                        if (typeof type !== 'string') {
-                                            this._warn('impossible to get pipelines, effect type is not a string, resetting');
-                                            component[property_name + '_reset']();
-                                            return component[property_name];
-                                        }
-
-                                        if (!('id' in effect)) {
-                                            this._warn('impossible to get pipelines, effect has not id, resetting');
-                                            component[property_name + '_reset']();
-                                            return component[property_name];
-                                        }
-                                        let id = effect.id.deep_unpack();
-                                        if (typeof id !== 'string') {
-                                            this._warn('impossible to get pipelines, effect id is not a string, resetting');
-                                            component[property_name + '_reset']();
-                                            return component[property_name];
-                                        }
-
-                                        let params = {};
-                                        if ('params' in effect)
-                                            params = effect.params.deep_unpack();
-                                        if (!(params && typeof params === 'object' && params.constructor === Object)) {
-                                            this._warn('impossible to get pipelines, effect params is not an object, resetting');
-                                            component[property_name + '_reset']();
-                                            return component[property_name];
-                                        }
-                                        Object.keys(params).forEach(param_key => {
-                                            params[param_key] = params[param_key].deep_unpack();
-                                        });
-
-                                        effect.type = type;
-                                        effect.id = id;
-                                        effect.params = params;
-                                    });
-                                    pipeline.name = name;
-                                    pipeline.effects = effects;
-                                });
-                                return pips;
+                                try {
+                                    return unpack_pipelines(component_settings.get_value(key.name));
+                                } catch (error) {
+                                    this._warn(`impossible to get pipelines, resetting: ${error.message}`);
+                                    component_settings.reset(key.name);
+                                    return unpack_pipelines(component_settings.get_value(key.name));
+                                }
                             },
-                            set(pips) {
-                                let pipelines = {};
-                                Object.keys(pips).forEach(pipeline_id => {
-                                    let pipeline = pips[pipeline_id];
-                                    if (!(pipeline && typeof pipeline === 'object' && pipeline.constructor === Object)) {
-                                        this._warn('impossible to set pipelines, pipeline is not an object');
-                                        return;
-                                    }
-
-                                    if (!('name' in pipeline)) {
-                                        this._warn('impossible to set pipelines, pipeline has no name');
-                                        return;
-                                    }
-                                    if (typeof pipeline.name !== 'string') {
-                                        this._warn('impossible to set pipelines, pipeline name is not a string');
-                                        return;
-                                    }
-
-                                    if (!('effects' in pipeline)) {
-                                        this._warn('impossible to set pipelines, pipeline has no effect');
-                                        return;
-                                    }
-                                    if (!Array.isArray(pipeline.effects)) {
-                                        this._warn('impossible to set pipelines, effects is not an array');
-                                        return;
-                                    }
-
-                                    let gvariant_effects = [];
-                                    pipeline.effects.forEach(effect => {
-                                        if (!(effect instanceof Object)) {
-                                            this._warn('impossible to set pipelines, effect is not an object');
-                                            return;
-                                        }
-
-                                        if (!('type' in effect)) {
-                                            this._warn('impossible to set pipelines, effect has not type');
-                                            return;
-                                        }
-                                        if (typeof effect.type !== 'string') {
-                                            this._warn('impossible to set pipelines, effect type is not a string');
-                                            return;
-                                        }
-
-                                        if (!('id' in effect)) {
-                                            this._warn('impossible to set pipelines, effect has not id');
-                                            return;
-                                        }
-                                        if (typeof effect.id !== 'string') {
-                                            this._warn('impossible to set pipelines, effect id is not a string');
-                                            return;
-                                        }
-
-                                        let params = {};
-                                        if ('params' in effect) {
-                                            params = effect.params;
-                                        }
-                                        let gvariant_params = {};
-                                        Object.keys(params).forEach(param_key => {
-                                            let param = params[param_key];
-                                            if (typeof param === 'boolean')
-                                                gvariant_params[param_key] = GLib.Variant.new_boolean(param);
-                                            else if (typeof param === 'number') {
-                                                if (Number.isInteger(param))
-                                                    gvariant_params[param_key] = GLib.Variant.new_int32(param);
-                                                else
-                                                    gvariant_params[param_key] = GLib.Variant.new_double(param);
-                                            } else if (typeof param === 'string')
-                                                gvariant_params[param_key] = GLib.Variant.new_string(param);
-                                            else if (Array.isArray(param) && param.length == 4)
-                                                gvariant_params[param_key] = new GLib.Variant("(dddd)", param);
-                                            else
-                                                this._warn('impossible to set pipeline, effect parameter type is unknown');
-                                        });
-
-                                        gvariant_effects.push(
-                                            new GLib.Variant("a{sv}", {
-                                                type: GLib.Variant.new_string(effect.type),
-                                                id: GLib.Variant.new_string(effect.id),
-                                                params: new GLib.Variant("a{sv}", gvariant_params)
-                                            })
-                                        );
-                                    });
-
-                                    pipelines[pipeline_id] = {
-                                        name: GLib.Variant.new_string(pipeline.name),
-                                        effects: new GLib.Variant("av", gvariant_effects)
-                                    };
-                                });
-                                let val = new GLib.Variant("a{sa{sv}}", pipelines);
-                                component_settings.set_value(key.name, val);
+                            set(pipelines) {
+                                try {
+                                    component_settings.set_value(key.name, pack_pipelines(pipelines));
+                                } catch (error) {
+                                    this._warn(`impossible to set pipelines: ${error.message}`);
+                                }
                             }
                         });
                         break;

--- a/src/dbus/services.js
+++ b/src/dbus/services.js
@@ -55,7 +55,7 @@ export const ApplicationsService = class ApplicationsService {
 
         // inspect window now
         const inspector = new LookingGlass.Inspector(Main.createLookingGlass());
-        inspector.connect('target', (me, target, x, y) => {
+        inspector.connect('target', (me, target, _x, _y) => {
             // remove border effect when window is picked.
             const effect_name = 'lookingGlass_RedBorderEffect';
             target

--- a/src/effects/effect_groups.js
+++ b/src/effects/effect_groups.js
@@ -1,0 +1,31 @@
+export function get_effects_groups(_ = _ => '') {
+    return {
+        blur_effects: {
+            name: _('Blur effects'),
+            contains: [
+                'native_static_gaussian_blur',
+                'gaussian_blur',
+                'monte_carlo_blur',
+            ],
+        },
+        texture_effects: {
+            name: _('Texture effects'),
+            contains: [
+                'downscale',
+                'upscale',
+                'pixelize',
+                'refraction',
+                'derivative',
+                'noise',
+                'color',
+                'luminosity',
+                'rgb_to_hsl',
+                'hsl_to_rgb',
+            ],
+        },
+        shape_effects: {
+            name: _('Shape effects'),
+            contains: ['corner'],
+        },
+    };
+}

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -13,42 +13,7 @@ import { RgbToHslEffect } from './rgb_to_hsl.js';
 import { HslToRgbEffect } from './hsl_to_rgb.js';
 import { LuminosityEffect } from './luminosity.js';
 import { RefractionEffect } from './refraction.js';
-
-// We do in this way because I've not found another way to store our preferences in a dictionnary
-// while calling `gettext` on it while in preferences. Not so pretty, but works.
-export function get_effects_groups(_ = _ => "") {
-    return {
-        blur_effects: {
-            name: _("Blur effects"),
-            contains: [
-                "native_static_gaussian_blur",
-                "gaussian_blur",
-                "monte_carlo_blur"
-            ]
-        },
-        texture_effects: {
-            name: _("Texture effects"),
-            contains: [
-                "downscale",
-                "upscale",
-                "pixelize",
-                "refraction",
-                "derivative",
-                "noise",
-                "color",
-                "luminosity",
-                "rgb_to_hsl",
-                "hsl_to_rgb"
-            ]
-        },
-        shape_effects: {
-            name: _("Shape effects"),
-            contains: [
-                "corner"
-            ]
-        }
-    };
-};
+export { get_effects_groups } from './effect_groups.js';
 
 export function get_supported_effects(_ = () => "") {
     return {

--- a/src/effects/native_static_gaussian_blur.js
+++ b/src/effects/native_static_gaussian_blur.js
@@ -20,7 +20,11 @@ export const NativeStaticBlurEffect = utils.IS_IN_PREFERENCES ?
                 normalized_params.unscaled_radius = normalized_params.radius;
             delete normalized_params.radius;
 
-            const { unscaled_radius, brightness, ...parent_params } = normalized_params;
+            const {
+                unscaled_radius: _unscaled_radius,
+                brightness: _brightness,
+                ...parent_params
+            } = normalized_params;
             super({ ...parent_params, mode: Shell.BlurMode.ACTOR });
 
             this._theme_context = St.ThemeContext.get_for_stage(global.stage);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -203,7 +203,11 @@ const REFRACTION_EFFECT_META = {
 const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionEffect extends Clutter.ShaderEffect {
 
         constructor(params) {
-            const { webcam_gloss, webcam_device, ...parent_params } = params;
+            const {
+                webcam_gloss: _webcam_gloss,
+                webcam_device: _webcam_device,
+                ...parent_params
+            } = params;
             super({ ...parent_params });
             utils.initialize_shader_effect(this, SHADER_SOURCE);
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -166,7 +166,8 @@ export default class BlurMyShell extends Extension {
             this._disable_user_session();
         this._overview_blur.restore_patched_proto();
 
-        // disable lockscreen blur too
+        // disable components that stay active outside the user session
+        this._popup.disable();
         this._lockscreen_blur.disable();
 
         // untrack them

--- a/src/preferences/pipelines_management/pipeline_choose_row.js
+++ b/src/preferences/pipelines_management/pipeline_choose_row.js
@@ -73,7 +73,10 @@ export const PipelineChooseRow = GObject.registerClass({
             const pipeline_id = this._pipeline_model.get_string(i);
             // if we have more pipelines than we should have: rebuild...
             // that is the case when resetting the preferences for example
-            if (!(pipeline_id in this.pipelines_manager)) {
+            if (
+                pipeline_id !== 'create_new'
+                && !(pipeline_id in this.pipelines_manager.pipelines)
+            ) {
                 this.create_pipelines_list();
                 return;
             }


### PR DESCRIPTION
## Summary

- make pipeline settings parsing and serialization atomic
- prevent duplicated pipelines from sharing or mutating effect data
- correctly synchronize externally created, renamed, and removed pipelines
- fix pipeline actor signal cleanup and redundant effect removal
- group managed connections by object instead of installing a destroy handler per signal
- remove the per-frame GObject signal round-trip from dynamic blur repaint handling
- reuse app-folder blur effects and replace legacy Tweener animation with `Clutter.Timeline`
- use constant-time effect pool operations
- fix unnecessary pipeline selector list rebuilding
- remove dead code and split pipeline serialization and effect-group metadata into focused modules

## Why

Several runtime helpers had accumulated avoidable allocations, duplicate signal handlers, and validation paths that could continue after encountering malformed data. Pipeline duplication could also mutate the original pipeline because effect objects were shared.

This refactor tightens those lifecycle boundaries while preserving the existing dynamic blur repaint workaround and GNOME 46–51 compatibility.