### PR TITLE
Additional Popup blur fixes

### DIFF
--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -157,13 +157,13 @@ export const PopupBlurSurface = class PopupBlurSurface {
     
 
     is_quick_settings() {
-        return this.style.has_any_style_class(this.target, ['quick-toggle-menu','quick-settings'])
-            || this.style.has_any_style_class(this.root_actor, ['quick-toggle-menu','quick-settings']);
+        return this.style.has_any_style_class(this.target, ['quick-toggle-menu','quick-settings','datemenu-popover'])
+            || this.style.has_any_style_class(this.root_actor, ['quick-toggle-menu','quick-settings','datemenu-popover']);
     }
 
     is_heavy_surface() {
-        return this.style.has_any_style_class(this.target, ['datemenu-popover','quick-settings','modal-dialog'])
-            || this.style.has_any_style_class(this.root_actor, ['datemenu-popover','quick-settings','modal-dialog']);
+        return this.style.has_any_style_class(this.target, ['datemenu-popover','quick-settings','modal-dialog','candidate-popup-content', 'candidate-popup-boxpointer'])
+            || this.style.has_any_style_class(this.root_actor, ['datemenu-popover','quick-settings','modal-dialog','candidate-popup-content', 'candidate-popup-boxpointer']);
     }
 
     update() {

--- a/src/components/popup/surface_placement.js
+++ b/src/components/popup/surface_placement.js
@@ -139,10 +139,10 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
         this.monitor_index = match.monitor_index;
 
         const surface_geometry = this.create_surface_geometry(
-            match.intersection.x,
-            match.intersection.y,
-            match.intersection.width,
-            match.intersection.height
+            rect.x,
+            rect.y,
+            rect.width,
+            rect.height
         );
         surface_geometry.monitor_index = match.monitor_index;
         return surface_geometry;

--- a/src/components/popup/surface_signals.js
+++ b/src/components/popup/surface_signals.js
@@ -19,25 +19,7 @@ const SURFACE_SIGNALS = [
     'notify::scale-y',
     'notify::pseudo-class',
     'style-changed',
-];
-
-const ANCESTOR_SIGNALS = [
-    'notify::allocation',
-    'notify::position',
-    'notify::size',
-    'notify::x',
-    'notify::y',
-    'notify::width',
-    'notify::height',
-    'notify::clip-rect',
-    'notify::visible',
-    'notify::mapped',
-    'notify::translation-x',
-    'notify::translation-y',
-    'notify::scale-x',
-    'notify::scale-y',
-    'notify::pseudo-class',
-];
+]; 
 
 export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
     constructor(surface) {
@@ -47,7 +29,7 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         this.destroyed_actors = new WeakSet();
     }
 
-    connect_actor(actor, is_ancestor = false) {
+    connect_actor(actor) {
         if (!actor || this.signal_actors.has(actor))
             return;
 
@@ -55,9 +37,8 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         this.track_destroy(actor);
 
         const is_heavy_surface = this.surface.is_heavy_surface();
-        const signals_to_use = is_ancestor ? ANCESTOR_SIGNALS : SURFACE_SIGNALS;
 
-        signals_to_use.forEach(signal => {
+        SURFACE_SIGNALS.forEach(signal => {
             try {
             let id = actor.connect(signal, () => {
                 this.clear_pending_idles();
@@ -94,7 +75,7 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         }
 
         while (actor && actor !== this.surface.parent) {
-            this.connect_actor(actor, true);
+            this.connect_actor(actor);
             try {
                 actor = actor.get_parent?.();
             } catch (e) {

--- a/src/styles/popup/base.css
+++ b/src/styles/popup/base.css
@@ -9,7 +9,6 @@
 .bms-popup-background-transparent .candidate-popup-content,
 .bms-popup-background-transparent .quick-settings,
 .bms-popup-background-transparent .quick-toggle-menu,
-.bms-popup-background-transparent .message,
 .bms-popup-background-transparent .osd-window,
 .bms-popup-background-transparent .resize-popup,
 .bms-popup-background-transparent .switcher-list,
@@ -50,7 +49,8 @@
 .bms-popup-background-dark .switcher-list,
 .bms-popup-background-dark .workspace-switcher,
 .bms-popup-background-dark .modal-dialog,
-.bms-popup-background-dark .run-dialog {
+.bms-popup-background-dark .run-dialog,
+.bms-popup-background-transparent .message {
     color: #ffffff;
     background: rgba(45, 45, 50, 0.22) !important;
     border-color: transparent;
@@ -60,16 +60,6 @@
 .bms-popup-background-transparent .message,
 .bms-popup-background-light .message,
 .bms-popup-background-dark .message {
-    box-shadow: none;
-}
-
-.bms-popup-background-transparent .message:second-in-stack {
-    background: rgba(58, 58, 64, 0.2) !important;
-    box-shadow: 0 1px 1px 0 transparent;
-}
-
-.bms-popup-background-transparent .message:lower-in-stack {
-    background: rgba(48, 48, 54, 0.14) !important;
     box-shadow: none;
 }
 

--- a/src/styles/popup/transparent.css
+++ b/src/styles/popup/transparent.css
@@ -1,3 +1,35 @@
+.bms-popup-background-transparent .message:second-in-stack {
+    background: rgba(35, 35, 40, 0.3) !important;
+    box-shadow: 0 1px 1px 0 transparent;
+}
+
+.bms-popup-background-transparent .message:lower-in-stack {
+    background: rgba(35, 35, 40, 0.2) !important;
+    box-shadow: none;
+}
+
+.bms-popup-background-transparent .message-list-controls .message-list-clear-button {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+.bms-popup-background-transparent .message-list-controls .message-list-clear-button:hover,
+.bms-popup-background-transparent .message-list-controls .message-list-clear-button:focus {
+    background-color: rgba(255, 255, 255, 0.13) !important;
+}
+
+.bms-popup-background-transparent .message-list-controls .message-list-clear-button:active {
+    background-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+.bms-popup-background-transparent .quick-toggle,
+.bms-popup-background-transparent .quick-toggle-has-menu .quick-toggle-menu-button,
+.bms-popup-background-transparent .notification-button {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.11) !important;
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
 .bms-popup-background-transparent .quick-settings .icon-button,
 .bms-popup-background-transparent .quick-settings-system-item .button,
 .bms-popup-background-transparent .quick-settings-system-item .power-item {
@@ -5,6 +37,12 @@
     background-color: rgba(255, 255, 255, 0.08) !important;
     border-color: rgba(255, 255, 255, 0.06);
     box-shadow: none;
+}
+
+.bms-popup-background-transparent .quick-toggle:hover,
+.bms-popup-background-transparent .quick-toggle-has-menu .quick-toggle-menu-button:hover,
+.bms-popup-background-transparent .notification-button:hover {
+    background-color: rgba(255, 255, 255, 0.18) !important;
 }
 
 .bms-popup-background-transparent .quick-settings .icon-button:hover,
@@ -19,7 +57,103 @@
 .bms-popup-background-transparent .quick-settings .icon-button:active,
 .bms-popup-background-transparent .quick-settings-system-item .button:active,
 .bms-popup-background-transparent .quick-settings-system-item .power-item:active {
-    background-color: rgba(255, 255, 255, 0.17) !important;
+    background-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+.bms-popup-background-transparent .calendar {
+    color: #ffffff;
+    background-color: transparent;
+    border-color: transparent;
+    box-shadow: none;
+}
+
+.bms-popup-background-transparent .datemenu-today-button {
+    background-color: transparent !important;
+    box-shadow: none;
+}
+
+.bms-popup-background-transparent .datemenu-today-button:hover,
+.bms-popup-background-transparent .datemenu-today-button:focus {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+.bms-popup-background-transparent .datemenu-today-button:active,
+.bms-popup-background-transparent .datemenu-today-button:checked {
+    background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.bms-popup-background-transparent .datemenu-today-button StLabel,
+.bms-popup-background-transparent .datemenu-today-button .date-label {
+    color: #ffffff !important;
+}
+
+.bms-popup-background-transparent .datemenu-today-button .day-label {
+    color: rgba(255, 255, 255, 0.68) !important;
+}
+
+.bms-popup-background-transparent .events-button,
+.bms-popup-background-transparent .world-clocks-button,
+.bms-popup-background-transparent .weather-button {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.07) !important;
+    border-color: rgba(255, 255, 255, 0.05);
+    box-shadow: none;
+}
+
+.bms-popup-background-transparent .events-button:hover,
+.bms-popup-background-transparent .world-clocks-button:hover,
+.bms-popup-background-transparent .weather-button:hover {
+    background-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.bms-popup-background-transparent .calendar .calendar-month-header .calendar-month-label,
+.bms-popup-background-transparent .calendar .calendar-month-header .pager-button {
+    color: #ffffff !important;
+    background-color: transparent !important;
+    box-shadow: none;
+}
+
+.bms-popup-background-transparent .calendar .calendar-day-heading,
+.bms-popup-background-transparent .calendar .calendar-day {
+    color: #ffffff !important;
+    background-color: transparent !important;
+    box-shadow: none;
+}
+
+.bms-popup-background-transparent .calendar .calendar-day-heading {
+    color: rgba(255, 255, 255, 0.68) !important;
+}
+
+.bms-popup-background-transparent .calendar .calendar-day.calendar-weekend {
+    color: rgba(255, 255, 255, 0.68) !important;
+}
+
+.bms-popup-background-transparent .calendar .calendar-day.calendar-other-month,
+.bms-popup-background-transparent .calendar .calendar-day.calendar-other-month.calendar-weekend {
+    color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.bms-popup-background-transparent .calendar-day:selected,
+.bms-popup-background-transparent .calendar-day:checked,
+.bms-popup-background-transparent .calendar-day.calendar-today {
+    color: #ffffff !important;
+    background-color: #3584e4 !important;
+    color: -st-accent-fg-color !important;
+    background-color: -st-accent-color !important;
+}
+
+.bms-popup-background-transparent .calendar .calendar-day:hover,
+.bms-popup-background-transparent .calendar .calendar-month-header .pager-button:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.bms-popup-background-transparent .calendar-day:selected:hover,
+.bms-popup-background-transparent .calendar-day:checked:hover,
+.bms-popup-background-transparent .calendar-day.calendar-today:hover {
+    color: #ffffff !important;
+    background-color: #4990e7 !important;
+    color: -st-accent-fg-color !important;
+    background-color: st-lighten(-st-accent-color, 4%) !important;
 }
 
 .bms-popup-background-transparent .quick-toggle:checked,
@@ -54,64 +188,7 @@
     background-color: st-lighten(st-mix(-st-accent-color, #ffffff, 85%), 4%) !important;
 }
 
-.bms-popup-background-transparent .message-list-controls .message-list-clear-button {
-    color: #ffffff;
-    background-color: rgba(255, 255, 255, 0.08) !important;
-}
-
-.bms-popup-background-transparent .message-list-controls .message-list-clear-button:hover,
-.bms-popup-background-transparent .message-list-controls .message-list-clear-button:focus {
-    background-color: rgba(255, 255, 255, 0.13) !important;
-}
-
-.bms-popup-background-transparent .message-list-controls .message-list-clear-button:active {
-    background-color: rgba(255, 255, 255, 0.17) !important;
-}
-
-.bms-popup-background-transparent .datemenu-today-button {
-    background-color: transparent !important;
-    box-shadow: none;
-}
-
-.bms-popup-background-transparent .datemenu-today-button:hover,
-.bms-popup-background-transparent .datemenu-today-button:focus {
-    background-color: rgba(255, 255, 255, 0.08) !important;
-}
-
-.bms-popup-background-transparent .datemenu-today-button:active,
-.bms-popup-background-transparent .datemenu-today-button:checked {
-    background-color: rgba(255, 255, 255, 0.12) !important;
-}
-
-.bms-popup-background-transparent .calendar .calendar-month-header .calendar-month-label,
-.bms-popup-background-transparent .calendar .calendar-month-header .pager-button,
-.bms-popup-background-transparent .calendar .calendar-day-heading,
-.bms-popup-background-transparent .calendar .calendar-day {
-    background-color: transparent !important;
-    box-shadow: none;
-}
-
-.bms-popup-background-transparent .calendar .calendar-day:hover,
-.bms-popup-background-transparent .calendar .calendar-day:focus,
-.bms-popup-background-transparent .calendar .calendar-month-header .pager-button:hover,
-.bms-popup-background-transparent .calendar .calendar-month-header .pager-button:focus {
-    background-color: rgba(255, 255, 255, 0.08) !important;
-}
-
-.bms-popup-background-transparent .calendar .calendar-day:active,
-.bms-popup-background-transparent .calendar .calendar-day:selected,
-.bms-popup-background-transparent .calendar .calendar-day:checked {
-    background-color: rgba(255, 255, 255, 0.12) !important;
-}
-
-.bms-popup-background-transparent .calendar .calendar-day.calendar-today,
-.bms-popup-background-transparent .calendar .calendar-day.calendar-today:hover,
-.bms-popup-background-transparent .calendar .calendar-day.calendar-today:focus,
-.bms-popup-background-transparent .calendar .calendar-day.calendar-today:active,
-.bms-popup-background-transparent .calendar .calendar-day.calendar-today:selected,
-.bms-popup-background-transparent .calendar .calendar-day.calendar-today:checked {
-    color: #ffffff !important;
-    background-color: #3584e4 !important;
-    color: -st-accent-fg-color !important;
-    background-color: -st-accent-color !important;
+.bms-popup-background-transparent .quick-toggle-has-menu:checked .quick-toggle-separator {
+    background-color: rgba(255, 255, 255, 0.3);
+    background-color: st-mix(-st-accent-fg-color, -st-accent-color, 30%);
 }


### PR DESCRIPTION
This is mostly just cleaning up the mess I've made in previous PR

- Added `candidate-popup-content` and `candidate-popup-boxpointer` to `is_heavy_surface()` to fix https://github.com/aunetx/blur-my-shell/issues/953. This is mostly tested with ibus-mozc so for other IME, millage may vary

https://github.com/user-attachments/assets/c0408575-da0c-4aae-bd63-19439d131ec2

- Removed the old ancestor check path since skipping descendant transition scans for QS help more here. Also fixed Window switcher (alt+tab) and monitor mode popup not being blurred
- Also skipping descendant transition scans for `datemenu-popover` as well. 

- `get_monitor_clipped_surface_geometry()` now return `rect` to allow the blur to properly overflow outside of current monitor without being stop at the monitor boundary
<img width="417" height="1101" alt="image" src="https://github.com/user-attachments/assets/7d976d47-0e56-49f0-8946-60e46f08c0b8" />

https://github.com/user-attachments/assets/2020e4fc-bc4b-42db-a11f-abcc3d49e518

- Copy dark stylesheet to transparent stylesheet to at least make Transparent override look less unfinished & improve visibility as well 
<img width="501" height="673" alt="image" src="https://github.com/user-attachments/assets/1578e560-7814-4ede-bb79-307df2077cb1" />


