### PR TITLE
Add the option to hide blur while an app is fullscreen

### DIFF
--- a/resources/ui/applications.ui
+++ b/resources/ui/applications.ui
@@ -205,6 +205,21 @@ This may cause some latency or performance issues.</property>
 
         <child>
           <object class="AdwActionRow">
+            <property name="title" translatable="yes">Unblur when Fullscreen</property>
+            <property name="subtitle" translatable="yes">Forces the blur to be removed when a window is in fullscreen mode.</property>
+            <property name="activatable-widget">unblur_when_fullscreen</property>
+            <property name="sensitive" bind-source="blur" bind-property="state" bind-flags="sync-create" />
+
+            <child>
+              <object class="GtkSwitch" id="unblur_when_fullscreen">
+                <property name="valign">center</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
+          <object class="AdwActionRow">
             <property name="title" translatable="yes">Enable all by default</property>
             <property name="subtitle" translatable="yes">Adds blur behind all windows by default.</property>
             <property name="activatable-widget">enable_all</property>

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -442,6 +442,11 @@
             <default>false</default>
             <summary>Wether or not to blur applications on the overview</summary>
         </key>
+        <!-- UNBLUR WHEN FULLSCREEN -->
+        <key type="b" name="unblur-when-fullscreen">
+            <default>false</default>
+            <summary>Wether or not to unblur applications when they are fullscreen</summary>
+        </key>
         <!-- ENABLE ALL -->
         <key type="b" name="enable-all">
             <default>false</default>

--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -173,6 +173,39 @@ export const ApplicationsBlur = class ApplicationsBlur {
                 }
             );
         }
+        else {
+            this.connections.connect(
+                Main.overview, 'showing',
+                _ => this.meta_window_map.forEach((meta_window, _pid) => {
+                    let window_actor = meta_window.get_compositor_private();
+                    window_actor?.hide();
+                })
+            );
+            // when the overview is closed, hide every actor that is not on the
+            // current workspace (to mimic the original behaviour)
+            this.connections.connect(
+                Main.overview, 'hidden',
+                _ => { this.meta_window_map.forEach((meta_window, _pid) => {
+                        let window_actor = meta_window.get_compositor_private();
+                        if (
+                            (!meta_window.get_workspace().active) || meta_window.minimized
+                        ){
+                            window_actor.hide();
+                        }
+                        else {
+                            window_actor.show();
+                            if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN) {
+                                 this.unblur_when_fullscreen(meta_window);
+                            }     
+                            else {
+                                meta_window.blur_actor?.show();
+                            }
+                                
+                        }
+                    });
+                }
+            );
+        }
     }
 
     /// Iterate through all existing windows and add blur as needed.
@@ -375,6 +408,9 @@ export const ApplicationsBlur = class ApplicationsBlur {
 
         meta_window.blur_actor = blur_actor;
 
+        if (!this.settings.applications.BLUR_ON_OVERVIEW && Main.overview.visible)
+            blur_actor.hide();
+
         // make sure window is blurred in overview
         if (this.settings.applications.BLUR_ON_OVERVIEW)
             this.enforce_window_visibility_on_overview_for(window_actor);
@@ -387,6 +423,11 @@ export const ApplicationsBlur = class ApplicationsBlur {
 
         // update corner radius based on window state
         this.update_corner_radius(meta_window);
+
+        // unblur when fullscreen
+        if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN) {
+            this.unblur_when_fullscreen(meta_window);
+        }
 
         // now set up the signals, for the window actor only: they are disconnected
         // in `remove_blur`, whereas the signals for the meta window are disconnected
@@ -403,7 +444,12 @@ export const ApplicationsBlur = class ApplicationsBlur {
         );
         this.connections.connect(
             meta_window, 'notify::fullscreen',
-            _ => this.update_corner_radius(meta_window)
+            _ => {
+                this.update_corner_radius(meta_window);
+                if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN){
+                    this.unblur_when_fullscreen(meta_window);
+                }
+            }
         );
 
         // update the window opacity when it changes, else we don't control it fully
@@ -423,10 +469,18 @@ export const ApplicationsBlur = class ApplicationsBlur {
             window_actor,
             'notify::visible',
             window_actor => {
-                if (window_actor.visible)
-                    meta_window.blur_actor.show();
-                else
+                if (window_actor.visible) {
+                    if (!this.settings.applications.BLUR_ON_OVERVIEW && Main.overview.visible) {
+                        meta_window.blur_actor.hide();
+                    }
+                    else if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN){
+                        this.unblur_when_fullscreen(meta_window);
+                    }
+                    else { meta_window.blur_actor.show(); }
+                }
+                else {
                     meta_window.blur_actor.hide();
+                }
             }
         );
     }
@@ -461,7 +515,12 @@ export const ApplicationsBlur = class ApplicationsBlur {
         }
         // if we remove the focus and have blur, show it and make the window transparent
         else if (blur_actor) {
-            blur_actor.show();
+            if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN) {
+                this.unblur_when_fullscreen(meta_window);
+            }
+            else {
+                blur_actor.show();
+            }
             this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
         }
     }
@@ -509,11 +568,36 @@ export const ApplicationsBlur = class ApplicationsBlur {
         }
     }
 
+    unblur_when_fullscreen(meta_window) {
+        const is_fullscreen = meta_window.fullscreen;
+
+        let window_actor = null;
+        if (meta_window) {
+            window_actor = meta_window.get_compositor_private();
+        }
+
+        if (is_fullscreen) {
+            meta_window.blur_actor.hide();
+            this.set_window_opacity(window_actor, 255);
+        } else {
+            meta_window.blur_actor.show();
+            this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
+        }    
+    }
+
     /// Update all corners, to use when the setting has been changed.
     update_all_corner_radii() {
         this.meta_window_map.forEach(
             (meta_window, _pid) => this.update_corner_radius(meta_window)
         )
+    }
+
+    update_fullscreen_status() {
+        if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN){
+            this.meta_window_map.forEach(
+                (meta_window, _pid) => this.unblur_when_fullscreen(meta_window)
+            )
+        }
     }
 
     /// Set the opacity of the window actor that sits on top of the blur effect.

--- a/src/components/applications.js
+++ b/src/components/applications.js
@@ -145,67 +145,23 @@ export const ApplicationsBlur = class ApplicationsBlur {
     /// shown on every window of the workspaces viewer.
     connect_to_overview() {
         this.connections.disconnect_all_for(Main.overview);
+        this.overview_visible = Main.overview.visible;
 
-        if (this.settings.applications.BLUR_ON_OVERVIEW) {
-            // when the overview is opened, show every window actors (which
-            // allows the blur to be shown too)
-            this.connections.connect(
-                Main.overview, 'showing',
-                _ => this.meta_window_map.forEach((meta_window, _pid) => {
-                    let window_actor = meta_window.get_compositor_private();
-                    window_actor?.show();
-                })
-            );
+        const reconcile_windows = () => this.meta_window_map.forEach(
+            (meta_window, _pid) => this.reconcile_window_visibility(meta_window)
+        );
+        this.connections.connect(Main.overview, 'showing', _ => {
+            this.overview_visible = true;
+            reconcile_windows();
+        });
+        this.connections.connect(Main.overview, 'hidden', _ => {
+            this.overview_visible = false;
+            reconcile_windows();
+        });
 
-            // when the overview is closed, hide every actor that is not on the
-            // current workspace (to mimic the original behaviour)
-            this.connections.connect(
-                Main.overview, 'hidden',
-                _ => {
-                    this.meta_window_map.forEach((meta_window, _pid) => {
-                        let window_actor = meta_window.get_compositor_private();
-
-                        if (
-                            (!meta_window.get_workspace().active) || meta_window.minimized
-                        )
-                            window_actor.hide();
-                    });
-                }
-            );
-        }
-        else {
-            this.connections.connect(
-                Main.overview, 'showing',
-                _ => this.meta_window_map.forEach((meta_window, _pid) => {
-                    let window_actor = meta_window.get_compositor_private();
-                    window_actor?.hide();
-                })
-            );
-            // when the overview is closed, hide every actor that is not on the
-            // current workspace (to mimic the original behaviour)
-            this.connections.connect(
-                Main.overview, 'hidden',
-                _ => { this.meta_window_map.forEach((meta_window, _pid) => {
-                        let window_actor = meta_window.get_compositor_private();
-                        if (
-                            (!meta_window.get_workspace().active) || meta_window.minimized
-                        ){
-                            window_actor.hide();
-                        }
-                        else {
-                            window_actor.show();
-                            if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN) {
-                                 this.unblur_when_fullscreen(meta_window);
-                            }     
-                            else {
-                                meta_window.blur_actor?.show();
-                            }
-                                
-                        }
-                    });
-                }
-            );
-        }
+        this.meta_window_map.forEach((meta_window, _pid) =>
+            this.reconcile_window_visibility(meta_window)
+        );
     }
 
     /// Iterate through all existing windows and add blur as needed.
@@ -411,23 +367,13 @@ export const ApplicationsBlur = class ApplicationsBlur {
         if (!this.settings.applications.BLUR_ON_OVERVIEW && Main.overview.visible)
             blur_actor.hide();
 
-        // make sure window is blurred in overview
-        if (this.settings.applications.BLUR_ON_OVERVIEW)
-            this.enforce_window_visibility_on_overview_for(window_actor);
-
         // update the size
         this.update_size(pid);
-
-        // set the window actor's opacity
-        this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
 
         // update corner radius based on window state
         this.update_corner_radius(meta_window);
 
-        // unblur when fullscreen
-        if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN) {
-            this.unblur_when_fullscreen(meta_window);
-        }
+        this.reconcile_window_visibility(meta_window);
 
         // now set up the signals, for the window actor only: they are disconnected
         // in `remove_blur`, whereas the signals for the meta window are disconnected
@@ -446,9 +392,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
             meta_window, 'notify::fullscreen',
             _ => {
                 this.update_corner_radius(meta_window);
-                if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN){
-                    this.unblur_when_fullscreen(meta_window);
-                }
+                this.reconcile_window_visibility(meta_window);
             }
         );
 
@@ -456,8 +400,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
         this.connections.connect(
             window_actor, 'notify::opacity',
             _ => {
-                if (this.focused_window_pid != pid)
-                    this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
+                this.reconcile_window_visibility(meta_window);
             }
         );
 
@@ -468,20 +411,7 @@ export const ApplicationsBlur = class ApplicationsBlur {
         this.connections.connect(
             window_actor,
             'notify::visible',
-            window_actor => {
-                if (window_actor.visible) {
-                    if (!this.settings.applications.BLUR_ON_OVERVIEW && Main.overview.visible) {
-                        meta_window.blur_actor.hide();
-                    }
-                    else if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN){
-                        this.unblur_when_fullscreen(meta_window);
-                    }
-                    else { meta_window.blur_actor.show(); }
-                }
-                else {
-                    meta_window.blur_actor.hide();
-                }
-            }
+            _ => this.reconcile_window_visibility(meta_window)
         );
     }
 
@@ -489,62 +419,18 @@ export const ApplicationsBlur = class ApplicationsBlur {
     /// we are not focused anymore). It automatically removes the ancient focus.
     /// With `focus=false`, just remove the focus from said window (which can still be null).
     set_focus_for_window(meta_window, focus = true) {
-        let blur_actor = null;
-        let window_actor = null;
         let new_pid = null;
         if (meta_window) {
-            blur_actor = meta_window.blur_actor;
-            window_actor = meta_window.get_compositor_private();
             new_pid = meta_window.bms_pid;
         }
 
-        if (focus) {
-            // remove old focused window if any
-            if (this.focused_window_pid) {
-                const old_focused_window = this.meta_window_map.get(this.focused_window_pid);
-                if (old_focused_window)
-                    this.set_focus_for_window(old_focused_window, false);
-            }
-            // set new focused window pid
+        if (focus)
             this.focused_window_pid = new_pid;
-            // if we have blur, hide it and make the window opaque
-            if (this.settings.applications.DYNAMIC_OPACITY && blur_actor) {
-                blur_actor.hide();
-                this.set_window_opacity(window_actor, 255);
-            }
-        }
-        // if we remove the focus and have blur, show it and make the window transparent
-        else if (blur_actor) {
-            if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN) {
-                this.unblur_when_fullscreen(meta_window);
-            }
-            else {
-                blur_actor.show();
-            }
-            this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
-        }
-    }
+        else
+            this.focused_window_pid = null;
 
-    /// Makes sure that, when the overview is visible, the window actor will
-    /// stay visible no matter what.
-    /// We can instead hide the last child of the window actor, which will
-    /// improve performances without hiding the blur effect.
-    enforce_window_visibility_on_overview_for(window_actor) {
-        this.connections.connect(window_actor, 'notify::visible',
-            _ => {
-                if (this.settings.applications.BLUR_ON_OVERVIEW) {
-                    if (
-                        !window_actor.visible
-                        && Main.overview.visible
-                    ) {
-                        window_actor.show();
-                        window_actor.get_last_child().hide();
-                    } else if (
-                        window_actor.visible
-                    )
-                        window_actor.get_last_child().show();
-                }
-            }
+        this.meta_window_map.forEach((tracked_window, _pid) =>
+            this.reconcile_window_visibility(tracked_window)
         );
     }
 
@@ -568,21 +454,31 @@ export const ApplicationsBlur = class ApplicationsBlur {
         }
     }
 
-    unblur_when_fullscreen(meta_window) {
-        const is_fullscreen = meta_window.fullscreen;
+    reconcile_window_visibility(meta_window, overview_visible = this.overview_visible) {
+        const window_actor = meta_window.get_compositor_private();
+        const blur_actor = meta_window.blur_actor;
+        if (!window_actor || !blur_actor)
+            return;
 
-        let window_actor = null;
-        if (meta_window) {
-            window_actor = meta_window.get_compositor_private();
-        }
+        const is_focused = this.settings.applications.DYNAMIC_OPACITY
+            && meta_window.bms_pid === this.focused_window_pid;
+        const is_fullscreen = this.settings.applications.UNBLUR_WHEN_FULLSCREEN
+            && meta_window.fullscreen;
+        const visible_for_blur = window_actor.visible
+            || (this.settings.applications.BLUR_ON_OVERVIEW && overview_visible);
+        const show_blur = visible_for_blur
+            && !is_focused
+            && !is_fullscreen
+            && (this.settings.applications.BLUR_ON_OVERVIEW || !overview_visible);
 
-        if (is_fullscreen) {
-            meta_window.blur_actor.hide();
-            this.set_window_opacity(window_actor, 255);
-        } else {
-            meta_window.blur_actor.show();
-            this.set_window_opacity(window_actor, this.settings.applications.OPACITY);
-        }    
+        if (show_blur)
+            blur_actor.show();
+        else
+            blur_actor.hide();
+
+        this.set_window_opacity(window_actor, show_blur
+            ? this.settings.applications.OPACITY
+            : 255);
     }
 
     /// Update all corners, to use when the setting has been changed.
@@ -593,11 +489,9 @@ export const ApplicationsBlur = class ApplicationsBlur {
     }
 
     update_fullscreen_status() {
-        if (this.settings.applications.UNBLUR_WHEN_FULLSCREEN){
-            this.meta_window_map.forEach(
-                (meta_window, _pid) => this.unblur_when_fullscreen(meta_window)
-            )
-        }
+        this.meta_window_map.forEach(
+            (meta_window, _pid) => this.reconcile_window_visibility(meta_window)
+        );
     }
 
     /// Set the opacity of the window actor that sits on top of the blur effect.
@@ -615,14 +509,9 @@ export const ApplicationsBlur = class ApplicationsBlur {
 
     /// Update the opacity of all window actors.
     set_opacity() {
-        let opacity = this.settings.applications.OPACITY;
-
-        this.meta_window_map.forEach(((meta_window, pid) => {
-            if (pid != this.focused_window_pid && meta_window.blur_actor) {
-                let window_actor = meta_window.get_compositor_private();
-                this.set_window_opacity(window_actor, opacity);
-            }
-        }));
+        this.meta_window_map.forEach((meta_window, _pid) =>
+            this.reconcile_window_visibility(meta_window)
+        );
     }
 
     /// Find the system's window scaling.

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -68,6 +68,7 @@ export const KEYS = [
             { type: Type.I, name: "opacity" },
             { type: Type.B, name: "dynamic-opacity" },
             { type: Type.B, name: "blur-on-overview" },
+            { type: Type.B, name: "unblur-when-fullscreen" },
             { type: Type.B, name: "enable-all" },
             { type: Type.AS, name: "whitelist" },
             { type: Type.AS, name: "blacklist" },

--- a/src/extension.js
+++ b/src/extension.js
@@ -563,6 +563,12 @@ export default class BlurMyShell extends Extension {
                 this._applications_blur.connect_to_overview();
         });
 
+        // application unblur-when-fullscreen changed
+        this._settings.applications.UNBLUR_WHEN_FULLSCREEN_changed(() => {
+            if (this._settings.applications.BLUR)
+                this._applications_blur.update_fullscreen_status();
+        });
+
         // application enable-all changed
         this._settings.applications.ENABLE_ALL_changed(() => {
             if (this._settings.applications.BLUR)

--- a/src/preferences/applications.js
+++ b/src/preferences/applications.js
@@ -45,6 +45,7 @@ export const Applications = GObject.registerClass({
         'opacity',
         'dynamic_opacity',
         'blur_on_overview',
+        'unblur_when_fullscreen',
         'enable_all',
         'whitelist',
         'add_window_whitelist',
@@ -88,6 +89,10 @@ export const Applications = GObject.registerClass({
         );
         this.preferences.applications.settings.bind(
             'blur-on-overview', this._blur_on_overview, 'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+        this.preferences.applications.settings.bind(
+            'unblur-when-fullscreen', this._unblur_when_fullscreen, 'active',
             Gio.SettingsBindFlags.DEFAULT
         );
         this.preferences.applications.settings.bind(


### PR DESCRIPTION
This PR add the ability to hide blur while an app is in fullscreen (https://github.com/aunetx/blur-my-shell/issues/899), plus some changes which I'm going to list here
<img width="1690" height="1848" alt="image" src="https://github.com/user-attachments/assets/820a9203-9c59-407e-8908-96b034e9a3d8" />
(probably will also set the opacity to 255 as well)


- Application blur will only render on overview if Blur on overview is on (https://github.com/aunetx/blur-my-shell/issues/749)