### PR TITLE
Some tweaks to Popup Blur and dock styling

### DIFF
--- a/src/styles/dash.css
+++ b/src/styles/dash.css
@@ -4,21 +4,23 @@
 * `.transparent-dash`
 */
 .transparent-dash .dash-background {
-    background-color: transparent !important;
+    background: transparent !important;
 }
 
 /*
 * `.light-dash`
 */
 .light-dash .dash-background {
-    background-color: rgba(200, 200, 200, 0.2) !important;
+    background: rgba(255, 255, 255, 0.58) !important;
+    border: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 /*
 * `.dark-dash`
 */
 .dark-dash .dash-background {
-    background-color: rgba(100, 100, 100, 0.35) !important;
+    background: rgba(45, 45, 50, 0.22) !important;
+    border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 

--- a/src/styles/popup/base.css
+++ b/src/styles/popup/base.css
@@ -75,6 +75,22 @@
     box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08);
 }
 
+.bms-popup-background-light .modal-dialog,
+.bms-popup-background-light .run-dialog,
+.bms-popup-surface-light .modal-dialog,
+.bms-popup-surface-light .run-dialog,
+.bms-popup-background-dark .modal-dialog,
+.bms-popup-background-dark .run-dialog,
+.bms-popup-surface-dark .modal-dialog,
+.bms-popup-surface-dark .run-dialog {
+    border: 1px solid;
+}
+
+.bms-popup-background-light .message:hover,
+.bms-popup-surface-light .message:hover {
+    background: rgba(255, 255, 255, 0.4) !important;
+}
+
 .bms-popup-background-dark .popup-menu-content,
 .bms-popup-background-dark .popup-sub-menu,
 .bms-popup-background-dark .candidate-popup-content,
@@ -96,30 +112,42 @@
 .bms-popup-background-dark .candidate-popup-content,
 .bms-popup-background-dark .quick-settings,
 .bms-popup-background-dark .quick-toggle-menu,
-.bms-popup-background-dark .message,
 .bms-popup-background-dark .osd-window,
 .bms-popup-background-dark .resize-popup,
 .bms-popup-background-dark .switcher-list,
 .bms-popup-background-dark .workspace-switcher,
 .bms-popup-background-dark .modal-dialog,
 .bms-popup-background-dark .run-dialog,
-.bms-popup-background-transparent .message,
 .bms-popup-surface-dark .popup-menu-content,
 .bms-popup-surface-dark .popup-sub-menu,
 .bms-popup-surface-dark .candidate-popup-content,
 .bms-popup-surface-dark .quick-settings,
 .bms-popup-surface-dark .quick-toggle-menu,
-.bms-popup-surface-dark .message,
 .bms-popup-surface-dark .osd-window,
 .bms-popup-surface-dark .resize-popup,
 .bms-popup-surface-dark .switcher-list,
 .bms-popup-surface-dark .workspace-switcher,
 .bms-popup-surface-dark .modal-dialog,
-.bms-popup-surface-dark .run-dialog,
-.bms-popup-surface-transparent .message {
+.bms-popup-surface-dark .run-dialog {
     background: rgba(45, 45, 50, 0.22) !important;
-    border-color: transparent;
+    border-color: rgba(255, 255, 255, 0.05);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+}
+
+.bms-popup-background-dark .message,
+.bms-popup-background-transparent .message,
+.bms-popup-surface-dark .message,
+.bms-popup-surface-transparent .message {
+    background: rgba(255, 255, 255, 0.07) !important;
+    border-color: rgba(255, 255, 255, 0.05);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+}
+
+.bms-popup-background-dark .message:hover,
+.bms-popup-background-transparent .message:hover,
+.bms-popup-surface-dark .message:hover,
+.bms-popup-surface-transparent .message:hover {
+    background: rgba(255, 255, 255, 0.12) !important;
 }
 
 .bms-popup-background-transparent .message,

--- a/src/styles/popup/base.css
+++ b/src/styles/popup/base.css
@@ -83,7 +83,7 @@
 .bms-popup-background-dark .run-dialog,
 .bms-popup-surface-dark .modal-dialog,
 .bms-popup-surface-dark .run-dialog {
-    border: 1px solid;
+    border: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .bms-popup-background-light .message:hover,

--- a/src/styles/popup/dark.css
+++ b/src/styles/popup/dark.css
@@ -1,12 +1,12 @@
 .bms-popup-background-dark .message:second-in-stack,
 .bms-popup-surface-dark .message:second-in-stack {
-    background: rgba(35, 35, 40, 0.3) !important;
+    background: rgba(255, 255, 255, 0.05) !important;
     box-shadow: 0 1px 1px 0 transparent;
 }
 
 .bms-popup-background-dark .message:lower-in-stack,
 .bms-popup-surface-dark .message:lower-in-stack {
-    background: rgba(35, 35, 40, 0.2) !important;
+    background: rgba(255, 255, 255, 0.02) !important;
     box-shadow: none;
 }
 

--- a/src/styles/popup/transparent.css
+++ b/src/styles/popup/transparent.css
@@ -1,12 +1,12 @@
 .bms-popup-background-transparent .message:second-in-stack,
 .bms-popup-surface-transparent .message:second-in-stack {
-    background: rgba(35, 35, 40, 0.3) !important;
+    background: rgba(255, 255, 255, 0.05) !important;
     box-shadow: 0 1px 1px 0 transparent;
 }
 
 .bms-popup-background-transparent .message:lower-in-stack,
 .bms-popup-surface-transparent .message:lower-in-stack {
-    background: rgba(35, 35, 40, 0.2) !important;
+    background: rgba(255, 255, 255, 0.02) !important;
     box-shadow: none;
 }
 


### PR DESCRIPTION
This PR introduce some tweaks to Popup blur & Dock stylesheets (https://github.com/aunetx/blur-my-shell/issues/960):
  - Dock coloring now match Popup blur (+ border for Dark / Light style)
  - Popup blur now has border in Dark style and tweak Notification styling so that it match Events, World clocks and Weather section
<img width="1366" height="768" alt="Screenshot From 2026-08-20 18-31-29" src="https://github.com/user-attachments/assets/cd5097d0-6689-41d1-9706-1458e678b425" />
<img width="1366" height="768" alt="Screenshot From 2026-08-20 18-32-25" src="https://github.com/user-attachments/assets/abdbb32b-94f5-478a-9b13-c86d5132656b" />
<img width="487" height="188" alt="Screenshot From 2026-08-20 22-27-36" src="https://github.com/user-attachments/assets/2340173c-b9dc-4f1b-b865-f8413e3f9e0a" />

Splited off from #965