### PR TITLE
fix: preserve Dash to Dock style classes

### DIFF
--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -98,9 +98,15 @@ class DashInfos {
     override_style() {
         this.remove_style();
 
-        this.dash.set_style_class_name(
-            DASH_STYLES[this.settings.dash_to_dock.STYLE_DASH_TO_DOCK]
-        );
+        const style = DASH_STYLES[
+            this.settings.dash_to_dock.STYLE_DASH_TO_DOCK
+        ];
+
+        // Dash to Dock owns its style class list. Replacing it removes the
+        // extension's layout and border-radius rules. Add Blur My Shell's
+        // visual modifier alongside the native classes instead.
+        if (style && !this.dash.has_style_class_name(style))
+            this.dash.add_style_class_name(style);
     }
 
     remove_style() {


### PR DESCRIPTION
## Summary

- preserve Dash to Dock’s native style classes when applying Blur My Shell’s dash appearance
- add the Blur My Shell modifier class instead of replacing the complete class list

Replacing the class list removed Dash to Dock’s layout and border-radius rules, producing a wide, boxy dock background.

## Verification

- `node --check src/components/dash_to_dock.js`
- `make build`