### PR TITLE
perf: throttle shadow-driven blur repaints

### DIFF
--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -16,24 +16,48 @@ export const PaintSignals = class PaintSignals {
         this.disconnect_all_for_actor(actor);
 
         let last_repaint_at = 0;
-        const paint_effect = new PaintCallbackEffect();
-        paint_effect.set_callback(() => {
-            const now = GLib.get_monotonic_time();
-            if (now - last_repaint_at < REPAINT_INTERVAL_US)
-                return;
-
-            last_repaint_at = now;
+        let repaint_timeout_id = 0;
+        const queue_repaint = () => {
+            last_repaint_at = GLib.get_monotonic_time();
             try {
                 blur_effect.queue_repaint();
             } catch (e) { }
+        };
+        const cancel_repaint = () => {
+            if (!repaint_timeout_id)
+                return;
+
+            GLib.Source.remove(repaint_timeout_id);
+            repaint_timeout_id = 0;
+        };
+        const paint_effect = new PaintCallbackEffect();
+        paint_effect.set_callback(() => {
+            const now = GLib.get_monotonic_time();
+            const elapsed = now - last_repaint_at;
+            if (elapsed >= REPAINT_INTERVAL_US) {
+                cancel_repaint();
+                queue_repaint();
+                return;
+            }
+
+            if (repaint_timeout_id)
+                return;
+
+            const delay = Math.max(1, Math.ceil((REPAINT_INTERVAL_US - elapsed) / 1000));
+            repaint_timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
+                repaint_timeout_id = 0;
+                queue_repaint();
+                return GLib.SOURCE_REMOVE;
+            });
         });
 
         actor.add_effect(paint_effect);
         const destroy_id = this.connections.connect(actor, 'destroy', () => {
             paint_effect.set_callback(null);
+            cancel_repaint();
             this.entries.delete(actor);
         });
-        this.entries.set(actor, { paint_effect, destroy_id });
+        this.entries.set(actor, { paint_effect, destroy_id, cancel_repaint });
     }
 
     disconnect_all_for_actor(actor) {
@@ -43,6 +67,7 @@ export const PaintSignals = class PaintSignals {
 
         this.entries.delete(actor);
         entry.paint_effect.set_callback(null);
+        entry.cancel_repaint();
         this.connections.disconnect(actor, entry.destroy_id);
         try {
             actor.remove_effect(entry.paint_effect);

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -32,10 +32,7 @@ export const PaintSignals = class PaintSignals {
         };
         const paint_effect = new PaintCallbackEffect();
         paint_effect.set_callback(paint_flags => {
-            // queue_repaint() invalidates the effect itself, which results in
-            // a paint without ACTOR_DIRTY. Do not turn that repaint into a
-            // new trailing timeout.
-            if (!(paint_flags & Clutter.PaintFlag.ACTOR_DIRTY))
+            if (!(paint_flags & Clutter.EffectPaintFlags.ACTOR_DIRTY))
                 return;
 
             const now = GLib.get_monotonic_time();

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -1,7 +1,10 @@
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 
-const PAINTS_BETWEEN_REPAINTS = 2;
+// Shell.BlurEffect needs explicit invalidation for some shadow updates. Limit
+// those refreshes so a constantly painting actor cannot keep the GPU busy.
+const REPAINT_INTERVAL_US = 100_000;
 
 export const PaintSignals = class PaintSignals {
     constructor(connections) {
@@ -12,15 +15,14 @@ export const PaintSignals = class PaintSignals {
     connect(actor, blur_effect) {
         this.disconnect_all_for_actor(actor);
 
-        let paints_to_skip = 0;
+        let last_repaint_at = 0;
         const paint_effect = new PaintCallbackEffect();
         paint_effect.set_callback(() => {
-            if (paints_to_skip > 0) {
-                paints_to_skip--;
+            const now = GLib.get_monotonic_time();
+            if (now - last_repaint_at < REPAINT_INTERVAL_US)
                 return;
-            }
 
-            paints_to_skip = PAINTS_BETWEEN_REPAINTS;
+            last_repaint_at = now;
             try {
                 blur_effect.queue_repaint();
             } catch (e) { }

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -31,7 +31,13 @@ export const PaintSignals = class PaintSignals {
             repaint_timeout_id = 0;
         };
         const paint_effect = new PaintCallbackEffect();
-        paint_effect.set_callback(() => {
+        paint_effect.set_callback(paint_flags => {
+            // queue_repaint() invalidates the effect itself, which results in
+            // a paint without ACTOR_DIRTY. Do not turn that repaint into a
+            // new trailing timeout.
+            if (!(paint_flags & Clutter.PaintFlag.ACTOR_DIRTY))
+                return;
+
             const now = GLib.get_monotonic_time();
             const elapsed = now - last_repaint_at;
             if (elapsed >= REPAINT_INTERVAL_US) {
@@ -88,7 +94,7 @@ const PaintCallbackEffect = GObject.registerClass(
         }
 
         vfunc_paint(node, paint_context, paint_flags) {
-            this._callback?.();
+            this._callback?.(paint_flags);
             super.vfunc_paint(node, paint_context, paint_flags);
         }
     }

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -17,11 +17,15 @@ export const PaintSignals = class PaintSignals {
 
         let last_repaint_at = 0;
         let repaint_timeout_id = 0;
+        let skip_next_paint = false;
         const queue_repaint = () => {
             last_repaint_at = GLib.get_monotonic_time();
+            skip_next_paint = true;
             try {
                 blur_effect.queue_repaint();
-            } catch (e) { }
+            } catch (e) {
+                skip_next_paint = false;
+            }
         };
         const cancel_repaint = () => {
             if (!repaint_timeout_id)
@@ -32,6 +36,11 @@ export const PaintSignals = class PaintSignals {
         };
         const paint_effect = new PaintCallbackEffect();
         paint_effect.set_callback(paint_flags => {
+            if (skip_next_paint) {
+                skip_next_paint = false;
+                return;
+            }
+
             if (!(paint_flags & Clutter.EffectPaintFlags.ACTOR_DIRTY))
                 return;
 


### PR DESCRIPTION
Replaces frame-count-based blur invalidation with a monotonic 100 ms throttle. This keeps shadow-driven blur refreshes responsive while preventing continuously painting actors from requeuing costly blur work every few frames. Built successfully with the project Makefile.