### PR TITLE
Fix Dash-to-dock Panel mode not blurring on startup & Revert #963

### DIFF
--- a/src/components/dash_to_dock.js
+++ b/src/components/dash_to_dock.js
@@ -425,6 +425,15 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
             _ => this.update_size()
         );
 
+        const slider = dash_container._slider;
+        if (slider) {
+            this.connections.connect(
+                slider,
+                ['notify::slide-x', 'notify::allocation'],
+                _ => this.update_size()
+            );
+        }
+
         const dash_background = dash._background ||
             dash.get_children().find(child => child.get_style_class_name?.()?.includes('dash-background')) ||
             dash;
@@ -444,6 +453,12 @@ export const DashBlur = class DashBlur extends Signals.EventEmitter {
         );
 
         this.update_size();
+
+        global.compositor.get_laters().add(Meta.LaterType.BEFORE_REDRAW, () => {
+            this.update_size();
+            return false;
+        });
+
         this.update_background();
 
         // returns infos

--- a/src/conveniences/paint_signals.js
+++ b/src/conveniences/paint_signals.js
@@ -1,10 +1,7 @@
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
-import GLib from 'gi://GLib';
 
-// Shell.BlurEffect needs explicit invalidation for some shadow updates. Limit
-// those refreshes so a constantly painting actor cannot keep the GPU busy.
-const REPAINT_INTERVAL_US = 100_000;
+const PAINTS_BETWEEN_REPAINTS = 2;
 
 export const PaintSignals = class PaintSignals {
     constructor(connections) {
@@ -15,61 +12,26 @@ export const PaintSignals = class PaintSignals {
     connect(actor, blur_effect) {
         this.disconnect_all_for_actor(actor);
 
-        let last_repaint_at = 0;
-        let repaint_timeout_id = 0;
-        let skip_next_paint = false;
-        const queue_repaint = () => {
-            last_repaint_at = GLib.get_monotonic_time();
-            skip_next_paint = true;
+        let paints_to_skip = 0;
+        const paint_effect = new PaintCallbackEffect();
+        paint_effect.set_callback(() => {
+            if (paints_to_skip > 0) {
+                paints_to_skip--;
+                return;
+            }
+
+            paints_to_skip = PAINTS_BETWEEN_REPAINTS;
             try {
                 blur_effect.queue_repaint();
-            } catch (e) {
-                skip_next_paint = false;
-            }
-        };
-        const cancel_repaint = () => {
-            if (!repaint_timeout_id)
-                return;
-
-            GLib.Source.remove(repaint_timeout_id);
-            repaint_timeout_id = 0;
-        };
-        const paint_effect = new PaintCallbackEffect();
-        paint_effect.set_callback(paint_flags => {
-            if (skip_next_paint) {
-                skip_next_paint = false;
-                return;
-            }
-
-            if (!(paint_flags & Clutter.EffectPaintFlags.ACTOR_DIRTY))
-                return;
-
-            const now = GLib.get_monotonic_time();
-            const elapsed = now - last_repaint_at;
-            if (elapsed >= REPAINT_INTERVAL_US) {
-                cancel_repaint();
-                queue_repaint();
-                return;
-            }
-
-            if (repaint_timeout_id)
-                return;
-
-            const delay = Math.max(1, Math.ceil((REPAINT_INTERVAL_US - elapsed) / 1000));
-            repaint_timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
-                repaint_timeout_id = 0;
-                queue_repaint();
-                return GLib.SOURCE_REMOVE;
-            });
+            } catch (e) { }
         });
 
         actor.add_effect(paint_effect);
         const destroy_id = this.connections.connect(actor, 'destroy', () => {
             paint_effect.set_callback(null);
-            cancel_repaint();
             this.entries.delete(actor);
         });
-        this.entries.set(actor, { paint_effect, destroy_id, cancel_repaint });
+        this.entries.set(actor, { paint_effect, destroy_id });
     }
 
     disconnect_all_for_actor(actor) {
@@ -79,7 +41,6 @@ export const PaintSignals = class PaintSignals {
 
         this.entries.delete(actor);
         entry.paint_effect.set_callback(null);
-        entry.cancel_repaint();
         this.connections.disconnect(actor, entry.destroy_id);
         try {
             actor.remove_effect(entry.paint_effect);
@@ -100,7 +61,7 @@ const PaintCallbackEffect = GObject.registerClass(
         }
 
         vfunc_paint(node, paint_context, paint_flags) {
-            this._callback?.(paint_flags);
+            this._callback?.();
             super.vfunc_paint(node, paint_context, paint_flags);
         }
     }

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -503,7 +503,7 @@ export function get_supported_effects(_ = () => "") {
             editable_params: {
                 radius: {
                     name: _("Radius"),
-                    description: _("The radius of the corner. GNOME apps use a radius of 12 px by default."),
+                    description: _("The radius of the corner. GNOME apps use a radius of 15 px by default."),
                     type: "integer",
                     min: 0,
                     max: 150,


### PR DESCRIPTION
- Fix #974 by tracking _slider signals and deferring dock update
- Revert #963 to fix #978
- Edit corner effects description in Static blur pipeline settings to now said that GNOME apps use a 15px radius instead of 12px (it's been 15px since GNOME 48)