### PR TITLE
More popup blur style tweaks

### DIFF
--- a/src/styles/popup/base.css
+++ b/src/styles/popup/base.css
@@ -91,6 +91,13 @@
     background: rgba(255, 255, 255, 0.4) !important;
 }
 
+.bms-popup-background-light .message:active,
+.bms-popup-surface-light .message:active,
+.bms-popup-background-light .message:focus,
+.bms-popup-surface-light .message:focus {
+    background: rgba(255, 255, 255, 0.7) !important;
+}
+
 .bms-popup-background-dark .popup-menu-content,
 .bms-popup-background-dark .popup-sub-menu,
 .bms-popup-background-dark .candidate-popup-content,
@@ -148,6 +155,17 @@
 .bms-popup-surface-dark .message:hover,
 .bms-popup-surface-transparent .message:hover {
     background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.bms-popup-background-dark .message:focus,
+.bms-popup-background-transparent .message:focus,
+.bms-popup-surface-dark .message:focus,
+.bms-popup-surface-transparent .message:focus,
+.bms-popup-background-dark .message:active,
+.bms-popup-background-transparent .message:active,
+.bms-popup-surface-dark .message:active,
+.bms-popup-surface-transparent .message:active {
+    background: rgba(255, 255, 255, 0.15) !important;
 }
 
 .bms-popup-background-transparent .message,
@@ -234,6 +252,27 @@
     -barlevel-background-color: rgba(255, 255, 255, 0.14);
     -barlevel-active-background-color: #ffffff;
     -barlevel-overdrive-color: #f66151;
+}
+
+.bms-popup-background-light .switcher-list .item-box:focus,
+.bms-popup-background-light .switcher-list .item-box:selected,
+.bms-popup-surface-light .switcher-list .item-box:focus,
+.bms-popup-surface-light .switcher-list .item-box:selected {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
+.bms-popup-background-dark .switcher-list .item-box:focus,
+.bms-popup-background-dark .switcher-list .item-box:selected,
+.bms-popup-surface-dark .switcher-list .item-box:focus,
+.bms-popup-surface-dark .switcher-list .item-box:selected {
+  background-color: rgba(255, 255, 255, 0.13) !important;
+}
+
+.bms-popup-background-transparent .switcher-list .item-box:focus,
+.bms-popup-background-transparent .switcher-list .item-box:selected,
+.bms-popup-surface-transparent .switcher-list .item-box:focus,
+.bms-popup-surface-transparent .switcher-list .item-box:selected {
+  background-color: rgba(255, 255, 255, 0.13) !important;
 }
 
 .bms-popup-background-transparent .popup-sub-menu,

--- a/src/styles/popup/dark.css
+++ b/src/styles/popup/dark.css
@@ -10,6 +10,54 @@
     box-shadow: none;
 }
 
+.bms-popup-background-dark .message-media-control,
+.bms-popup-surface-dark .message-media-control {
+  background-color: transparent;
+}
+
+.bms-popup-background-dark .message-media-control:last-child,
+.bms-popup-surface-dark .message-media-control:last-child {
+  background-color: transparent;
+}
+
+.bms-popup-background-dark .message-media-control:first-child:last-child,
+.bms-popup-surface-dark .message-media-control:first-child:last-child {
+  background-color: transparent;
+}
+
+.bms-popup-background-dark .message-media-control:hover,
+.bms-popup-surface-dark .message-media-control:hover,
+.bms-popup-background-dark .message-expand-button:hover,
+.bms-popup-surface-dark .message-expand-button:hover,
+.bms-popup-background-dark .switcher-list .item-box:hover,
+.bms-popup-surface-dark .switcher-list .item-box:hover {
+  background-color: rgba(255, 255, 255, 0.20) !important;
+}
+
+.bms-popup-background-dark .message-media-control:active,
+.bms-popup-surface-dark .message-media-control:active,
+.bms-popup-background-dark .message-expand-button:active,
+.bms-popup-surface-dark .message-expand-button:active,
+.bms-popup-background-dark .switcher-list .item-box:active,
+.bms-popup-surface-dark .switcher-list .item-box:active {
+  background-color: rgba(255, 255, 255, 0.24) !important;
+}
+
+.bms-popup-background-dark .message-media-control:focus,
+.bms-popup-background-dark .message-media-control:checked,
+.bms-popup-surface-dark .message-media-control:focus,
+.bms-popup-surface-dark .message-media-control:checked,
+.bms-popup-background-dark .message-expand-button:focus,
+.bms-popup-background-dark .message-expand-button:checked,
+.bms-popup-surface-dark .message-expand-button:focus,
+.bms-popup-surface-dark .message-expand-button:checked,
+.bms-popup-background-dark .message-notification-group StButton:focus,
+.bms-popup-background-dark .message-notification-group StButton:checked,
+.bms-popup-surface-dark .message-notification-group StButton:focus,
+.bms-popup-surface-dark .message-notification-group StButton:checked {
+  background-color: rgba(255, 255, 255, 0.13) !important;
+}
+
 .bms-popup-background-dark .message-list-controls .message-list-clear-button {
     color: #ffffff;
     background-color: rgba(255, 255, 255, 0.08) !important;

--- a/src/styles/popup/dark.css
+++ b/src/styles/popup/dark.css
@@ -15,16 +15,6 @@
   background-color: transparent;
 }
 
-.bms-popup-background-dark .message-media-control:last-child,
-.bms-popup-surface-dark .message-media-control:last-child {
-  background-color: transparent;
-}
-
-.bms-popup-background-dark .message-media-control:first-child:last-child,
-.bms-popup-surface-dark .message-media-control:first-child:last-child {
-  background-color: transparent;
-}
-
 .bms-popup-background-dark .message-media-control:hover,
 .bms-popup-surface-dark .message-media-control:hover,
 .bms-popup-background-dark .message-expand-button:hover,

--- a/src/styles/popup/light.css
+++ b/src/styles/popup/light.css
@@ -15,16 +15,6 @@
   background-color: transparent;
 }
 
-.bms-popup-background-light .message-media-control:last-child,
-.bms-popup-surface-light .message-media-control:last-child {
-  background-color: transparent;
-}
-
-.bms-popup-background-light .message-media-control:first-child:last-child,
-.bms-popup-surface-light .message-media-control:first-child:last-child {
-  background-color: transparent;
-}
-
 .bms-popup-background-light .message-media-control:hover,
 .bms-popup-surface-light .message-media-control:hover,
 .bms-popup-background-light .message-expand-button:hover,

--- a/src/styles/popup/light.css
+++ b/src/styles/popup/light.css
@@ -10,6 +10,58 @@
     box-shadow: none;
 }
 
+.bms-popup-background-light .message-media-control,
+.bms-popup-surface-light .message-media-control {
+  background-color: transparent;
+}
+
+.bms-popup-background-light .message-media-control:last-child,
+.bms-popup-surface-light .message-media-control:last-child {
+  background-color: transparent;
+}
+
+.bms-popup-background-light .message-media-control:first-child:last-child,
+.bms-popup-surface-light .message-media-control:first-child:last-child {
+  background-color: transparent;
+}
+
+.bms-popup-background-light .message-media-control:hover,
+.bms-popup-surface-light .message-media-control:hover,
+.bms-popup-background-light .message-expand-button:hover,
+.bms-popup-surface-light .message-expand-button:hover,
+.bms-popup-background-light .message-notification-group StButton:hover,
+.bms-popup-surface-light .message-notification-group StButton:hover,
+.bms-popup-background-light .switcher-list .item-box:hover,
+.bms-popup-surface-light .switcher-list .item-box:hover {
+  background-color: rgba(0, 0, 0, 0.18) !important;
+}
+
+.bms-popup-background-light .message-media-control:active,
+.bms-popup-surface-light .message-media-control:active,
+.bms-popup-background-light .message-expand-button:active,
+.bms-popup-surface-light .message-expand-button:active,
+.bms-popup-background-light .message-notification-group StButton:active,
+.bms-popup-surface-light .message-notification-group StButton:active,
+.bms-popup-background-light .switcher-list .item-box:active,
+.bms-popup-surface-light .switcher-list .item-box:active {
+  background-color: rgba(0, 0, 0, 0.22) !important;
+}
+
+.bms-popup-background-light .message-media-control:focus,
+.bms-popup-background-light .message-media-control:checked,
+.bms-popup-surface-light .message-media-control:focus,
+.bms-popup-surface-light .message-media-control:checked,
+.bms-popup-background-light .message-expand-button:focus,
+.bms-popup-background-light .message-expand-button:checked,
+.bms-popup-surface-light .message-expand-button:focus,
+.bms-popup-surface-light .message-expand-button:checked,
+.bms-popup-background-light .message-notification-group StButton:focus,
+.bms-popup-background-light .message-notification-group StButton:checked,
+.bms-popup-surface-light .message-notification-group StButton:focus,
+.bms-popup-surface-light .message-notification-group StButton:checked {
+  background-color: rgba(0, 0, 0, 0.12) !important;
+}
+
 .bms-popup-background-light .message .message-header,
 .bms-popup-background-light .message .message-header .message-header-content .event-time {
     color: rgba(34, 34, 38, 0.68);

--- a/src/styles/popup/transparent.css
+++ b/src/styles/popup/transparent.css
@@ -15,16 +15,6 @@
   background-color: transparent;
 }
 
-.bms-popup-background-transparent .message-media-control:last-child,
-.bms-popup-surface-transparent .message-media-control:last-child {
-  background-color: transparent;
-}
-
-.bms-popup-background-transparent .message-media-control:first-child:last-child,
-.bms-popup-surface-transparent .message-media-control:first-child:last-child {
-  background-color: transparent;
-}
-
 .bms-popup-background-transparent .message-media-control:hover,
 .bms-popup-surface-transparent .message-media-control:hover,
 .bms-popup-background-transparent .message-expand-button:hover,

--- a/src/styles/popup/transparent.css
+++ b/src/styles/popup/transparent.css
@@ -10,6 +10,58 @@
     box-shadow: none;
 }
 
+.bms-popup-background-transparent .message-media-control,
+.bms-popup-surface-transparent .message-media-control {
+  background-color: transparent;
+}
+
+.bms-popup-background-transparent .message-media-control:last-child,
+.bms-popup-surface-transparent .message-media-control:last-child {
+  background-color: transparent;
+}
+
+.bms-popup-background-transparent .message-media-control:first-child:last-child,
+.bms-popup-surface-transparent .message-media-control:first-child:last-child {
+  background-color: transparent;
+}
+
+.bms-popup-background-transparent .message-media-control:hover,
+.bms-popup-surface-transparent .message-media-control:hover,
+.bms-popup-background-transparent .message-expand-button:hover,
+.bms-popup-surface-transparent .message-expand-button:hover,
+.bms-popup-background-transparent .message-notification-group StButton:hover,
+.bms-popup-surface-transparent .message-notification-group StButton:hover,
+.bms-popup-background-transparent .switcher-list .item-box:hover,
+.bms-popup-surface-transparent .switcher-list .item-box:hover {
+  background-color: rgba(255, 255, 255, 0.20) !important;
+}
+
+.bms-popup-background-transparent .message-media-control:active,
+.bms-popup-surface-transparent .message-media-control:active,
+.bms-popup-background-transparent .message-expand-button:active,
+.bms-popup-surface-transparent .message-expand-button:active,
+.bms-popup-background-transparent .message-notification-group StButton:active,
+.bms-popup-surface-transparent .message-notification-group StButton:active,
+.bms-popup-background-transparent .switcher-list .item-box:active,
+.bms-popup-surface-transparent .switcher-list .item-box:active {
+  background-color: rgba(255, 255, 255, 0.24) !important;
+}
+
+.bms-popup-background-transparent .message-media-control:focus,
+.bms-popup-background-transparent .message-media-control:checked,
+.bms-popup-surface-transparent .message-media-control:focus,
+.bms-popup-surface-transparent .message-media-control:checked,
+.bms-popup-background-transparent .message-expand-button:focus,
+.bms-popup-background-transparent .message-expand-button:checked,
+.bms-popup-surface-transparent .message-expand-button:focus,
+.bms-popup-surface-transparent .message-expand-button:checked,
+.bms-popup-background-transparent .message-notification-group StButton:focus,
+.bms-popup-background-transparent .message-notification-group StButton:checked,
+.bms-popup-surface-transparent .message-notification-group StButton:focus,
+.bms-popup-surface-transparent .message-notification-group StButton:checked {
+  background-color: rgba(255, 255, 255, 0.13) !important;
+}
+
 .bms-popup-background-transparent .message-list-controls .message-list-clear-button {
     color: #ffffff;
     background-color: rgba(255, 255, 255, 0.08) !important;


### PR DESCRIPTION
This introduce a couple more tweaks to Popup blur styling:
- Add button state styling for `.switcher-list`, `.message-expand-button` and `.message-media-control`

There's supposed to be state styling for `.message` as well, there's styling for it but they don't work on touchscreen for some reason