### PR TITLE
Add new, more optimized glass effect

### DIFF
--- a/src/effects/effect_groups.js
+++ b/src/effects/effect_groups.js
@@ -6,6 +6,7 @@ export function get_effects_groups(_ = _ => '') {
                 'native_static_gaussian_blur',
                 'gaussian_blur',
                 'monte_carlo_blur',
+                'glass',
             ],
         },
         texture_effects: {

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -13,6 +13,8 @@ import { RgbToHslEffect } from './rgb_to_hsl.js';
 import { HslToRgbEffect } from './hsl_to_rgb.js';
 import { LuminosityEffect } from './luminosity.js';
 import { RefractionEffect } from './refraction.js';
+import { GlassEffect } from './glass.js';
+
 export { get_effects_groups } from './effect_groups.js';
 
 export function get_supported_effects(_ = () => "") {
@@ -493,6 +495,111 @@ export function get_supported_effects(_ = () => "") {
             description: _("Converts the image from HSLA colorspace to RGBA."),
             is_advanced: true,
             editable_params: {}
+        },
+
+        glass: {
+            class: GlassEffect,
+            name: _("Glass"),
+            description: _("A glass refraction effect that simulates a lens distorting the background."),
+            is_advanced: false,
+            editable_params: {
+                radius: {
+                    name: _("Corner radius"),
+                    description: _("The radius of the glass corners."),
+                    type: "integer",
+                    min: 5,
+                    max: 150,
+                    increment: 1,
+                },
+                refraction: {
+                    name: _("Refraction"),
+                    description: _("How strong the light refract along the edges."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+                depth: {
+                    name: _("Depth"),
+                    description: _("How thick your refraction appears from the edges."),
+                    type: "float",
+                    min: 0.,
+                    max: 50.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+                dispersion: {
+                    name: _("Dispersion"),
+                    description: _("Chromatic aberration at the edges of your glass."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+                splay: {
+                    name: _("Splay"),
+                    description: _("The spread of how light bends around edges."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+                light_angle: {
+                    name: _("Light angle"),
+                    description: _("The direction the light hits the glass surface."),
+                    type: "integer",
+                    min: 0,
+                    max: 360,
+                    increment: 1,
+                },
+                light_intensity: {
+                    name: _("Light intensity"),
+                    description: _("How bright the rim light and shadow appear."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+                light_ambient: {
+                    name: _("Light ambient"),
+                    description: _("The base brightness applied evenly around the edges."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+                light_depth: {
+                    name: _("Light depth"),
+                    description: _("How far the rim light extends inward from the border."),
+                    type: "float",
+                    min: 0.,
+                    max: 10.,
+                    increment: 1.,
+                    big_increment: 2.,
+                    digits: 0.
+                },
+                light_feather: {
+                    name: _("Light feather"),
+                    description: _("How softly the rim light fades toward the center."),
+                    type: "float",
+                    min: 0.,
+                    max: 100.,
+                    increment: 1.,
+                    big_increment: 10.,
+                    digits: 0.
+                },
+            }
         },
 
         corner: {

--- a/src/effects/glass.glsl
+++ b/src/effects/glass.glsl
@@ -1,0 +1,152 @@
+uniform sampler2D tex;
+
+// Resolution
+uniform float width;
+uniform float height;
+
+// Clipping
+uniform float clip_x0;
+uniform float clip_y0;
+uniform float clip_width;
+uniform float clip_height;
+
+// Glass
+uniform float radius;
+uniform float refraction;
+uniform float depth;
+uniform float dispersion;
+uniform float splay;
+
+// Light
+uniform float light_angle;
+uniform float light_intensity;
+uniform float light_ambient;
+uniform float light_depth;
+uniform float light_feather;
+
+float sdf(vec2 p, vec2 b, float r) {
+    vec2 d = abs(p) - b + vec2(r);
+    return min(max(d.x, d.y), 0.0) + length(max(d, 0.0)) - r;   
+}
+
+float safe_sqrt(float val) {
+    return sqrt(max(val, 0.0));
+}
+
+float nonzero(float val){
+    return max(val, 000.1);
+}
+
+vec4 getTextureColorAt(vec2 coord) {
+    vec2 uv = coord / vec2(width, height);
+
+    if (uv.x < 2. / width)
+        uv.x = 2. / width;
+
+    if (uv.y < 2. / height)
+        uv.y = 2. / height;
+
+    if (uv.x > 1. - 3. / width)
+        uv.x = 1. - 3. / width;
+
+    if (uv.y > 1. - 3. / height)
+        uv.y = 1. - 3. / height;
+
+    return texture2D(tex, uv);
+}
+
+vec4 get_clipped_bounding() {
+    // TODO: Clipping still got cut off
+    float x0 = clip_x0 + 2.5;
+    float y0 = clip_y0 + 2.0;
+    float w = clip_width - 4.0;
+    float h = clip_height - 3.0;
+
+    // No clip rect set, fall back to full texture size
+    if(clip_width < 0.0)
+        w = width - 4.0;
+    
+    if(clip_height < 0.0)
+        h = height - 3.0;
+    
+    return vec4(x0, y0, nonzero(w), nonzero(h));
+}
+
+void main() {
+    vec2 resolution = vec2(width, height);
+    vec2 uv = cogl_tex_coord_in[0].xy;
+
+    vec4 bounding = get_clipped_bounding();
+
+    vec2 glass_size = bounding.zw;
+    vec2 half_size = glass_size * 0.5;
+    float min_size = min(glass_size.x, glass_size.y);
+
+    vec2 frag_coord = uv * resolution;
+    vec2 glass_coord = frag_coord - (bounding.xy + half_size);
+
+    float raw_sdf = sdf(glass_coord, half_size, radius);
+    float inversed_sdf = -raw_sdf / min_size ;
+
+    // Simple AA via smoothstep  
+    float border_alpha = radius > 0.0 ? 1.0 - smoothstep(-0.5, 0.5, raw_sdf) : 1.0;
+    if(border_alpha <= 0.0) 
+        discard;   
+
+    // Normalized local coordinate, [-1.0, 1.0]
+    vec2 local_coord = glass_coord / half_size; 
+
+    float max_depth = min(min_size * 0.5, 50.0);
+
+    // Remap SDF to distance from the center point, 0.0 = center, 1.0 = border
+    float edge_falloff = min(nonzero(depth), max_depth) / min_size;
+    float dist_from_center = 1.0 - clamp(inversed_sdf / min(edge_falloff, 0.4), 0.0, 1.0); 
+
+    // Apply displacement using sphere projection formula: y = 1.0 - sqrt(1.0 - x²)
+    float sphere = 1.0 - safe_sqrt(1.0 - pow(dist_from_center, 2.0));
+    float displacement = sphere * refraction;
+
+    // Isolate wide axis refraction to edge band only, suppressing the flat center zone
+    // Prevents wide shapes from refracting inward like an oval lens at splay = 0.0
+    vec2 edge_mask = smoothstep(half_size - min_size, half_size, abs(glass_coord));
+    vec2 reach = vec2(max_depth) * mix(edge_mask, vec2(1.0), splay) * 1.5;
+
+    // Sample background at offset position to create the warping effect
+    vec2 offset = local_coord * displacement * reach;
+    vec2 glass_color_coord = frag_coord - offset;
+
+    // Apply chromatic aberration to refracted edges only
+    float edge = smoothstep(0.0, 0.02, inversed_sdf);
+    vec2 shift = local_coord * edge * mix(0.0, 3.0, dispersion);
+    vec4 base_color = getTextureColorAt(glass_color_coord);
+    vec4 left_sample = getTextureColorAt(glass_color_coord - shift);
+    vec4 right_sample = getTextureColorAt(glass_color_coord + shift);
+
+    vec4 final_color = vec4(
+      left_sample.r,
+      base_color.g,
+      right_sample.b,
+      base_color.a
+    );
+ 
+    // Light effect
+    float angle = atan(-local_coord.y, local_coord.x);
+    float rim_light = sin(angle + light_angle);
+
+    float hard_dist = 1.0 - clamp(inversed_sdf * min_size / nonzero(light_depth), 0.0, 1.0);
+    float hard_mask = smoothstep(0.0, nonzero(light_feather) * 2.0, hard_dist);
+    float soft_mask = smoothstep(0.0, 5.0, dist_from_center);
+
+    float shine  = clamp( rim_light, 0.0, 1.0);
+    float shadow = clamp(-rim_light, 0.0, 0.7);
+
+    float rim_lit  = pow(shine,  4.0) * 0.5 + shine  * 0.75;
+    float rim_fill = pow(shadow, 4.0) * 0.5 + shadow * 0.75;
+    float rim_combined = rim_lit + rim_fill + light_ambient;
+
+    final_color.rgb += hard_mask * light_intensity * rim_combined;
+    final_color.rgb -= soft_mask * light_intensity * shine * 0.15;
+    final_color.rgb += soft_mask * light_intensity * shadow * 0.65;
+
+    cogl_color_out = mix(getTextureColorAt(frag_coord), final_color, border_alpha);
+} 

--- a/src/effects/glass.js
+++ b/src/effects/glass.js
@@ -1,0 +1,399 @@
+import GObject from 'gi://GObject';
+
+import * as utils from '../conveniences/utils.js';
+import * as uniforms from '../conveniences/shader_uniforms.js';
+const St = await utils.import_in_shell_only('gi://St');
+const Shell = await utils.import_in_shell_only('gi://Shell');
+const Clutter = await utils.import_in_shell_only('gi://Clutter');
+
+const SHADER_FILENAME = 'glass.glsl';
+const SHADER_SOURCE = utils.get_shader_source(Shell, SHADER_FILENAME, import.meta.url);
+const DEFAULT_PARAMS = {
+    radius: 24, depth: 20,
+    refraction: 50, dispersion: 20, splay: 0,
+    light_angle: 45, light_intensity: 20, light_ambient: 50,
+    light_depth: 1.5, light_feather: 70,
+    width: 0, height: 0, 
+    clip: [0, 0, -1, -1]
+};
+
+const GLASS_EFFECT_META = {
+        GTypeName: "BMSGlassEffect",
+        Properties: {
+            'radius': GObject.ParamSpec.double(
+                `radius`,
+                `Corner Radius`,
+                `Corner Radius`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                24.0,
+            ),
+            'refraction': GObject.ParamSpec.double(
+                `refraction`,
+                `Refraction`,
+                `Refraction`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 100.0,
+                50.0,
+            ),
+            'depth': GObject.ParamSpec.double(
+                `depth`,
+                `Depth`,
+                `Depth`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 50.0,
+                20.0,
+            ),
+            'dispersion': GObject.ParamSpec.double(
+                `dispersion`,
+                `Dispersion`,
+                `Dispersion`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 100.0,
+                20.0,
+            ),
+            'splay': GObject.ParamSpec.double(
+                `splay`,
+                `Splay`,
+                `Splay`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 100.0,
+                0.0,
+            ),
+            'light_angle': GObject.ParamSpec.int(
+                'light_angle',
+                'Light Angle',
+                'Light Angle',
+                GObject.ParamFlags.READWRITE,
+                0, 360,
+                45,
+            ),
+            'light_intensity': GObject.ParamSpec.double(
+                'light_intensity',
+                'Light Intensity',
+                'Light Intensity',
+                GObject.ParamFlags.READWRITE,
+                0.0, 100.0,
+                20.0,
+            ),
+            'light_ambient': GObject.ParamSpec.double(
+                'light_ambient',
+                'Light Ambient',
+                'Light Ambient',
+                GObject.ParamFlags.READWRITE,
+                0.0, 100.0,
+                50.0,
+            ),
+            'light_depth': GObject.ParamSpec.double(
+                'light_depth',
+                'Light Depth',
+                'Light Depth',
+                GObject.ParamFlags.READWRITE,
+                0.0, 10.0,
+                1.5,
+            ),
+            'light_feather': GObject.ParamSpec.double(
+                'light_feather',
+                'Light Feather',
+                'Light Feather',
+                GObject.ParamFlags.READWRITE,
+                0.0, 100.0,
+                70.0,
+            ),
+            'width': GObject.ParamSpec.double(
+                `width`,
+                `Width`,
+                `Width`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+            'height': GObject.ParamSpec.double(
+                `height`,
+                `Height`,
+                `Height`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+            // The shader stores the clip rectangle separately;
+            'clip': GObject.ParamSpec.double(
+                `clip`,
+                `Clip`,
+                `Clip`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+        }
+};
+
+const GlassEffectClass = utils.IS_IN_PREFERENCES ? null : class GlassEffect extends Clutter.ShaderEffect {
+
+        constructor(params) {
+            super(params);
+
+            utils.initialize_shader_effect(this, SHADER_SOURCE);
+
+            this._clip_x0 = null;
+            this._clip_y0 = null;
+            this._clip_width = null;
+            this._clip_height = null;
+
+            utils.setup_params(this, params);
+        
+            const theme_context = St.ThemeContext.get_for_stage(global.stage);
+            this._scale_factor = theme_context.scale_factor;
+
+            theme_context.connectObject('notify::scale-factor', _ => {
+                this._scale_factor = theme_context.scale_factor;
+                this.update_radius();
+            }, this);
+        }
+
+        static get default_params() {
+            return DEFAULT_PARAMS;
+        }
+
+        get refraction() {
+            return this._refraction;
+        }
+
+        set refraction(value) {
+            if (this._refraction !== value) {
+                this._refraction = value;
+
+                this.update_displacement();
+            }
+        }
+
+        get depth() {
+             return this._depth;
+        }
+
+        set depth(value) {
+            if (this._depth !== value) {
+                this._depth = value;
+            
+                this.update_displacement();
+            }
+        }
+
+        get dispersion() {
+            return this._dispersion;
+        }
+
+        set dispersion(value) {
+            if (this._dispersion !== value) {
+                this._dispersion = value;
+
+                this.update_displacement();   
+            }
+        }
+
+        get splay() {
+             return this._splay;
+        }
+
+        set splay(value) {
+            if (this._splay !== value) {
+                this._splay = value;
+
+                this.update_displacement();
+            }
+        }
+
+        update_displacement(){
+            uniforms.set_uniform(this, "refraction", parseFloat(this._refraction / 100 - 1e-6));
+            uniforms.set_uniform(this, "depth", parseFloat(this._depth - 1e-6));
+            uniforms.set_uniform(this, "dispersion", parseFloat(this._dispersion / 100 - 1e-6));
+            uniforms.set_uniform(this, "splay", parseFloat((this._splay / 100 * 2.0)- 1e-6));
+        }
+        
+        get radius() {
+            return this._radius;
+        }
+
+        set radius(value) {
+            if (this._radius !== value) {
+                this._radius = value;
+
+                this.update_radius();
+            }
+        }
+
+        update_radius() {
+            let radius = Math.min(
+                this.radius * this._scale_factor,
+                this.width / 2, this.height / 2
+            );
+
+            if (this._clip_width >= 0 || this._clip_height >= 0)
+                radius = Math.min(radius, this._clip_width / 2, this._clip_height / 2);
+
+            uniforms.set_uniform(this, 'radius', parseFloat(radius - 1e-6));
+        }
+
+        get light_angle() {
+            return this._light_angle;
+        }
+
+        set light_angle(value) {
+            if (this._light_angle !== value) {
+                this._light_angle = value;
+
+                this.update_light();
+            }
+        }
+
+        get light_intensity() {
+            return this._light_intensity;
+        }
+
+        set light_intensity(value) {
+            if (this._light_intensity !== value) {
+                this._light_intensity = value;
+
+                this.update_light();
+            }
+        }
+
+        get light_ambient() {
+            return this._light_ambient;
+        }
+
+        set light_ambient(value) {
+            if (this._light_ambient !== value) {
+                this._light_ambient = value;
+
+                this.update_light();
+            }
+        }
+
+        get light_depth() {
+            return this._light_depth;
+        }
+        
+        set light_depth(value) {
+            if (this._light_depth !== value) {
+                this._light_depth = value;
+
+                this.update_light();
+            }
+        }
+        
+        get light_feather() {
+            return this._light_feather;
+        }
+        
+        set light_feather(value) {
+            if (this._light_feather !== value) {
+                this._light_feather = value;
+
+                this.update_light();
+            }
+        }
+
+        update_light(){
+            uniforms.set_uniform(this, 'light_angle', parseFloat(this._light_angle * Math.PI / 180.0));
+            uniforms.set_uniform(this, 'light_intensity', parseFloat(this._light_intensity / 100.0 - 1e-6));
+            uniforms.set_uniform(this, 'light_ambient', parseFloat(this._light_ambient / 100.0 - 1e-6));
+            uniforms.set_uniform(this, "light_depth", parseFloat(this._light_depth - 1e-6));
+            uniforms.set_uniform(this, "light_feather", parseFloat(this._light_feather / 100 - 1e-6));
+        }
+
+        get width() {
+            return this._width;
+        }
+
+        set width(value) {
+            const clamped = Math.max(1, value || 1);
+            if (this._width !== clamped) {
+                this._width = clamped;
+
+                uniforms.set_uniform(this, 'width', parseFloat(this._width + 3.0 - 1e-6));
+                this.update_radius();
+            }
+        }
+
+        get height() {
+            return this._height;
+        }
+
+        set height(value) {
+            const clamped = Math.max(1, value || 1);
+            if (this._height !== clamped) {
+                this._height = clamped;
+
+                uniforms.set_uniform(this, 'height', parseFloat(this._height + 3.0 - 1e-6));
+                this.update_radius();
+            }
+        }
+
+        get clip() {
+            return [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height];
+        }
+
+        set clip(value) {
+            [this._clip_x0, this._clip_y0, this._clip_width, this._clip_height] = value;
+            uniforms.set_uniform(this, 'clip_x0', parseFloat(this._clip_x0 - 1e-6));
+            uniforms.set_uniform(this, 'clip_y0', parseFloat(this._clip_y0 - 1e-6));
+            uniforms.set_uniform(this, 'clip_width', parseFloat(this._clip_width + 3.0 - 1e-6));
+            uniforms.set_uniform(this, 'clip_height', parseFloat(this._clip_height + 3.0 - 1e-6));
+            this.update_radius();
+        }
+
+        detach_actor_clip_sync(actor = this.get_actor()) {
+            if (!actor || !this._actor_connection_clip_rect_id)
+                return;
+
+            try {
+                actor.disconnect(this._actor_connection_clip_rect_id);
+            } catch (e) { }
+
+            this._actor_connection_clip_rect_id = null;
+        }
+
+        sync_actor_clip(actor) {
+            this.detach_actor_clip_sync(actor);
+            this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
+            this._actor_connection_clip_rect_id = actor.connect('notify::clip-rect', _ => {
+                this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
+            });
+        }
+
+        vfunc_set_actor(actor) {
+            if (this._actor_connection_size_id) {
+                let old_actor = this.get_actor();
+                old_actor?.disconnect(this._actor_connection_size_id);
+            }
+            this.detach_actor_clip_sync();
+
+            if (actor) {
+                this.width = actor.width;
+                this.height = actor.height;
+                this._actor_connection_size_id = actor.connect('notify::size', _ => {
+                    this.width = actor.width;
+                    this.height = actor.height;
+                });
+
+                this.sync_actor_clip(actor);
+            }
+            else {
+                this._actor_connection_size_id = null;
+            }
+
+            super.vfunc_set_actor(actor);
+        }
+
+        vfunc_paint_target(paint_node, paint_context) {
+            uniforms.upload_uniforms(this);
+            super.vfunc_paint_target(paint_node, paint_context);
+        }
+}
+
+
+
+export const GlassEffect = utils.IS_IN_PREFERENCES
+    ? { default_params: DEFAULT_PARAMS }
+    : utils.register_shader_effect(GLASS_EFFECT_META, GlassEffectClass, SHADER_SOURCE);


### PR DESCRIPTION
**This PR adds new glass effect as an alternative to the existing refraction effect**
- More optimized with less bloated glsl code without losing quality
- Visually match to Figma glass effect and looks very similar to MacOS 26
- Tuned to be more close as Figma as possible including refraction, depth, splay and other props

### Implementation
Most of this code logic taken from this article:
[Medium - Liquid Glass: iOS Effect Explanation](https://medium.com/@aghajari/liquid-glass-ios-effect-explanation-dabadd6414ae)

So basically this works by masking the actor using sdf, then remapping the distance from center this also adjust the depth, and add displacement using sphere projection formula to edge of the glass. 

For the splay effect, i did some experiment to find the best tune and it works by masking the displacement on the wide axis.


### Comparison

*GNOME Shell*
<img width="1710" height="1112" alt="Screenshot 2026-09-07 at 10 39 35 AM" src="https://github.com/user-attachments/assets/af480ed8-55eb-4e4c-83de-fe11265ecbda" />

*MacOS 26.1*
<img width="1710" height="1112" alt="Screenshot 2026-09-07 at 10 39 30 AM" src="https://github.com/user-attachments/assets/f335e62a-be16-46af-aa6a-1c07c331f561" />

*The dock looks so similar the mac 

*Figma Glass Effect*
<img width="1710" height="1111" alt="Screenshot 2026-09-07 at 1 08 50 PM" src="https://github.com/user-attachments/assets/6568124c-952c-482d-95f3-e6b3335f51d1" />


*This kinda looks like jelly though*
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/beff31cb-8116-4442-9cd7-c96f503bcba4" />

### MacOS dock like pipeline settings
**Add these effects:**
1. Luminosity
   - Saturation: 1.05
   
2. Native gaussian blur
   - Radius: 0.8
   - Brightness: 0.95
   
3. Glass
   - Corner Radius: 24
   - Refraction: 100
   - Depth: 32
   - Splay: 0
   - Light Angle: 45º
   - Light Intensity: 10
   - Light ambient: 50
   - Light depth: 10
   - Light feather: 100

   


## One more issue
The clip padding under `get_clipped_bounding()` currently still being hard-coded because without it the glass looks out of bound or the bounding doesnt match with the actor bound. These hard-coded values works on my display but i don't know on other display and how to make this fit with the actor bounding

I assume that when actor be a texture, the size get offseted by 3 for example if the width is 100, the texture width is 103 so I tried to offset it by 3px but it doesnt work either and it still looks like it got cut off. Please help me with this...


<br><br>


*Hope this PR helps, thank you....*
Soon imma try to implement live liquid glass effect