### PR TITLE
Rounded Blur library install script update

### DIFF
--- a/scripts/GUIDE.md
+++ b/scripts/GUIDE.md
@@ -35,6 +35,31 @@ paru -S gnome-rounded-blur
 yay -S gnome-rounded-blur
 ```
 
+### For Fedora (or any of its derivaties, including Atomic based distro) users
+
+Fedora user can follow the following steps to install the libray
+
+- **REMEMBER TO UNINSTALL THE LIBRARY FIRST IF YOU ALREADY INSTALL IT VIA THE SCRIPT HERE**, you can uninstall it by following the uninstall command below
+- Enable the following copr using this command 
+```
+sudo dnf copr enable aneagle/gnome-rounded-blur
+```
+- Then, install the library using `dnf`
+```
+sudo dnf install gnome-rounded-blur
+```
+
+**Note:**
+- Fedora Atomic user may want to manually add the copr by downloading the copr `.repo` from [here](https://copr.fedorainfracloud.org/coprs/aneagle/gnome-rounded-blur/) and copy the file into `/etc/yum.repos.d/`, then use the following command to refresh the metadata
+```
+sudo rpm-ostree refresh-md --force 
+```
+- Bazzite (or any of ubluek atomic distro) can directly install the library via the following command (Fedora Atomic user after following the previous step can use this as well)
+```
+rpm-ostree install gnome-rounded-blur
+```
+
+
 ### Build it yourself
 
 You can visit the original repo [here](https://github.com/kancko/gnome-rounded-blur) for guide on how to build the library yourself. Do keep in mind that

--- a/scripts/GUIDE.md
+++ b/scripts/GUIDE.md
@@ -35,9 +35,9 @@ paru -S gnome-rounded-blur
 yay -S gnome-rounded-blur
 ```
 
-### For Fedora (or any of its derivaties, including Atomic based distro) users
+### For Fedora (or any of its derivatives, including Atomic based distro) users
 
-Fedora user can follow the following steps to install the libray
+Fedora user can follow the following steps to install the library
 
 - **REMEMBER TO UNINSTALL THE LIBRARY FIRST IF YOU ALREADY INSTALL IT VIA THE SCRIPT HERE**, you can uninstall it by following the uninstall command below
 - Enable the following copr using this command 
@@ -54,7 +54,7 @@ sudo dnf install gnome-rounded-blur
 ```
 sudo rpm-ostree refresh-md --force 
 ```
-- Bazzite (or any of ubluek atomic distro) can directly install the library via the following command (Fedora Atomic user after following the previous step can use this as well)
+- Bazzite (or any of ublue atomic distro) can directly install the library via the following command (Fedora Atomic user after following the previous step can use this as well)
 ```
 rpm-ostree install gnome-rounded-blur
 ```

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -208,18 +208,17 @@ prep_stage(){
 	else
 		if [[ "$MUTTER_SYS_VER" -ge 51 ]]; then
 			DIFF_VALUE_2="$MUTTER_SYS_VER"
-			sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
-			sed -i -E "s/mutter_req = '>= [0-9.]+'/mutter_req = '>= $MUTTER_SYS_VER.0'/" meson.build
 		elif [[ "$MUTTER_SYS_VER" -ge "$HARDCODE_MUTTER_SYS_VER" ]]; then
 			DIFF_VALUE=$((MUTTER_SYS_VER - HARDCODE_MUTTER_SYS_VER))
 			DIFF_VALUE_2=$((MUTTER_API_REPO_VER + DIFF_VALUE))
-			sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
 		else
 			DIFF_VALUE=$((HARDCODE_MUTTER_SYS_VER - MUTTER_SYS_VER))
 			DIFF_VALUE_2=$((MUTTER_API_REPO_VER - DIFF_VALUE))
-			sed -i -E "s/mutter_req = '>= [0-9.]+'/mutter_req = '>= $MUTTER_SYS_VER.0'/" meson.build
-			sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
 		fi
+
+		sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
+		sed -i -E "s/mutter_req = '>= [0-9.]+'/mutter_req = '>= $MUTTER_SYS_VER.0'/" meson.build
+		sed -i -E "s/dependency\('libmutter-[0-9]+'\)/dependency('libmutter-' + mutter_api_version)/" meson.build
 	fi
 	
 	install_dep

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
 
-check_env(){
-	OS_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID=).*')
-	OS_LIKE_ID_TYPE=$(cat /etc/os-release | grep -m 1 -o -P '(?<=ID_LIKE=).*' || true)
+is_os_family(){
+	local target="$1"
+	local os_id
+	local -a os_ids
+	read -r -a os_ids <<< "${OS_ID_TYPE:-} ${OS_LIKE_ID_TYPE:-}"
+	for os_id in "${os_ids[@]}"; do
+		if [[ "$os_id" = "$target" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
 
-	if [[ "$OS_ID_TYPE" = "arch" ]] || [[ "$OS_LIKE_ID_TYPE" = "arch" ]]; then
+check_env(){
+	source /etc/os-release
+	OS_ID_TYPE=${ID:-}
+	OS_LIKE_ID_TYPE=${ID_LIKE:-}
+
+	if is_os_family "arch"; then
 		if [[ $i = "y" ]] && [[ $u = "n" ]]; then		
 			echo "--------------------------------------------------------"
 			echo "Please do not use this script to install gnome-rounded-blur on Arch Linux"
@@ -22,7 +36,7 @@ check_env(){
 		exit 1
 	fi
 
-	if [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
+	if is_os_family "fedora"; then
 		if [[ $i = "y" ]] && [[ $u = "n" ]]; then		
 			echo "--------------------------------------------------------"
 			echo "Please do not use this script to install gnome-rounded-blur on Fedora"
@@ -50,7 +64,7 @@ check_env(){
 install_git(){
 	if ! command -v git >/dev/null 2>&1
 	then
-		if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
+		if is_os_family "debian"; then
 			echo "--------------------------------------------------------"
 			echo "Installing git"
 			echo "--------------------------------------------------------"
@@ -65,7 +79,7 @@ install_git(){
 	fi
 
 	# Ubuntu doesn't have this installed for some reason.
-	if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then	
+	if is_os_family "debian"; then
 		if ! command -v mutter >/dev/null 2>&1
 		then
 			echo "--------------------------------------------------------"
@@ -77,11 +91,11 @@ install_git(){
 }
 
 install_dep(){
-	if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]]; then
+	if is_os_family "debian"; then
 		echo "--------------------------------------------------------"
 		echo "Installing dependency"
 		echo "--------------------------------------------------------"
-		sudo apt -y install libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
+		sudo apt -y install libglib2.0-dev build-essential libmutter-"$DIFF_VALUE_2"-dev gobject-introspection meson
 	else
 		echo "--------------------------------------------------------"
 		echo "Please manually install the equivalent of libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson on your computer"
@@ -97,15 +111,14 @@ install_lib(){
 	echo "--------------------------------------------------------"
 	echo "Building the library"
 	echo "--------------------------------------------------------"
-	meson setup build;
-	meson compile -C build;
+	meson setup build --prefix=/usr
+	meson compile -C build
 	
 	# meson install the library in the wrong directory, we'll do that ourselves
 	echo "--------------------------------------------------------"
 	echo "Installing the library"
 	echo "--------------------------------------------------------"
-	meson install -C build --destdir "$dest_dir"
-	sudo cp -rf ./build/binary/usr/local/* /usr/
+	sudo meson install -C build
 	
 	echo "--------------------------------------------------------"
 	echo "For the changes to apply, please log out and then log back in."
@@ -115,18 +128,25 @@ install_lib(){
 uninstall_lib(){
 	check_env
 	
-	if [[ "$OS_ID_TYPE" = "debian" ]] || [[ "$OS_LIKE_ID_TYPE" = "debian" ]] || [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
+	if is_os_family "debian" || is_os_family "fedora"; then
 		echo "--------------------------------------------------------"
 		echo "Uninstalling"
 		echo "--------------------------------------------------------"
 		sudo rm -rf /usr/include/blur-effect-1.0
-		if [ -e /usr/lib64/libblur-effect-1.0.so ]; then
-			sudo rm /usr/lib64/girepository-1.0/Blur-1.0.typelib /usr/lib64/pkgconfig/blur-effect-1.0.pc /usr/lib64/libblur-effect-1.0.so /usr/lib64/libblur-effect-1.0.so.1 /usr/lib64/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		elif [ -e /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so ]; then
-			sudo rm /usr/lib/x86_64-linux-gnu/girepository-1.0/Blur-1.0.typelib /usr/lib/x86_64-linux-gnu/pkgconfig/blur-effect-1.0.pc /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1 /usr/lib/x86_64-linux-gnu/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		elif [ -e /usr/lib/libblur-effect-1.0.so ]; then
-			sudo rm /usr/lib/girepository-1.0/Blur-1.0.typelib /usr/lib/pkgconfig/blur-effect-1.0.pc /usr/lib/libblur-effect-1.0.so /usr/lib/libblur-effect-1.0.so.1 /usr/lib/libblur-effect-1.0.so.1.0.0 /usr/share/gir-1.0/Blur-1.0.gir || true
-		else
+		
+		# Clean library matching multiarch directories
+		local cleaned=0
+		for prefix in /usr/lib /usr/lib64 /usr/lib/*-linux-gnu; do
+			if [ -e "$prefix/libblur-effect-1.0.so" ]; then
+				sudo rm -f "$prefix"/girepository-1.0/Blur-1.0.typelib \
+				           "$prefix"/pkgconfig/blur-effect-1.0.pc \
+				           "$prefix"/libblur-effect-1.0.so* \
+				           /usr/share/gir-1.0/Blur-1.0.gir || true
+				cleaned=1
+			fi
+		done
+		
+		if [ $cleaned -eq 0 ]; then
 			echo "--------------------------------------------------------"
 			echo "No library found, skipping"
 			echo "--------------------------------------------------------"
@@ -151,35 +171,58 @@ prep_stage(){
 	echo "--------------------------------------------------------"
 	echo "Cloning repo"
 	echo "--------------------------------------------------------"
-	cd $build_dir
+	cd "$build_dir"
 	# Remove current working dir if found
 	if [ -d "gnome-rounded-blur" ]; then
 		rm -rf gnome-rounded-blur
-		git clone $REPO
-		cd gnome-rounded-blur;
-	else
-		git clone $REPO
-		cd gnome-rounded-blur;
 	fi
+	git clone --depth 1 "$REPO"
+	cd gnome-rounded-blur
 	
 	# Get mutter version
-	MUTTER_SYS_VER=$(mutter --version | grep -o -P '(?<=mutter ).*' | sed -e 's/"//g' -e "s/'//g" -e 's/\..*//g')
-	HARDCODE_MUTTER_SYS_VER=$(cat meson.build | grep -o -P '(?<=mutter_req = ).*' | sed -e 's/"//g' -e "s/'//g" -e 's/\..*//g' -e 's/>//g' -e 's/=//g' -e 's/ //g')
-	MUTTER_API_REPO_VER=$(cat meson.build | grep -o -P '(?<=mutter_api_version = ).*' | sed -e 's/"//g' -e "s/'//g" -e 's/ //g')
-	
-	# Edit meson.build to allow builing
-	if [[ "$MUTTER_SYS_VER" -ge "$HARDCODE_MUTTER_SYS_VER" ]]; then
-		DIFF_VALUE=$(echo "$MUTTER_SYS_VER - $HARDCODE_MUTTER_SYS_VER" | bc)
-		DIFF_VALUE_2=$(echo "$MUTTER_API_REPO_VER + $DIFF_VALUE" | bc)
-		sed -i -e '0,/'"mutter_api_version = ""$MUTTER_API_REPO_VER"'/{s/'"$MUTTER_API_REPO_VER"'/'"$DIFF_VALUE_2"'/g}' meson.build
+	if command -v mutter >/dev/null 2>&1; then
+		MUTTER_SYS_VER=$(mutter --version | grep -o -P '(?<=mutter ).*' | sed -e 's/"//g' -e "s/'//g" -e 's/\..*//g')
+	elif command -v gnome-shell >/dev/null 2>&1; then
+		MUTTER_SYS_VER=$(gnome-shell --version | grep -oE '[0-9]+' | head -n 1)
 	else
-		DIFF_VALUE=$(echo "$HARDCODE_MUTTER_SYS_VER - $MUTTER_SYS_VER" | bc)
-		DIFF_VALUE_2=$(echo "$MUTTER_API_REPO_VER - $DIFF_VALUE" | bc)
-		sed -i -e '0,/'"mutter_req = ""$HARDCODE_MUTTER_SYS_VER"'/{s/'"$HARDCODE_MUTTER_SYS_VER"'/'"$MUTTER_SYS_VER"'/g}' meson.build
-		sed -i -e '0,/'"mutter_api_version = ""$MUTTER_API_REPO_VER"'/{s/'"$MUTTER_API_REPO_VER"'/'"$DIFF_VALUE_2"'/g}' meson.build
+		MUTTER_SYS_VER=51
 	fi
 	
-	install_dep;
+	HARDCODE_MUTTER_SYS_VER=$(cat meson.build | grep -o -P '(?<=mutter_req = ).*' | sed -e 's/"//g' -e "s/'//g" -e 's/\..*//g' -e 's/>//g' -e 's/=//g' -e 's/ //g' | head -n 1)
+	MUTTER_API_REPO_VER=$(cat meson.build | grep -o -P '(?<=mutter_api_version = ).*' | sed -e 's/"//g' -e "s/'//g" -e 's/ //g' | head -n 1)
+	
+	# Edit meson.build to allow builing
+	if grep -q "mutter_api_versions" meson.build; then
+		if [[ "$MUTTER_SYS_VER" -ge 51 ]]; then
+			DIFF_VALUE_2="$MUTTER_SYS_VER"
+			if ! grep -q "'$MUTTER_SYS_VER'" meson.build; then
+				sed -i -e "s/mutter_api_versions = \[/mutter_api_versions = ['$MUTTER_SYS_VER', /g" meson.build
+			fi
+		elif [[ "$MUTTER_SYS_VER" -eq 50 ]]; then
+			DIFF_VALUE_2="18"
+		else
+			DIFF_VALUE_2=$((MUTTER_SYS_VER - 32))
+			sed -i -e "s/mutter_api_versions = \[/mutter_api_versions = ['$DIFF_VALUE_2', /g" meson.build
+			sed -i -e "s/mutter_req = '>= 50.0'/mutter_req = '>= $MUTTER_SYS_VER.0'/g" meson.build
+		fi
+	else
+		if [[ "$MUTTER_SYS_VER" -ge 51 ]]; then
+			DIFF_VALUE_2="$MUTTER_SYS_VER"
+			sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
+			sed -i -E "s/mutter_req = '>= [0-9.]+'/mutter_req = '>= $MUTTER_SYS_VER.0'/" meson.build
+		elif [[ "$MUTTER_SYS_VER" -ge "$HARDCODE_MUTTER_SYS_VER" ]]; then
+			DIFF_VALUE=$((MUTTER_SYS_VER - HARDCODE_MUTTER_SYS_VER))
+			DIFF_VALUE_2=$((MUTTER_API_REPO_VER + DIFF_VALUE))
+			sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
+		else
+			DIFF_VALUE=$((HARDCODE_MUTTER_SYS_VER - MUTTER_SYS_VER))
+			DIFF_VALUE_2=$((MUTTER_API_REPO_VER - DIFF_VALUE))
+			sed -i -E "s/mutter_req = '>= [0-9.]+'/mutter_req = '>= $MUTTER_SYS_VER.0'/" meson.build
+			sed -i -E "s/mutter_api_version = '[0-9]+'/mutter_api_version = '$DIFF_VALUE_2'/" meson.build
+		fi
+	fi
+	
+	install_dep
 }
 
 help_doc(){
@@ -192,10 +235,8 @@ help_doc(){
 }
 
 
-# More safety, by turning some bugs into errors.
 set -o errexit -o pipefail -o noclobber -o nounset
 
-# ignore errexit with `&& true`
 getopt --test > /dev/null && true
 if [[ $? -ne 4 ]]; then
     echo 'I’m sorry, `getopt --test` failed in this environment.'
@@ -205,16 +246,10 @@ fi
 LONGOPTS=install,uninstall,help
 OPTIONS=iuh
 
-# -temporarily store output to be able to check for errors
-# -activate quoting/enhanced mode (e.g. by writing out “--options”)
-# -pass arguments only via   -- "$@"   to separate them correctly
-# -if getopt fails, it complains itself to stderr
 PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
-# read getopt’s output this way to handle the quoting right:
 eval set -- "$PARSED"
 
 i=n u=n h=n
-# now enjoy the options in order and nicely split until we see --
 while true; do
     case "$1" in
         -i|--install)
@@ -247,8 +282,7 @@ while true; do
 done
 
 # handle non-option arguments
-if [[ $# -ne 1 ]]; then
-    echo "$0: A single input file is required."
+if [[ "$i" = "n" && "$u" = "n" && "$h" = "n" ]]; then
 	help_doc
     exit 4
 fi

--- a/scripts/rounded_blur_build.sh
+++ b/scripts/rounded_blur_build.sh
@@ -21,6 +21,30 @@ check_env(){
 		sleep 5
 		exit 1
 	fi
+
+	if [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
+		if [[ $i = "y" ]] && [[ $u = "n" ]]; then		
+			echo "--------------------------------------------------------"
+			echo "Please do not use this script to install gnome-rounded-blur on Fedora"
+			echo "To install this library on Fedora, follow the guide below"
+			echo "https://github.com/aunetx/blur-my-shell/blob/master/scripts/GUIDE.md"
+			echo "--------------------------------------------------------"
+			sleep 5
+			exit 1
+		elif [[ $i = "n" ]] && [[ $u = "y" ]]; then	
+			echo "--------------------------------------------------------"
+			echo "Checking if the library is already installed via system package manager"
+			echo "--------------------------------------------------------"
+			if rpm -q --quiet "gnome-rounded-blur"; then
+				echo "--------------------------------------------------------"
+				echo "Please do not use this script to uninstall gnome-rounded-blur on Fedora"
+				echo "To uninstall this library on Fedora, use your system package manager"
+				echo "--------------------------------------------------------"
+				sleep 5
+				exit 1
+			fi
+		fi
+	fi
 }
 
 install_git(){
@@ -31,11 +55,6 @@ install_git(){
 			echo "Installing git"
 			echo "--------------------------------------------------------"
 			sudo apt -y install git 
-		elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
-			echo "--------------------------------------------------------"
-			echo "Installing git"
-			echo "--------------------------------------------------------"
-			sudo dnf -y install git
 		else
 			echo "--------------------------------------------------------"
 			echo "Please manually install git using your distro's package manager"
@@ -63,11 +82,6 @@ install_dep(){
 		echo "Installing dependency"
 		echo "--------------------------------------------------------"
 		sudo apt -y install libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson
-	elif [[ "$OS_ID_TYPE" = "fedora" ]] || [[ "$OS_LIKE_ID_TYPE" = "fedora" ]]; then
-		echo "--------------------------------------------------------"
-		echo "Installing dependency"
-		echo "--------------------------------------------------------"
-		sudo dnf -y install glib2-devel @c-development meson mutter-devel gobject-introspection
 	else
 		echo "--------------------------------------------------------"
 		echo "Please manually install the equivalent of libglib2.0-dev build-essential libmutter-$DIFF_VALUE_2-dev gobject-introspection meson on your computer"


### PR DESCRIPTION
- Update the script to now inform Fedora user that they should use dnf to install the library from now on using external copr (https://github.com/ublue-os/packages/pull/1336)
- Support GNOME 51 (https://github.com/kancko/gnome-rounded-blur/pull/4)