### PR TITLE
refine notifcard expand/collapse look and feel for Popup Blur mode ON

### DIFF
--- a/src/components/popup/message_stacks.js
+++ b/src/components/popup/message_stacks.js
@@ -411,8 +411,6 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
             if (this.original_message_opacity.has(message)) {
                 message.opacity = this.original_message_opacity.get(message);
                 this.original_message_opacity.delete(message);
-            } else {
-                message.opacity = 255;
             }
         } catch (e) { }
     }
@@ -616,6 +614,7 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
         this.destroyed_actors = new WeakSet();
         this.bms_clipped = new WeakSet();
         this.original_opacity = new WeakMap();
+        this.original_message_opacity = new WeakMap();
         this.enabled = false;
     }
 };

--- a/src/components/popup/message_stacks.js
+++ b/src/components/popup/message_stacks.js
@@ -18,6 +18,7 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
         this.group_connections = new Map();
         this.update_ids = new Map();
         this.original_opacity = new WeakMap();
+        this.original_message_opacity = new WeakMap();
         this.enabled = false;
     }
 
@@ -139,7 +140,10 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
         if (group.layout_manager) {
             const lm = group.layout_manager;
             try {
-                const id = lm.connect('notify::expansion', () => this.update_group_header(group));
+                const id = lm.connect('notify::expansion', () => {
+                    this.update_group_header(group);
+                    this.update_group_messages(group);
+                });
                 this.group_connections.set(group, { lm, id });
             } catch (e) { }
         }
@@ -157,8 +161,14 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
     }
 
     update_all() {
-        this.messages.forEach(message => this.update_message(message));
-        this.groups.forEach(group => this.update_group_header(group));
+        this.groups.forEach(group => {
+            this.update_group_header(group);
+            this.update_group_messages(group);
+        });
+        this.messages.forEach(message => {
+            if (!this.get_message_group(message))
+                this.update_message(message);
+        });
     }
 
     update_group_header(group) {
@@ -175,6 +185,31 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
 
             header.opacity = target_opacity;
         } catch (e) { }
+    }
+
+    get_group_messages(group) {
+        const list = [];
+        const find_messages = actor => {
+            if (this.has_style_class(actor, 'message')) {
+                list.push(actor);
+                return;
+            }
+            this.get_children(actor).forEach(find_messages);
+        };
+        find_messages(group);
+        return list;
+    }
+
+    update_group_messages(group) {
+        if (!this.enabled || !this.watch_actor(group))
+            return;
+
+        const expansion = group.layout_manager?.expansion ?? (group.expanded ? 1.0 : 0.0);
+        const messages = this.get_group_messages(group);
+
+        messages.forEach((message, index) => {
+            this.update_message_with_expansion(message, index, expansion, group);
+        });
     }
 
     queue_update_all() {
@@ -204,14 +239,73 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
         }
 
         const group = this.get_message_group(message);
-        const is_expanded = group ? group.expanded : this.is_in_expanded_group(message);
+        if (group) {
+            const expansion = group.layout_manager?.expansion ?? (group.expanded ? 1.0 : 0.0);
+            const index = this.get_message_index_in_group(message);
+            this.update_message_with_expansion(message, index >= 0 ? index : 0, expansion, group);
+        } else {
+            const is_expanded = this.is_in_expanded_group(message);
+            if (this.is_stacked(message) && !is_expanded) {
+                this.apply_stack_mask(message);
+                this.hide_message_content(message);
+                this.restore_message_opacity(message);
+            } else {
+                this.remove_stack_mask(message);
+            }
+        }
+    }
 
-        if (this.is_stacked(message) && !is_expanded) {
+    update_message_with_expansion(message, index, expansion, group) {
+        if (!this.enabled || !this.watch_actor(message))
+            return;
+
+        const is_stacked = this.is_stacked(message) || index > 0;
+
+        if (!is_stacked) {
+            this.remove_stack_mask(message);
+            return;
+        }
+
+        if (expansion >= 0.99) {
+            this.remove_stack_mask(message);
+            return;
+        }
+
+        if (expansion <= 0.01) {
             this.apply_stack_mask(message);
             this.hide_message_content(message);
-        } else {
-            this.remove_stack_mask(message);
+            this.restore_message_opacity(message);
+            return;
         }
+
+        // 0.01 < expansion < 0.99: Animating unravel / collapse
+        try {
+            const height = message.height || message.get_height() || 0;
+            const width = message.width || message.get_width() || 0;
+
+            if (height <= 0 || width <= 0)
+                return;
+
+            const base_edge = (index === 1) ? 10 : (index === 2 ? 7 : 0);
+            const visible_edge = Math.round(base_edge + (height - base_edge) * expansion);
+            const clip_y = Math.max(0, height - visible_edge);
+
+            message.set_clip(0, clip_y, width, visible_edge);
+            this.bms_clipped.add(message);
+
+            // Staggered opacity progress for cards so they smoothly fade in as they unravel
+            const stagger_start = Math.min(0.8, index * 0.04);
+            const progress = Math.min(1.0, Math.max(0.0, (expansion - stagger_start) / (1.0 - stagger_start)));
+            const target_alpha = Math.round(255 * progress);
+
+            this.set_child_opacity(message, target_alpha);
+
+            if (index >= 3) {
+                this.set_message_opacity(message, target_alpha);
+            } else {
+                this.restore_message_opacity(message);
+            }
+        } catch (e) { }
     }
 
     apply_stack_mask(message) {
@@ -266,9 +360,10 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
         }
 
         this.restore_message_content(message);
+        this.restore_message_opacity(message);
     }
 
-    hide_message_content(message) {
+    set_child_opacity(message, opacity) {
         const child = this.get_child(message);
         if (!child)
             return;
@@ -277,8 +372,12 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
             if (!this.original_opacity.has(child))
                 this.original_opacity.set(child, child.opacity ?? 255);
 
-            child.opacity = 0;
+            child.opacity = opacity;
         } catch (e) { }
+    }
+
+    hide_message_content(message) {
+        this.set_child_opacity(message, 0);
     }
 
     restore_message_content(message) {
@@ -290,6 +389,30 @@ export const PopupBlurMessageStacks = class PopupBlurMessageStacks {
             if (this.original_opacity.has(child)) {
                 child.opacity = this.original_opacity.get(child);
                 this.original_opacity.delete(child);
+            }
+        } catch (e) { }
+    }
+
+    set_message_opacity(message, opacity) {
+        if (!this.watch_actor(message))
+            return;
+        try {
+            if (!this.original_message_opacity.has(message))
+                this.original_message_opacity.set(message, message.opacity ?? 255);
+
+            message.opacity = opacity;
+        } catch (e) { }
+    }
+
+    restore_message_opacity(message) {
+        if (!message || this.destroyed_actors.has(message))
+            return;
+        try {
+            if (this.original_message_opacity.has(message)) {
+                message.opacity = this.original_message_opacity.get(message);
+                this.original_message_opacity.delete(message);
+            } else {
+                message.opacity = 255;
             }
         } catch (e) { }
     }


### PR DESCRIPTION
## Description
This PR resolves visual artifacts and harsh color flashes when expanding or collapsing notification card stacks with translucent background styling and especially when Popup Blur is ON.

### Problem
Previously, when expanding a collapsed notification group, `remove_stack_mask()` was invoked immediately at the start of the expansion transition. This unclipped all 10–20 notification cards and restored their content opacities to 100% while they were still stacked on top of each other at the top of the list. As a result, 10–20 translucent card background layers accumulated simultaneously, producing a bright, solid color flash during the unraveling animation. Similarly, during collapse, cards were visibly masked while sliding upward.

### Solution
- **Expansion-Aware Tracking**: Connected `notify::expansion` on the layout manager to track `expansion` frame-by-frame ($0.0 \to 1.0$) during the transition animation.
- **Dynamic Clip & Opacity Interpolation**:
  - `0.01 < expansion < 0.99`: Clip heights expand dynamically in sync with the layout animation, while card content and background opacities are staggered and faded in proportionally to `expansion`.
  - `expansion >= 0.99`: Removes clips cleanly and enforces 100% opacities once fully unravelled.
  - `expansion <= 0.01`: Restores the tight collapsed mask heights and hidden child opacities.

### Benefits
- **Zero Alpha Pile-up**: Prevents translucent background accumulation during group unraveling.
- **Smooth Collapsing**: Cards shrink clips and fade out gracefully when bundling back up, eliminating "masked cards flying upward" glitches.
- **High Performance**: Performs basic math in JS without triggering layout reflows or CSS invalidations; reduces GPU overdraw during transitions.

### Before:
<img width="501" height="270" alt="Screenshot From 2026-08-06 22-36-10" src="https://github.com/user-attachments/assets/3b92bf34-415f-4e7d-be66-f8bee76f02d2" />
<img width="503" height="682" alt="Screenshot From 2026-08-06 22-12-06" src="https://github.com/user-attachments/assets/3e59107a-0c45-4906-b83e-a32ecb884e32" />

### After (Behavior of both Expand and Collapse):
<img width="506" height="772" alt="Screenshot From 2026-08-06 22-38-55" src="https://github.com/user-attachments/assets/4651430d-7f04-4b62-8245-bbd3956b0cf2" />

