### PR TITLE
Add option to preserve shell theme for popup backgrounds

### DIFF
--- a/resources/ui/popup.ui
+++ b/resources/ui/popup.ui
@@ -184,6 +184,20 @@
 
             <child>
               <object class="AdwActionRow">
+                <property name="title" translatable="yes">Preserve shell theme</property>
+                <property name="subtitle" translatable="yes">Keep your shell theme's colors for popup controls.</property>
+                <property name="activatable-widget">preserve_shell_theme</property>
+
+                <child>
+                  <object class="GtkSwitch" id="preserve_shell_theme">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+
+            <child>
+              <object class="AdwActionRow">
                 <property name="title" translatable="yes">Background style</property>
                 <property name="subtitle" translatable="yes">The transparent/semi-transparent style for popups.</property>
                 <property name="activatable-widget">style_popup</property>

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -672,6 +672,11 @@
             <default>true</default>
             <summary>Boolean, whether to override the background or not</summary>
         </key>
+        <!-- PRESERVE SHELL THEME -->
+        <key type="b" name="preserve-shell-theme">
+            <default>false</default>
+            <summary>Boolean, whether to preserve the shell theme's popup control styling</summary>
+        </key>
         <!-- STYLE POPUP -->
         <key type="i" name="style-popup">
             <default>3</default>

--- a/src/components/popup/index.js
+++ b/src/components/popup/index.js
@@ -6,6 +6,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import {
     POPUP_BACKGROUND_STYLES,
+    POPUP_SURFACE_STYLES,
     PopupBlurTargets,
 } from './targets.js';
 import { PopupBlurSurface } from './blur_surface.js';
@@ -437,18 +438,25 @@ export const PopupBlur = class PopupBlur {
     }
 
     update_background() {
-        POPUP_BACKGROUND_STYLES.forEach(style => Main.uiGroup.remove_style_class_name(style));
+        [...POPUP_BACKGROUND_STYLES, ...POPUP_SURFACE_STYLES]
+            .forEach(style => Main.uiGroup.remove_style_class_name(style));
 
-        if (this.settings.popup.OVERRIDE_BACKGROUND)
+        if (this.settings.popup.OVERRIDE_BACKGROUND) {
+            const style = this.get_background_style();
+            const background_style = this.settings.popup.PRESERVE_SHELL_THEME ?
+                POPUP_SURFACE_STYLES[style] :
+                POPUP_BACKGROUND_STYLES[style];
             Main.uiGroup.add_style_class_name(
-                POPUP_BACKGROUND_STYLES[this.get_background_style()]
+                background_style
             );
+        }
 
         this.surfaces.forEach(surface => surface.update_settings());
     }
 
     get_background_style() {
         const style = this.settings.popup.STYLE_POPUP;
+
         if (style >= 0 && style < POPUP_BACKGROUND_STYLES.length)
             return style;
 
@@ -486,7 +494,8 @@ export const PopupBlur = class PopupBlur {
         this._log("removing blur from popup surfaces");
         this.enabled = false;
 
-        POPUP_BACKGROUND_STYLES.forEach(style => Main.uiGroup.remove_style_class_name(style));
+        [...POPUP_BACKGROUND_STYLES, ...POPUP_SURFACE_STYLES]
+            .forEach(style => Main.uiGroup.remove_style_class_name(style));
 
         const actors = [...this.surfaces.keys()];
         actors.forEach(actor => this.destroy_blur(actor));

--- a/src/components/popup/targets.js
+++ b/src/components/popup/targets.js
@@ -4,6 +4,9 @@ const POPUP_CHILD_STYLE_CLASSES = ['osd-window', 'resize-popup', 'switcher-list'
 const POPUP_DESCENDANT_TARGET_STYLE_CLASSES = ['switcher-list'];
 
 export const POPUP_BACKGROUND_STYLES = ['bms-popup-background-transparent', 'bms-popup-background-light', 'bms-popup-background-dark'];
+export const POPUP_SURFACE_STYLES = POPUP_BACKGROUND_STYLES.map(
+    style => style.replace('bms-popup-background-', 'bms-popup-surface-')
+);
 export const DEFAULT_CORNER_RADIUS = { key: 'corner-radius', property: 'CORNER_RADIUS' };
 export const POPUP_CORNER_RADII = [
     {

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -113,6 +113,7 @@ export const KEYS = [
             { type: Type.I, name: "osd-corner-radius" },
             { type: Type.I, name: "dialog-corner-radius" },
             { type: Type.B, name: "override-background" },
+            { type: Type.B, name: "preserve-shell-theme" },
             { type: Type.I, name: "style-popup" },
         ]
     },

--- a/src/extension.js
+++ b/src/extension.js
@@ -688,6 +688,13 @@ export default class BlurMyShell extends Extension {
                 this._popup.update_background();
         });
 
+        // Apply only the popup surface override, leaving shell theme control
+        // and text styles intact.
+        this._settings.popup.PRESERVE_SHELL_THEME_changed(() => {
+            if (this._settings.popup.BLUR)
+                this._popup.update_background();
+        });
+
         // popup background style changed
         this._settings.popup.STYLE_POPUP_changed(() => {
             if (this._settings.popup.BLUR)

--- a/src/preferences/popup.js
+++ b/src/preferences/popup.js
@@ -25,6 +25,7 @@ export const PopupBlur = GObject.registerClass({
         'dialog_corner_radius',
         'corner_radius_not_found_row',
         'override_background',
+        'preserve_shell_theme',
         'style_popup'
     ],
 }, class PopupBlur extends Adw.PreferencesPage {
@@ -88,6 +89,11 @@ export const PopupBlur = GObject.registerClass({
         this.preferences.popup.settings.bind(
             'override-background',
             this._override_background, 'enable-expansion',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.preferences.popup.settings.bind(
+            'preserve-shell-theme',
+            this._preserve_shell_theme, 'active',
             Gio.SettingsBindFlags.DEFAULT
         );
         this.preferences.popup.settings.bind(

--- a/src/styles/popup/base.css
+++ b/src/styles/popup/base.css
@@ -14,7 +14,18 @@
 .bms-popup-background-transparent .switcher-list,
 .bms-popup-background-transparent .workspace-switcher,
 .bms-popup-background-transparent .modal-dialog,
-.bms-popup-background-transparent .run-dialog {
+.bms-popup-background-transparent .run-dialog,
+.bms-popup-surface-transparent .popup-menu-content,
+.bms-popup-surface-transparent .popup-sub-menu,
+.bms-popup-surface-transparent .candidate-popup-content,
+.bms-popup-surface-transparent .quick-settings,
+.bms-popup-surface-transparent .quick-toggle-menu,
+.bms-popup-surface-transparent .osd-window,
+.bms-popup-surface-transparent .resize-popup,
+.bms-popup-surface-transparent .switcher-list,
+.bms-popup-surface-transparent .workspace-switcher,
+.bms-popup-surface-transparent .modal-dialog,
+.bms-popup-surface-transparent .run-dialog {
     background: transparent !important;
     border-color: transparent;
     box-shadow: none;
@@ -33,6 +44,32 @@
 .bms-popup-background-light .modal-dialog,
 .bms-popup-background-light .run-dialog {
     color: #222226;
+}
+
+.bms-popup-background-light .popup-menu-content,
+.bms-popup-background-light .popup-sub-menu,
+.bms-popup-background-light .candidate-popup-content,
+.bms-popup-background-light .quick-settings,
+.bms-popup-background-light .quick-toggle-menu,
+.bms-popup-background-light .message,
+.bms-popup-background-light .osd-window,
+.bms-popup-background-light .resize-popup,
+.bms-popup-background-light .switcher-list,
+.bms-popup-background-light .workspace-switcher,
+.bms-popup-background-light .modal-dialog,
+.bms-popup-background-light .run-dialog,
+.bms-popup-surface-light .popup-menu-content,
+.bms-popup-surface-light .popup-sub-menu,
+.bms-popup-surface-light .candidate-popup-content,
+.bms-popup-surface-light .quick-settings,
+.bms-popup-surface-light .quick-toggle-menu,
+.bms-popup-surface-light .message,
+.bms-popup-surface-light .osd-window,
+.bms-popup-surface-light .resize-popup,
+.bms-popup-surface-light .switcher-list,
+.bms-popup-surface-light .workspace-switcher,
+.bms-popup-surface-light .modal-dialog,
+.bms-popup-surface-light .run-dialog {
     background: rgba(255, 255, 255, 0.58) !important;
     border-color: rgba(0, 0, 0, 0.05);
     box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
@@ -52,6 +89,34 @@
 .bms-popup-background-dark .run-dialog,
 .bms-popup-background-transparent .message {
     color: #ffffff;
+}
+
+.bms-popup-background-dark .popup-menu-content,
+.bms-popup-background-dark .popup-sub-menu,
+.bms-popup-background-dark .candidate-popup-content,
+.bms-popup-background-dark .quick-settings,
+.bms-popup-background-dark .quick-toggle-menu,
+.bms-popup-background-dark .message,
+.bms-popup-background-dark .osd-window,
+.bms-popup-background-dark .resize-popup,
+.bms-popup-background-dark .switcher-list,
+.bms-popup-background-dark .workspace-switcher,
+.bms-popup-background-dark .modal-dialog,
+.bms-popup-background-dark .run-dialog,
+.bms-popup-background-transparent .message,
+.bms-popup-surface-dark .popup-menu-content,
+.bms-popup-surface-dark .popup-sub-menu,
+.bms-popup-surface-dark .candidate-popup-content,
+.bms-popup-surface-dark .quick-settings,
+.bms-popup-surface-dark .quick-toggle-menu,
+.bms-popup-surface-dark .message,
+.bms-popup-surface-dark .osd-window,
+.bms-popup-surface-dark .resize-popup,
+.bms-popup-surface-dark .switcher-list,
+.bms-popup-surface-dark .workspace-switcher,
+.bms-popup-surface-dark .modal-dialog,
+.bms-popup-surface-dark .run-dialog,
+.bms-popup-surface-transparent .message {
     background: rgba(45, 45, 50, 0.22) !important;
     border-color: transparent;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
@@ -59,7 +124,10 @@
 
 .bms-popup-background-transparent .message,
 .bms-popup-background-light .message,
-.bms-popup-background-dark .message {
+.bms-popup-background-dark .message,
+.bms-popup-surface-transparent .message,
+.bms-popup-surface-light .message,
+.bms-popup-surface-dark .message {
     box-shadow: none;
 }
 
@@ -115,7 +183,16 @@
 .bms-popup-background-dark .resize-popup,
 .bms-popup-background-transparent .workspace-switcher,
 .bms-popup-background-light .workspace-switcher,
-.bms-popup-background-dark .workspace-switcher {
+.bms-popup-background-dark .workspace-switcher,
+.bms-popup-surface-transparent .osd-window,
+.bms-popup-surface-light .osd-window,
+.bms-popup-surface-dark .osd-window,
+.bms-popup-surface-transparent .resize-popup,
+.bms-popup-surface-light .resize-popup,
+.bms-popup-surface-dark .resize-popup,
+.bms-popup-surface-transparent .workspace-switcher,
+.bms-popup-surface-light .workspace-switcher,
+.bms-popup-surface-dark .workspace-switcher {
     border-radius: 18px;
 }
 
@@ -133,19 +210,24 @@
 
 .bms-popup-background-transparent .popup-sub-menu,
 .bms-popup-background-light .popup-sub-menu,
-.bms-popup-background-dark .popup-sub-menu {
+.bms-popup-background-dark .popup-sub-menu,
+.bms-popup-surface-transparent .popup-sub-menu,
+.bms-popup-surface-light .popup-sub-menu,
+.bms-popup-surface-dark .popup-sub-menu {
     background: transparent !important;
     border-color: transparent;
     border-radius: 0 0 13px 13px;
     box-shadow: none;
 }
 
-.bms-popup-background-dark .popup-sub-menu > StBoxLayout {
+.bms-popup-background-dark .popup-sub-menu > StBoxLayout,
+.bms-popup-surface-dark .popup-sub-menu > StBoxLayout {
     background-color: rgba(58, 58, 64, 0.36) !important;
     border-radius: 0 0 13px 13px;
 }
 
-.bms-popup-background-light .popup-sub-menu > StBoxLayout {
+.bms-popup-background-light .popup-sub-menu > StBoxLayout,
+.bms-popup-surface-light .popup-sub-menu > StBoxLayout {
     background-color: rgba(255, 255, 255, 0.58) !important;
     border-radius: 0 0 13px 13px;
 }

--- a/src/styles/popup/dark.css
+++ b/src/styles/popup/dark.css
@@ -1,9 +1,11 @@
-.bms-popup-background-dark .message:second-in-stack {
+.bms-popup-background-dark .message:second-in-stack,
+.bms-popup-surface-dark .message:second-in-stack {
     background: rgba(35, 35, 40, 0.3) !important;
     box-shadow: 0 1px 1px 0 transparent;
 }
 
-.bms-popup-background-dark .message:lower-in-stack {
+.bms-popup-background-dark .message:lower-in-stack,
+.bms-popup-surface-dark .message:lower-in-stack {
     background: rgba(35, 35, 40, 0.2) !important;
     box-shadow: none;
 }

--- a/src/styles/popup/light.css
+++ b/src/styles/popup/light.css
@@ -1,9 +1,11 @@
-.bms-popup-background-light .message:second-in-stack {
+.bms-popup-background-light .message:second-in-stack,
+.bms-popup-surface-light .message:second-in-stack {
     background: rgba(255, 255, 255, 0.54) !important;
     box-shadow: 0 1px 1px 0 transparent;
 }
 
-.bms-popup-background-light .message:lower-in-stack {
+.bms-popup-background-light .message:lower-in-stack,
+.bms-popup-surface-light .message:lower-in-stack {
     background: rgba(255, 255, 255, 0.44) !important;
     box-shadow: none;
 }

--- a/src/styles/popup/transparent.css
+++ b/src/styles/popup/transparent.css
@@ -1,9 +1,11 @@
-.bms-popup-background-transparent .message:second-in-stack {
+.bms-popup-background-transparent .message:second-in-stack,
+.bms-popup-surface-transparent .message:second-in-stack {
     background: rgba(35, 35, 40, 0.3) !important;
     box-shadow: 0 1px 1px 0 transparent;
 }
 
-.bms-popup-background-transparent .message:lower-in-stack {
+.bms-popup-background-transparent .message:lower-in-stack,
+.bms-popup-surface-transparent .message:lower-in-stack {
     background: rgba(35, 35, 40, 0.2) !important;
     box-shadow: none;
 }


### PR DESCRIPTION
## Summary

- add a **Preserve shell theme** toggle under Popup Blur's background override
<img width="690" height="626" alt="Screenshot From 2026-08-10 00-29-12" src="https://github.com/user-attachments/assets/73fa2e7f-62fb-4708-9cf6-3068c4cf7977" />

- keep Blur My Shell's popup surface transparency/tint while allowing the active shell theme to style popup controls and text
- share the existing canonical surface rules across Transparent, Light, and Dark modes
- preserve notification and stacked-notification surface opacity without overriding their theme-provided controls

## Motivation

Popup background overrides currently style both the blurred surface and its child controls. This can replace colors and states supplied by custom shell themes.

The new option applies a surface-only style class. Backgrounds, borders, shadows, and corner geometry still support the blur, while buttons, toggles, sliders, calendars, notification controls, and text retain the shell theme's styling.

## Before and after

| Before | After |
| --- | --- |
| <img width="487" height="557" alt="before" src="https://github.com/user-attachments/assets/c355c7f4-d4a3-4197-9d25-0c14b6fb0cdf" />|<img width="487" height="557" alt="after" src="https://github.com/user-attachments/assets/0614877f-d122-421c-870f-2b99fb91387d" />|

<!--
GitHub image upload placeholders:
Before: /home/aditya/Pictures/Screenshots/before.png
After:  /home/aditya/Pictures/Screenshots/after.png
-->

## Testing

- tested on GNOME Shell 51 with the Marble shell theme
- verified Transparent mode with Preserve shell theme enabled and disabled
- verified popup menus, Quick Settings, notifications, stacked notifications, OSDs, switchers, and dialogs have surface-rule coverage
- verified the existing non-preserve selectors retain their original declarations
- verified every surface-only selector uses declarations from a canonical existing background selector