### PR TITLE
Popup blur stylesheet tweaks

### DIFF
--- a/src/styles/popup/base.css
+++ b/src/styles/popup/base.css
@@ -338,6 +338,18 @@
     background-color: rgba(255, 255, 255, 0.13) !important
 }
 
+.bms-popup-background-light .screenshot-ui-type-button,
+.bms-popup-background-light .screenshot-ui-show-pointer-button,
+.bms-popup-background-light .screenshot-ui-shot-cast-button {
+    color: #1a1a1e !important;
+}
+
+.bms-popup-background-light .screenshot-ui-type-button:insensitive,
+.bms-popup-background-light .screenshot-ui-show-pointer-button:insensitive,
+.bms-popup-background-light .screenshot-ui-shot-cast-button:insensitive {
+    color: rgba(26, 26, 30, 0.5) !important;
+}
+
 .bms-popup-background-transparent .screenshot-ui-type-button:hover,
 .bms-popup-background-dark .screenshot-ui-type-button:hover {
     background-color: rgba(255, 255, 255, 0.20) !important;
@@ -386,7 +398,7 @@
 .bms-popup-background-transparent .screenshot-ui-show-pointer-button:focus,
 .bms-popup-background-dark .screenshot-ui-show-pointer-button:checked,
 .bms-popup-background-dark .screenshot-ui-show-pointer-button:focus {
-    background-color: rgba(255, 255, 255, 0.13) !important
+    background-color: rgba(255, 255, 255, 0.13) !important;
 }
 
 .bms-popup-background-transparent .screenshot-ui-show-pointer-button:hover,
@@ -404,6 +416,58 @@
 .bms-popup-background-light .screenshot-ui-show-pointer-button:active,
 .bms-popup-background-light .screenshot-ui-show-pointer-button:outlined {
     background-color: rgba(0, 0, 0, 0.16) !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button {
+    border: 4px #1a1a1e !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button .screenshot-ui-capture-button-circle {
+    background-color: #1a1a1e !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button:hover .screenshot-ui-capture-button-circle,
+.bms-popup-background-light .screenshot-ui-capture-button:focus .screenshot-ui-capture-button-circle {
+    background-color: #3a3a3e !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button:active .screenshot-ui-capture-button-circle {
+    background-color: #5a5a5e !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button:cast .screenshot-ui-capture-button-circle {
+    background-color: #c01c28 !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button:cast:hover .screenshot-ui-capture-button-circle,
+.bms-popup-background-light .screenshot-ui-capture-button:cast:focus .screenshot-ui-capture-button-circle {
+    background-color: #d61f2d !important;
+}
+
+.bms-popup-background-light .screenshot-ui-capture-button:cast:active .screenshot-ui-capture-button-circle {
+    background-color: #a11722 !important;
+}
+
+.bms-popup-background-light .screenshot-ui-shot-cast-container {
+    background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.bms-popup-background-light .screenshot-ui-shot-cast-button:hover,
+.bms-popup-background-light .screenshot-ui-shot-cast-button:focus {
+    background-color: rgba(0, 0, 0, 0.18) !important;
+}
+
+.bms-popup-background-light .screenshot-ui-shot-cast-button:active {
+    background-color: rgba(0, 0, 0, 0.28) !important;
+}
+
+.bms-popup-background-light .screenshot-ui-shot-cast-button:checked {
+    background-color: #1a1a1e !important;
+    color: #ffffff !important;
+}
+
+.bms-popup-background-light .screenshot-ui-shot-cast-button:insensitive {
+    color: rgba(26, 26, 30, 0.5) !important;
 }
 
 .bms-popup-background-transparent .popup-sub-menu .popup-menu-section,
@@ -484,14 +548,19 @@
 
 .bms-popup-background-dark .keyboard-key:checked,
 .bms-popup-background-transparent .keyboard-key:checked,
-.bms-popup-background-dark .keyboard-key:focus,
-.bms-popup-background-transparent .keyboard-key:focus,
 .bms-popup-background-dark .keyboard-subkeys .keyboard-key:checked,
-.bms-popup-background-transparent .keyboard-subkeys .keyboard-key:checked,
-.bms-popup-background-dark .keyboard-subkeys .keyboard-key:focus,
-.bms-popup-background-transparent .keyboard-subkeys .keyboard-key:focus {
+.bms-popup-background-transparent .keyboard-subkeys .keyboard-key:checked {
   background-color: rgba(255, 255, 255, 0.13) !important;
   box-shadow: inset 0 0 0 2px rgba(53, 132, 228, 0.6);
+  color: #ffffff;
+}
+
+.bms-popup-background-dark .keyboard-key:focus,
+.bms-popup-background-transparent .keyboard-key:focus,
+.bms-popup-background-dark .keyboard-subkeys .keyboard-key:focus,
+.bms-popup-background-transparent .keyboard-subkeys .keyboard-key:focus {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  box-shadow: none;
   color: #ffffff;
 }
 
@@ -592,12 +661,17 @@
 }
 
 .bms-popup-background-light .keyboard-key:checked,
-.bms-popup-background-light .keyboard-key:focus,
-.bms-popup-background-light .keyboard-subkeys .keyboard-key:checked,
-.bms-popup-background-light .keyboard-subkeys .keyboard-key:focus {
+.bms-popup-background-light .keyboard-subkeys .keyboard-key:checked {
   background-color: rgba(0, 0, 0, 0.12) !important;
   box-shadow: inset 0 0 0 2px rgba(53, 132, 228, 0.6);
   color: #000000;
+}
+
+.bms-popup-background-light .keyboard-key:focus,
+.bms-popup-background-light .keyboard-subkeys .keyboard-key:focus {
+  background-color: rgba(0, 0, 0, 0.07) !important;
+  box-shadow: none;
+  color: #1a1a1a;
 }
 
 .bms-popup-background-light .keyboard-key:grayed {

--- a/src/styles/popup/dark.css
+++ b/src/styles/popup/dark.css
@@ -62,6 +62,11 @@
     background-color: rgba(255, 255, 255, 0.18) !important;
 }
 
+.bms-popup-background-dark .modal-dialog .button:insensitive,
+.bms-popup-background-dark .modal-dialog .modal-dialog-button-box .modal-dialog-button:insensitive {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
 .bms-popup-background-dark .quick-toggle,
 .bms-popup-background-dark .quick-toggle-has-menu .quick-toggle-menu-button,
 .bms-popup-background-dark .notification-button {
@@ -231,4 +236,23 @@
 .bms-popup-background-dark .quick-toggle-has-menu:checked .quick-toggle-separator {
     background-color: rgba(255, 255, 255, 0.3);
     background-color: st-mix(-st-accent-fg-color, -st-accent-color, 30%);
+}
+
+.bms-popup-background-dark StEntry {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.bms-popup-background-dark StEntry:focus {
+    background-color: rgba(255, 255, 255, 0.13) !important;
+    color: #ffffff !important;
+}
+
+.bms-popup-background-dark StEntry:insensitive {
+    background-color: rgba(255, 255, 255, 0.05) !important;
+    color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.bms-popup-background-dark StEntry StLabel.hint-text {
+    color: rgba(255, 255, 255, 0.5) !important;
 }

--- a/src/styles/popup/light.css
+++ b/src/styles/popup/light.css
@@ -313,3 +313,23 @@
     background-color: rgba(255, 255, 255, 0.3);
     background-color: st-mix(-st-accent-fg-color, -st-accent-color, 20%);
 }
+
+.bms-popup-background-light StEntry {
+    color: #222226 !important;
+    background-color: rgba(255, 255, 255, 0.42) !important;
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+.bms-popup-background-light StEntry:focus {
+    color: #222226 !important;
+    background-color: rgba(255, 255, 255, 0.54) !important;
+}
+
+.bms-popup-background-light StEntry:insensitive {
+    color: rgba(34, 34, 38, 0.5) !important;
+    background-color: rgba(255, 255, 255, 0.28) !important;
+}
+
+.bms-popup-background-light StEntry StLabel.hint-text {
+    color: rgba(34, 34, 38, 0.5) !important;
+}

--- a/src/styles/popup/transparent.css
+++ b/src/styles/popup/transparent.css
@@ -66,6 +66,11 @@
     background-color: rgba(255, 255, 255, 0.18) !important;
 }
 
+.bms-popup-background-transparent .modal-dialog .button:insensitive,
+.bms-popup-background-transparent .modal-dialog .modal-dialog-button-box .modal-dialog-button:insensitive {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
 .bms-popup-background-transparent .quick-toggle,
 .bms-popup-background-transparent .quick-toggle-has-menu .quick-toggle-menu-button,
 .bms-popup-background-transparent .notification-button {
@@ -235,4 +240,23 @@
 .bms-popup-background-transparent .quick-toggle-has-menu:checked .quick-toggle-separator {
     background-color: rgba(255, 255, 255, 0.3);
     background-color: st-mix(-st-accent-fg-color, -st-accent-color, 30%);
+}
+
+.bms-popup-background-transparent StEntry {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+}
+
+.bms-popup-background-transparent StEntry:focus {
+    background-color: rgba(255, 255, 255, 0.13) !important;
+    color: #ffffff !important;
+}
+
+.bms-popup-background-transparent StEntry:insensitive {
+    background-color: rgba(255, 255, 255, 0.05) !important;
+    color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.bms-popup-background-transparent StEntry StLabel.hint-text {
+    color: rgba(255, 255, 255, 0.5) !important;
 }


### PR DESCRIPTION
This introduce a small tweaks to popup blur stylesheet
- Style `modal-dialog` insensitive buttons
- Style `StEntry`
- Add missing styling for `screenshot-ui-panel` in light mode
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/287bb1f6-26d9-46d7-bf50-69760f072b75" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/63277934-eb05-4d6d-8f60-c6d59cdb165a" />

There is this gnome shell bug related to OSK keep the key highlighted after hover or tap when in password prompt, we should report this to them as well (without extension it's there but faintly brighter)
<img width="1366" height="768" alt="Screenshot From 2026-09-06 18-15-35" src="https://github.com/user-attachments/assets/c1114c2d-db81-4f52-b6d5-4afa93b39226" />

