### PR TITLE
Update Liquid Glass effect with Liquid (Gl)ass 0.1.1b shader

### DIFF
--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -330,7 +330,7 @@ export function get_supported_effects(_ = () => "") {
                 },
                 fresnel_angle: {
                     name: _("Fresnel glare angle"),
-                    description: _("Light direction of the fresnel glare, in degrees (0 is to the right, 90 is down)."),
+                    description: _("Light direction of the fresnel glare, in degrees (0 is from above, positive rotates clockwise)."),
                     type: "float",
                     min: -180.,
                     max: 180.,

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -350,7 +350,7 @@ export function get_supported_effects(_ = () => "") {
                 },
                 specular_strength: {
                     name: _("Specular glare strength"),
-                    description: _("Strength of the specular glare showing the light direction (toggle in preferences)."),
+                    description: _("Strength of the specular glare showing the light direction (0 disables it)."),
                     type: "float",
                     min: 0.,
                     max: 1.,

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -348,6 +348,16 @@ export function get_supported_effects(_ = () => "") {
                     big_increment: 0.5,
                     digits: 2
                 },
+                specular_strength: {
+                    name: _("Specular glare strength"),
+                    description: _("Strength of the specular glare showing the light direction (toggle in preferences)."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.01,
+                    big_increment: 0.1,
+                    digits: 2
+                },
                 tint: {
                     name: _("Tint strength"),
                     description: _("Amount of subtle milky glass tint over the blurred texture."),

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -293,7 +293,7 @@ export function get_supported_effects(_ = () => "") {
                     description: _("How far the liquid-glass lens reaches inward from the edge."),
                     type: "float",
                     min: 1.,
-                    max: 100.,
+                    max: 500.,
                     increment: 1.,
                     big_increment: 10.,
                     digits: 0
@@ -310,23 +310,33 @@ export function get_supported_effects(_ = () => "") {
                 },
                 falloff: {
                     name: _("Glass thickness"),
-                    description: _("Depth used by the Snell-style refraction profile."),
+                    description: _("Depth used by the refraction edge profile."),
                     type: "float",
                     min: 0.25,
-                    max: 8.,
+                    max: 20.,
                     increment: 0.05,
                     big_increment: 0.5,
                     digits: 2
                 },
                 gloss: {
                     name: _("Fresnel glare"),
-                    description: _("Strength of the Schlick fresnel rim glare from the glass edge."),
+                    description: _("Strength of the directional fresnel glare from the glass edge."),
                     type: "float",
                     min: 0.,
                     max: 1.,
                     increment: 0.01,
                     big_increment: 0.1,
                     digits: 2
+                },
+                fresnel_angle: {
+                    name: _("Fresnel glare angle"),
+                    description: _("Light direction of the fresnel glare, in degrees (0 is to the right, 90 is down)."),
+                    type: "float",
+                    min: -180.,
+                    max: 180.,
+                    increment: 5.,
+                    big_increment: 45.,
+                    digits: 0
                 },
                 tint: {
                     name: _("Tint strength"),

--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -338,6 +338,16 @@ export function get_supported_effects(_ = () => "") {
                     big_increment: 45.,
                     digits: 0
                 },
+                fresnel_width: {
+                    name: _("Fresnel glare width"),
+                    description: _("Thickness multiplier of the fresnel glare ring along the glass edge."),
+                    type: "float",
+                    min: 0.5,
+                    max: 6.,
+                    increment: 0.1,
+                    big_increment: 0.5,
+                    digits: 2
+                },
                 tint: {
                     name: _("Tint strength"),
                     description: _("Amount of subtle milky glass tint over the blurred texture."),

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -81,7 +81,7 @@ float quartzGlassHighlight(float distanceFromEdge,
     float threshold = 0.15;
     float directional = clamp((dot(lightDirection, normal) - threshold) /
                               max(1.0 - threshold, 0.0001), 0.0, 1.0);
-    float highlight = ring * (0.25 + 0.75 * directional);
+    float highlight = ring * (0.55 + 0.45 * directional);
 
     float oppositeAttenuation = 1.35;
     highlight /= max(1.0 + (1.0 - highlight) * oppositeAttenuation,
@@ -340,7 +340,7 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
                                            gloss, fresnel_angle) *
                       edgeOpacity;
     float bgLuminance = luminance(outRGB);
-    highlight *= mix(0.32, 1.0, bgLuminance);
+    highlight *= mix(0.5, 1.0, bgLuminance);
     highlight = min(highlight, 0.22);
     outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
 

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -324,8 +324,7 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     }
 
     float normDisp = distFromSide < refractionBand
-        ? quartzGlassEdgeProfile(distFromSide,
-                                 min(max(glassThickness, 1.0), refractionBand))
+        ? quartzGlassEdgeProfile(distFromSide, max(glassThickness, 1.0))
         : 0.0;
     float dispStrength = useCircularSurface ? edgeOpacity : edgeBand;
     vec2 dispPx = -dir * normDisp * refractionBand * strength * dispStrength;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -341,11 +341,16 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
 
     if (specular_strength > 0.001) {
-        float specular = quartzGlassHighlight(distFromSide, refractionBand, dir,
-                                              specular_strength, fresnel_angle) *
+        float specAngle = atan(dir.y, dir.x);
+        float sourceAngle = fresnel_angle + 3.14159265;
+        float dA = abs(mod(specAngle - sourceAngle + 3.14159265,
+                           6.2831853) - 3.14159265);
+        float lobe = exp(-dA * dA * 12.0);
+        float specular = lobe * quartzGlassHighlight(distFromSide, refractionBand,
+                                                     dir, 1.0, fresnel_angle) *
                          edgeOpacity;
         specular *= mix(0.32, 1.0, bgLuminance);
-        specular = min(specular, 0.35);
+        specular = min(specular * specular_strength, 0.4);
         outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specular);
     }
 

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -326,7 +326,7 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     float normDisp = distFromSide < refractionBand
         ? quartzGlassEdgeProfile(distFromSide, max(glassThickness, 1.0))
         : 0.0;
-    float dispStrength = useCircularSurface ? edgeOpacity : edgeBand;
+    float dispStrength = edgeBand;
     vec2 dispPx = -dir * normDisp * refractionBand * strength * dispStrength;
 
     float dispersion = clamp(rgb_fringing * DISPERSION_SCALE, 0.0, 20.0);

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -304,17 +304,6 @@ rimRadius = min(rimRadius, shortestSide * 0.5);
         }
     }
 
-float specularGlint = 0.0;
-    if (specular_strength > 0.001) {
-        vec2 sourceDir = -vec2(cos(fresnel_angle), sin(fresnel_angle));
-        vec2 sourcePos = vec2(localUV.x - 0.5, 0.5 - localUV.y) * 2.0;
-        float sourceDist = length(sourcePos);
-        vec2 sourceNormal = sourceDist > 0.001 ? sourcePos / sourceDist
-                                              : vec2(0.0, 1.0);
-        specularGlint = pow(clamp(dot(sourceDir, sourceNormal), 0.0, 1.0), 14.0)
-                        * smoothstep(1.1, 0.4, sourceDist);
-    }
-
 if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
         && distFromSide >= refractionBand) {
         vec4 sourceSample = sampleGlassBackdrop(actorUV);
@@ -324,7 +313,6 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
                                                opacity_factor);
         vec3 effectRGB = applyTintAndShadow(flatSample.rgb, localUV);
         vec3 outRGB = mix(sourceSample.rgb, effectRGB, opacity_factor);
-        outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specularGlint * specular_strength);
 
         cogl_color_out = vec4(outRGB * finalOpacity, finalOpacity);
         return;
@@ -351,7 +339,15 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     highlight *= mix(0.32, 1.0, bgLuminance);
     highlight = min(highlight, 0.22);
     outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
-    outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specularGlint * specular_strength);
+
+    if (specular_strength > 0.001) {
+        float specular = quartzGlassHighlight(distFromSide, refractionBand, dir,
+                                              specular_strength, fresnel_angle) *
+                         edgeOpacity;
+        specular *= mix(0.32, 1.0, bgLuminance);
+        specular = min(specular, 0.35);
+        outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specular);
+    }
 
     outRGB *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
     outRGB = mix(sourceColor.rgb, outRGB, opacity_factor);

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -1,23 +1,16 @@
-// GLSL port of liquidass 0.1.1b (Tweak.mm kShaderSrc), blended on Blur my
-// Shell's clutter pipeline.
+// GLSL port of liquidass 0.1.1b (Tweak.mm kShaderSrc) from Liquid (Gl)ass by
+// winaviation (https://github.com/winaviation-tweaks/liquid-ass), blended on
+// Blur my Shell's clutter pipeline.
 //
-// Original shader: Liquid (Gl)ass by winaviation
-// (https://github.com/winaviation-tweaks/liquid-ass)
-// This is modified/adapted material. The copyright holder explicitly granted
-// in email and in pull request #987 (2026-09-10) that the 0.1.1b shader and
-// this GLSL port may be redistributed as part of Blur my Shell under the
-// GNU GPL v3, with that permission extending to downstream users. Attribution
-// to the original work must be retained.
+// The copyright holder explicitly granted, in email and in pull request #987
+// (2026-09-10), that this ported shader file may be re-licensed and
+// redistributed under the GNU GPL v3 for Blur my Shell, with the same rights
+// extending to anyone who reuses it from this repository. The original
+// upstream project remains licensed under CC BY-NC 4.0
+// (https://creativecommons.org/licenses/by-nc/4.0/).
 //
 // Optional specular glare (off by default) is an addition beyond the 0.1.1b
 // port and is not part of the original shader.
-//
-// Original upstream license: CC BY-NC 4.0
-//   https://creativecommons.org/licenses/by-nc/4.0/
-// When this material is shared outside of Blur my Shell, the CC BY-NC 4.0
-// conditions still apply: attribution (Section 3(a)) and NonCommercial
-// use only (Section 2(a)(1)). The Licensor offers the material as-is and
-// disclaims all warranties and liability (Section 5).
 uniform sampler2D tex;
 uniform float width;
 uniform float height;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -64,8 +64,15 @@ float quartzGlassHighlight(float distanceFromEdge,
 
     float outerCoverage = clamp(distanceFromEdge / aa + 0.5, 0.0, 1.0);
     float radial = clamp(distanceFromEdge / ringWidth, 0.0, 1.0);
-    float decayRate = 1.0 + ringWidth;
-    float ring = outerCoverage * exp(-decayRate * radial);
+    float ring;
+    if (ringWidth < 3.0) {
+        float innerCoverage = clamp((ringWidth - distanceFromEdge) / aa + 0.5, 0.0, 1.0);
+        ring = outerCoverage * innerCoverage;
+        ring *= 1.0 - radial;
+    } else {
+        float decayRate = 3.0;
+        ring = outerCoverage * exp(-decayRate * radial);
+    }
 
     vec2 lightDirection = vec2(cos(angle), sin(angle));
     float threshold = 0.15;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -304,6 +304,17 @@ rimRadius = min(rimRadius, shortestSide * 0.5);
         }
     }
 
+float specularGlint = 0.0;
+    if (specular_strength > 0.001) {
+        vec2 sourceDir = -vec2(cos(fresnel_angle), sin(fresnel_angle));
+        vec2 sourcePos = vec2(localUV.x - 0.5, 0.5 - localUV.y) * 2.0;
+        float sourceDist = length(sourcePos);
+        vec2 sourceNormal = sourceDist > 0.001 ? sourcePos / sourceDist
+                                              : vec2(0.0, 1.0);
+        specularGlint = pow(clamp(dot(sourceDir, sourceNormal), 0.0, 1.0), 14.0)
+                        * smoothstep(1.1, 0.4, sourceDist);
+    }
+
 if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
         && distFromSide >= refractionBand) {
         vec4 sourceSample = sampleGlassBackdrop(actorUV);
@@ -313,6 +324,7 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
                                                opacity_factor);
         vec3 effectRGB = applyTintAndShadow(flatSample.rgb, localUV);
         vec3 outRGB = mix(sourceSample.rgb, effectRGB, opacity_factor);
+        outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specularGlint * specular_strength);
 
         cogl_color_out = vec4(outRGB * finalOpacity, finalOpacity);
         return;
@@ -339,17 +351,7 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     highlight *= mix(0.32, 1.0, bgLuminance);
     highlight = min(highlight, 0.22);
     outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
-
-    if (specular_strength > 0.001) {
-        vec2 sourceDir = -vec2(cos(fresnel_angle), sin(fresnel_angle));
-        vec2 sourcePos = vec2(localUV.x - 0.5, 0.5 - localUV.y) * 2.0;
-        float sourceDist = length(sourcePos);
-        vec2 sourceNormal = sourceDist > 0.001 ? sourcePos / sourceDist
-                                              : vec2(0.0, 1.0);
-        float glint = pow(clamp(dot(sourceDir, sourceNormal), 0.0, 1.0), 14.0)
-                      * smoothstep(1.1, 0.4, sourceDist);
-        outRGB = 1.0 - (1.0 - outRGB) * (1.0 - glint * specular_strength);
-    }
+    outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specularGlint * specular_strength);
 
     outRGB *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
     outRGB = mix(sourceColor.rgb, outRGB, opacity_factor);

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -63,10 +63,9 @@ float quartzGlassHighlight(float distanceFromEdge,
     float aa = 1.0;
 
     float outerCoverage = clamp(distanceFromEdge / aa + 0.5, 0.0, 1.0);
-    float innerCoverage = clamp((ringWidth - distanceFromEdge) / aa + 0.5, 0.0, 1.0);
-    float ring = outerCoverage * innerCoverage;
     float radial = clamp(distanceFromEdge / ringWidth, 0.0, 1.0);
-    ring *= 1.0 - radial;
+    float decayRate = 1.0 + ringWidth;
+    float ring = outerCoverage * exp(-decayRate * radial);
 
     vec2 lightDirection = vec2(cos(angle), sin(angle));
     float threshold = 0.15;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -75,9 +75,10 @@ float quartzGlassHighlight(float distanceFromEdge,
     }
 
     vec2 lightDirection = vec2(cos(angle), sin(angle));
-    float threshold = 0.15;
-    float directional = clamp((dot(lightDirection, normal) - threshold) /
-                              max(1.0 - threshold, 0.0001), 0.0, 1.0);
+    float cosT = clamp(dot(lightDirection, normal), 0.0, 1.0);
+    float fresnelBase = 0.04;
+    float schlick = fresnelBase + (1.0 - fresnelBase) * pow(1.0 - cosT, 3.0);
+    float directional = clamp(0.05 + 0.95 * schlick, 0.0, 1.0);
     float highlight = ring * directional;
 
     float oppositeAttenuation = 1.35;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -3,14 +3,16 @@
 //
 // Original shader: Liquid (Gl)ass by winaviation
 // (https://github.com/winaviation-tweaks/liquid-ass)
-// This is modified/adapted material. The copyright holder confirmed in email
-// (2026) that the 0.1.1b shader may be used in blur-my-shell, subject to the
-// CC BY-NC 4.0 terms below. Attribution to the original work must be retained.
+// This is modified/adapted material. The copyright holder explicitly granted
+// in email and in pull request #987 (2026-09-10) that the 0.1.1b shader and
+// this GLSL port may be redistributed as part of Blur my Shell under the
+// GNU GPL v3, with that permission extending to downstream users. Attribution
+// to the original work must be retained.
 //
 // Original upstream license: CC BY-NC 4.0
 //   https://creativecommons.org/licenses/by-nc/4.0/
-// When the material is shared as-is or modified, you must comply with the
-// CC BY-NC 4.0 conditions: attribution (Section 3(a)), and NonCommercial
+// When this material is shared outside of Blur my Shell, the CC BY-NC 4.0
+// conditions still apply: attribution (Section 3(a)) and NonCommercial
 // use only (Section 2(a)(1)). The Licensor offers the material as-is and
 // disclaims all warranties and liability (Section 5).
 uniform sampler2D tex;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -72,10 +72,9 @@ float quartzGlassHighlight(float distanceFromEdge,
     }
 
     vec2 lightDirection = vec2(cos(angle), sin(angle));
-    float cosT = clamp(dot(lightDirection, normal), 0.0, 1.0);
-    float fresnelBase = 0.04;
-    float schlick = fresnelBase + (1.0 - fresnelBase) * pow(1.0 - cosT, 3.0);
-    float directional = clamp(0.05 + 0.95 * schlick, 0.0, 1.0);
+    float threshold = 0.15;
+    float directional = clamp((dot(lightDirection, normal) - threshold) /
+                              max(1.0 - threshold, 0.0001), 0.0, 1.0);
     float highlight = ring * directional;
 
     float oppositeAttenuation = 1.35;

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -81,7 +81,7 @@ float quartzGlassHighlight(float distanceFromEdge,
     float threshold = 0.15;
     float directional = clamp((dot(lightDirection, normal) - threshold) /
                               max(1.0 - threshold, 0.0001), 0.0, 1.0);
-    float highlight = ring * (0.55 + 0.45 * directional);
+    float highlight = ring * directional;
 
     float oppositeAttenuation = 1.35;
     highlight /= max(1.0 + (1.0 - highlight) * oppositeAttenuation,
@@ -340,7 +340,7 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
                                            gloss, fresnel_angle) *
                       edgeOpacity;
     float bgLuminance = luminance(outRGB);
-    highlight *= mix(0.5, 1.0, bgLuminance);
+    highlight *= mix(0.32, 1.0, bgLuminance);
     highlight = min(highlight, 0.22);
     outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
 

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -1,4 +1,18 @@
-// GLSL port of winaviation-tweaks/liquidass LiquidAssBackboardd/Tweak.mm kShaderSrc.
+// GLSL port of liquidass 0.1.1b (Tweak.mm kShaderSrc), blended on Blur my
+// Shell's clutter pipeline.
+//
+// Original shader: Liquid (Gl)ass by winaviation
+// (https://github.com/winaviation-tweaks/liquid-ass)
+// This is modified/adapted material. The copyright holder confirmed in email
+// (2026) that the 0.1.1b shader may be used in blur-my-shell, subject to the
+// CC BY-NC 4.0 terms below. Attribution to the original work must be retained.
+//
+// Original upstream license: CC BY-NC 4.0
+//   https://creativecommons.org/licenses/by-nc/4.0/
+// When the material is shared as-is or modified, you must comply with the
+// CC BY-NC 4.0 conditions: attribution (Section 3(a)), and NonCommercial
+// use only (Section 2(a)(1)). The Licensor offers the material as-is and
+// disclaims all warranties and liability (Section 5).
 uniform sampler2D tex;
 uniform float width;
 uniform float height;
@@ -11,6 +25,7 @@ uniform int corners_bottom;
 uniform float rim_width;
 uniform float rgb_fringing;
 uniform float gloss;
+uniform float fresnel_angle;
 uniform float tint;
 uniform float tint_r;
 uniform float tint_g;
@@ -25,71 +40,40 @@ uniform float clip_y0;
 uniform float clip_width;
 uniform float clip_height;
 
-const float REFRACTIVE_INDEX = 1.52;
 const float DISPERSION_SCALE = 20.0;
 
-const float kDispersionRedIndex = 0.98;
-const float kDispersionGreenIndex = 1.00;
-const float kDispersionBlueIndex = 1.02;
-
-float surfaceConvexSquircle(float x) {
-    return pow(1.0 - pow(1.0 - x, 4.0), 0.25);
+float quartzGlassEdgeProfile(float distanceFromEdge,
+                             float refractionHeight) {
+    float t = clamp(distanceFromEdge / max(refractionHeight, 0.001), 0.0, 1.0);
+    return 1.0 - sqrt(t * (2.0 - t));
 }
 
-vec2 refractRay(vec2 normal, float eta) {
-    float cosI = -normal.y;
-    float k = 1.0 - eta * eta * (1.0 - cosI * cosI);
-    if (k < 0.0)
-        return vec2(0.0);
+float quartzGlassHighlight(float distanceFromEdge,
+                           float bezelWidth,
+                           vec2 surfaceNormal,
+                           float strength,
+                           float angle) {
+    float normalLength = max(length(surfaceNormal), 0.001);
+    vec2 normal = surfaceNormal / normalLength;
+    float ringWidth = clamp(bezelWidth * 0.24, 1.0, 2.5);
+    float aa = 1.0;
 
-    float kSqrt = sqrt(k);
-    return vec2(
-        -(eta * cosI + kSqrt) * normal.x,
-        eta - (eta * cosI + kSqrt) * normal.y
-    );
-}
+    float outerCoverage = clamp(distanceFromEdge / aa + 0.5, 0.0, 1.0);
+    float innerCoverage = clamp((ringWidth - distanceFromEdge) / aa + 0.5, 0.0, 1.0);
+    float ring = outerCoverage * innerCoverage;
+    float radial = clamp(distanceFromEdge / ringWidth, 0.0, 1.0);
+    ring *= 1.0 - radial;
 
-float rawRefraction(float bezelRatio, float glassThickness, float bezelWidth, float eta) {
-    float x = clamp(bezelRatio, 0.05, 0.95);
-    float y = surfaceConvexSquircle(x);
-    float y2 = surfaceConvexSquircle(x + 0.001);
-    float deriv = (y2 - y) / 0.001;
-    float mag = sqrt(deriv * deriv + 1.0);
-    vec2 n = vec2(-deriv / mag, -1.0 / mag);
-    vec2 r = refractRay(n, eta);
-    if (length(r) < 0.0001 || abs(r.y) < 0.0001)
-        return 0.0;
+    vec2 lightDirection = vec2(cos(angle), sin(angle));
+    float threshold = 0.15;
+    float directional = clamp((dot(lightDirection, normal) - threshold) /
+                              max(1.0 - threshold, 0.0001), 0.0, 1.0);
+    float highlight = ring * directional;
 
-    float remaining = y * bezelWidth + glassThickness;
-    return r.x * (remaining / r.y);
-}
-
-float displacementAtRatio(float bezelRatio, float glassThickness, float bezelWidth, float eta) {
-    float peak = rawRefraction(0.05, glassThickness, bezelWidth, eta);
-    if (abs(peak) < 0.0001)
-        return 0.0;
-
-    float raw = rawRefraction(bezelRatio, glassThickness, bezelWidth, eta);
-    float norm = raw / peak;
-    float profileFalloff = 1.0 - smoothstep(0.0, 1.0, bezelRatio);
-    return norm * profileFalloff;
-}
-
-float fresnelAtRatio(float bezelRatio, float refractiveIndex) {
-    float x = clamp(bezelRatio, 0.02, 0.98);
-    float y0 = surfaceConvexSquircle(max(0.001, x - 0.001));
-    float y1 = surfaceConvexSquircle(min(0.999, x + 0.001));
-    float slope = (y1 - y0) / 0.002;
-    float cosTheta = inversesqrt(1.0 + slope * slope);
-    float f0Base = (refractiveIndex - 1.0) / (refractiveIndex + 1.0);
-    float f0 = f0Base * f0Base;
-    float grazing = pow(1.0 - clamp(cosTheta, 0.0, 1.0), 5.0);
-    float fresnel = f0 + (1.0 - f0) * grazing;
-    return fresnel * (1.0 - smoothstep(0.0, 1.0, bezelRatio));
-}
-
-float dispersionOffsetScale(float channelIndex, float strengthValue) {
-    return 1.0 - (channelIndex - 1.0) * strengthValue;
+    float oppositeAttenuation = 1.35;
+    highlight /= max(1.0 + (1.0 - highlight) * oppositeAttenuation,
+                     0.0001);
+    return highlight * max(strength, 0.0);
 }
 
 float luminance(vec3 color) {
@@ -181,25 +165,50 @@ vec2 backdropSampleUV(vec2 sampleUV, vec2 displacementPx) {
     return displaced;
 }
 
-vec4 sampleDispersed(vec2 sampleUV, vec2 dispPx, float dispersion) {
-    float greenScale = dispersionOffsetScale(kDispersionGreenIndex, dispersion);
-    vec2 greenUV = backdropSampleUV(sampleUV, dispPx * greenScale);
+vec4 sampleDispersed(vec2 sampleUV, vec2 dispPx, vec2 aberrationPx,
+                     float dispersion) {
+    vec2 greenUV = backdropSampleUV(sampleUV, dispPx);
     vec4 greenSample = sampleGlassBackdrop(greenUV);
+
+    vec4 fallback = vec4(0.0);
+    if (greenSample.a < 0.01) {
+        fallback = sampleGlassBackdrop(sampleUV);
+        if (fallback.a < 0.01)
+            return vec4(0.0);
+        greenSample = fallback;
+    }
 
     vec4 bg = greenSample;
     if (dispersion > 0.001 && dot(dispPx, dispPx) > 0.0001) {
-        float redScale = dispersionOffsetScale(kDispersionRedIndex, dispersion);
-        float blueScale = dispersionOffsetScale(kDispersionBlueIndex, dispersion);
+        vec3 accumulated = vec3(0.0);
+        float accumulatedAlpha = 0.0;
 
-        vec2 redUV = backdropSampleUV(sampleUV, dispPx * redScale);
-        vec2 blueUV = backdropSampleUV(sampleUV, dispPx * blueScale);
-        vec4 redSample = sampleGlassBackdrop(redUV);
-        vec4 blueSample = sampleGlassBackdrop(blueUV);
+        for (int i = 0; i < 3; i++) {
+            float weight = 1.0 - float(i) / 3.0;
+            vec2 uv = backdropSampleUV(sampleUV,
+                                       dispPx + aberrationPx * weight);
+            vec4 sample = sampleGlassBackdrop(uv);
+            if (sample.a < 0.01)
+                sample = fallback;
+            accumulated.r += sample.r * weight;
+            accumulated.g += sample.g * (1.0 - weight);
+            accumulatedAlpha += sample.a;
+        }
 
-        bg.r = redSample.r;
-        bg.g = greenSample.g;
-        bg.b = blueSample.b;
-        bg.a = greenSample.a;
+        for (int i = 0; i < 4; i++) {
+            float weight = float(i) / 3.0;
+            vec2 uv = backdropSampleUV(sampleUV,
+                                       dispPx - aberrationPx * weight);
+            vec4 sample = sampleGlassBackdrop(uv);
+            if (sample.a < 0.01)
+                sample = fallback;
+            accumulated.g += sample.g * (1.0 - weight);
+            accumulated.b += sample.b * weight;
+            accumulatedAlpha += sample.a;
+        }
+
+        bg.rgb = accumulated * vec3(0.5, 1.0 / 3.0, 0.5);
+        bg.a = accumulatedAlpha / 7.0;
     }
     return bg;
 }
@@ -237,7 +246,6 @@ void main() {
         roundingRadius = 0.0;
     float bezel = max(1.0, min(edge_size, shortestSide * 0.5));
     float glassThickness = max(0.5, edge_size * 0.55 * falloff);
-    float eta = 1.0 / REFRACTIVE_INDEX;
 
     bool nearlySquare = abs(W - H) < max(4.0, shortestSide * 0.035);
     bool useCircularSurface = corners_top != 0 && corners_bottom != 0
@@ -275,7 +283,7 @@ void main() {
         edgeBand = clamp(1.0 - (distFromSide / rimRadius), 0.0, 1.0);
     } else {
         float rimRadius = max(1.0, bezel * 0.35 * max(1.0, rim_width));
-        rimRadius = min(rimRadius, shortestSide * 0.5);
+rimRadius = min(rimRadius, shortestSide * 0.5);
         if (R > 0.0 && (corners_top != 0 || corners_bottom != 0))
             rimRadius = min(rimRadius, max(1.0, R));
         refractionBand = rimRadius;
@@ -288,12 +296,13 @@ void main() {
         }
     }
 
-    if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
+if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
         && distFromSide >= refractionBand) {
         vec4 sourceSample = sampleGlassBackdrop(actorUV);
         vec2 flatUV = backdropSampleUV(actorUV, vec2(0.0));
         vec4 flatSample = sampleGlassBackdrop(flatUV);
-        float finalOpacity = edgeOpacity * mix(sourceSample.a, flatSample.a, opacity_factor);
+        float finalOpacity = edgeOpacity * mix(sourceSample.a, flatSample.a,
+                                               opacity_factor);
         vec3 effectRGB = applyTintAndShadow(flatSample.rgb, localUV);
         vec3 outRGB = mix(sourceSample.rgb, effectRGB, opacity_factor);
 
@@ -301,26 +310,31 @@ void main() {
         return;
     }
 
-    float bezelRatio = clamp(distFromSide / refractionBand, 0.0, 1.0);
     float normDisp = distFromSide < refractionBand
-        ? displacementAtRatio(bezelRatio, glassThickness, refractionBand, eta)
+        ? quartzGlassEdgeProfile(distFromSide,
+                                 min(max(glassThickness, 1.0), refractionBand))
         : 0.0;
     float dispStrength = useCircularSurface ? edgeOpacity : edgeBand;
     vec2 dispPx = -dir * normDisp * refractionBand * strength * dispStrength;
 
     float dispersion = clamp(rgb_fringing * DISPERSION_SCALE, 0.0, 20.0);
     vec4 sourceColor = sampleGlassBackdrop(actorUV);
-    vec4 bgColor = sampleDispersed(actorUV, dispPx, dispersion);
+    vec2 aberrationPx = -dir * normDisp * dispersion * 8.0 * dispStrength;
+    vec4 bgColor = sampleDispersed(actorUV, dispPx, aberrationPx, dispersion);
 
-    vec3 outRGB = mix(bgColor.rgb, vec3(tint_r, tint_g, tint_b), tint * tint_a);
-    float fresnel = fresnelAtRatio(bezelRatio, REFRACTIVE_INDEX) * edgeOpacity;
+    vec3 outRGB = mix(bgColor.rgb, vec3(tint_r, tint_g, tint_b),
+                      tint * tint_a);
+    float highlight = quartzGlassHighlight(distFromSide, refractionBand, dir,
+                                           gloss, fresnel_angle) *
+                      edgeOpacity;
     float bgLuminance = luminance(outRGB);
-    float glare = clamp(fresnel * 0.70 * mix(0.40, 1.0, bgLuminance), 0.0, 0.18)
-        * clamp(gloss, 0.0, 1.0);
-    outRGB = 1.0 - (1.0 - outRGB) * (1.0 - glare);
+    highlight *= mix(0.32, 1.0, bgLuminance);
+    highlight = min(highlight, 0.22);
+    outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
     outRGB *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
     outRGB = mix(sourceColor.rgb, outRGB, opacity_factor);
 
-    float finalOpacity = edgeOpacity * mix(sourceColor.a, bgColor.a, opacity_factor);
+    float finalOpacity = edgeOpacity * mix(sourceColor.a, bgColor.a,
+                                           opacity_factor);
     cogl_color_out = vec4(clamp(outRGB, 0.0, 1.0) * finalOpacity, finalOpacity);
 }

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -26,6 +26,7 @@ uniform float rim_width;
 uniform float rgb_fringing;
 uniform float gloss;
 uniform float fresnel_angle;
+uniform float fresnel_width;
 uniform float tint;
 uniform float tint_r;
 uniform float tint_g;
@@ -55,7 +56,8 @@ float quartzGlassHighlight(float distanceFromEdge,
                            float angle) {
     float normalLength = max(length(surfaceNormal), 0.001);
     vec2 normal = surfaceNormal / normalLength;
-    float ringWidth = clamp(bezelWidth * 0.24, 1.0, 2.5);
+    float ringWidth = clamp(bezelWidth * 0.24 * fresnel_width, 1.0,
+                            2.5 * fresnel_width);
     float aa = 1.0;
 
     float outerCoverage = clamp(distanceFromEdge / aa + 0.5, 0.0, 1.0);

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -9,6 +9,9 @@
 // GNU GPL v3, with that permission extending to downstream users. Attribution
 // to the original work must be retained.
 //
+// Optional specular glare (off by default) is an addition beyond the 0.1.1b
+// port and is not part of the original shader.
+//
 // Original upstream license: CC BY-NC 4.0
 //   https://creativecommons.org/licenses/by-nc/4.0/
 // When this material is shared outside of Blur my Shell, the CC BY-NC 4.0
@@ -29,6 +32,7 @@ uniform float rgb_fringing;
 uniform float gloss;
 uniform float fresnel_angle;
 uniform float fresnel_width;
+uniform float specular_strength;
 uniform float tint;
 uniform float tint_r;
 uniform float tint_g;
@@ -342,6 +346,18 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     highlight *= mix(0.32, 1.0, bgLuminance);
     highlight = min(highlight, 0.22);
     outRGB = 1.0 - (1.0 - outRGB) * (1.0 - highlight);
+
+    if (specular_strength > 0.001) {
+        vec2 sourceDir = -vec2(cos(fresnel_angle), sin(fresnel_angle));
+        vec2 sourcePos = vec2(localUV.x - 0.5, 0.5 - localUV.y) * 2.0;
+        float sourceDist = length(sourcePos);
+        vec2 sourceNormal = sourceDist > 0.001 ? sourcePos / sourceDist
+                                              : vec2(0.0, 1.0);
+        float glint = pow(clamp(dot(sourceDir, sourceNormal), 0.0, 1.0), 14.0)
+                      * smoothstep(1.1, 0.4, sourceDist);
+        outRGB = 1.0 - (1.0 - outRGB) * (1.0 - glint * specular_strength);
+    }
+
     outRGB *= 1.0 - smoothstep(0.25, 1.0, localUV.y) * shadow * 0.20;
     outRGB = mix(sourceColor.rgb, outRGB, opacity_factor);
 

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -48,13 +48,8 @@ float quartzGlassEdgeProfile(float distanceFromEdge,
     return 1.0 - sqrt(t * (2.0 - t));
 }
 
-float quartzGlassHighlight(float distanceFromEdge,
-                           float bezelWidth,
-                           vec2 surfaceNormal,
-                           float strength,
-                           float angle) {
-    float normalLength = max(length(surfaceNormal), 0.001);
-    vec2 normal = surfaceNormal / normalLength;
+float quartzGlassRing(float distanceFromEdge,
+                      float bezelWidth) {
     float ringWidth = clamp(bezelWidth * 0.24 * fresnel_width, 1.0,
                             2.5 * fresnel_width);
     float aa = 1.0;
@@ -70,12 +65,23 @@ float quartzGlassHighlight(float distanceFromEdge,
         float decayRate = 3.0;
         ring = outerCoverage * exp(-decayRate * radial);
     }
+    return ring;
+}
+
+float quartzGlassHighlight(float distanceFromEdge,
+                           float bezelWidth,
+                           vec2 surfaceNormal,
+                           float strength,
+                           float angle) {
+    float normalLength = max(length(surfaceNormal), 0.001);
+    vec2 normal = surfaceNormal / normalLength;
+    float ring = quartzGlassRing(distanceFromEdge, bezelWidth);
 
     vec2 lightDirection = vec2(cos(angle), sin(angle));
     float threshold = 0.15;
     float directional = clamp((dot(lightDirection, normal) - threshold) /
                               max(1.0 - threshold, 0.0001), 0.0, 1.0);
-    float highlight = ring * directional;
+    float highlight = ring * (0.25 + 0.75 * directional);
 
     float oppositeAttenuation = 1.35;
     highlight /= max(1.0 + (1.0 - highlight) * oppositeAttenuation,
@@ -345,9 +351,8 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
         float dA = abs(mod(specAngle - sourceAngle + 3.14159265,
                            6.2831853) - 3.14159265);
         float lobe = exp(-dA * dA * 12.0);
-        float specular = lobe * quartzGlassHighlight(distFromSide, refractionBand,
-                                                     dir, 1.0, fresnel_angle) *
-                         edgeOpacity;
+        float specular = quartzGlassRing(distFromSide, refractionBand) *
+                         lobe * edgeOpacity;
         specular *= mix(0.32, 1.0, bgLuminance);
         specular = min(specular * specular_strength, 0.4);
         outRGB = 1.0 - (1.0 - outRGB) * (1.0 - specular);

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -208,20 +208,7 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
                 uniforms.set_uniform(this, 'fresnel_width', parseFloat(this._fresnel_width - 1e-6));
             }
         }
-            get specular_glare() {
-            return this._specular_glare;
-        }
-
-        set specular_glare(value) {
-            const specularGlare = typeof value === 'boolean'
-                ? value : DEFAULT_PARAMS.specular_glare;
-            if (this._specular_glare !== specularGlare) {
-                this._specular_glare = specularGlare;
-                this._updateSpecularUniform();
-            }
-        }
-
-        get specular_strength() {
+            get specular_strength() {
             return this._specular_strength;
         }
 
@@ -231,16 +218,13 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
             );
             if (this._specular_strength !== specularStrength) {
                 this._specular_strength = specularStrength;
-                this._updateSpecularUniform();
-            }
-        }
 
-        _updateSpecularUniform() {
-            uniforms.set_uniform(
-                this,
-                'specular_strength',
-                parseFloat(this._specular_glare ? this._specular_strength : 0.0)
-            );
+                uniforms.set_uniform(
+                    this,
+                    'specular_strength',
+                    parseFloat(this._specular_strength - 1e-6)
+                );
+            }
         }
 
         get webcam_gloss() {

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -58,7 +58,7 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
         }
 
         set edge_size(value) {
-            const edgeSize = utils.clamp(value, 1, 200, DEFAULT_PARAMS.edge_size);
+            const edgeSize = utils.clamp(value, 1, 500, DEFAULT_PARAMS.edge_size);
             if (this._edge_size !== edgeSize) {
                 this._edge_size = edgeSize;
 
@@ -86,7 +86,7 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
         }
 
         set falloff(value) {
-            const falloff = utils.clamp(value, 0.25, 8, DEFAULT_PARAMS.falloff);
+            const falloff = utils.clamp(value, 0.25, 20, DEFAULT_PARAMS.falloff);
             if (this._falloff !== falloff) {
                 this._falloff = falloff;
 
@@ -172,6 +172,25 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
                 this._gloss = gloss;
 
                 uniforms.set_uniform(this, 'gloss', parseFloat(this._gloss - 1e-6));
+            }
+        }
+
+        get fresnel_angle() {
+            return this._fresnel_angle;
+        }
+
+        set fresnel_angle(value) {
+            const fresnelAngle = utils.clamp(
+                value, -180, 180, DEFAULT_PARAMS.fresnel_angle
+            );
+            if (this._fresnel_angle !== fresnelAngle) {
+                this._fresnel_angle = fresnelAngle;
+
+                uniforms.set_uniform(
+                    this,
+                    'fresnel_angle',
+                    parseFloat(this._fresnel_angle * Math.PI / 180.0)
+                );
             }
         }
 

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -208,7 +208,42 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
                 uniforms.set_uniform(this, 'fresnel_width', parseFloat(this._fresnel_width - 1e-6));
             }
         }
-            get webcam_gloss() {
+            get specular_glare() {
+            return this._specular_glare;
+        }
+
+        set specular_glare(value) {
+            const specularGlare = typeof value === 'boolean'
+                ? value : DEFAULT_PARAMS.specular_glare;
+            if (this._specular_glare !== specularGlare) {
+                this._specular_glare = specularGlare;
+                this._updateSpecularUniform();
+            }
+        }
+
+        get specular_strength() {
+            return this._specular_strength;
+        }
+
+        set specular_strength(value) {
+            const specularStrength = utils.clamp(
+                value, 0, 1, DEFAULT_PARAMS.specular_strength
+            );
+            if (this._specular_strength !== specularStrength) {
+                this._specular_strength = specularStrength;
+                this._updateSpecularUniform();
+            }
+        }
+
+        _updateSpecularUniform() {
+            uniforms.set_uniform(
+                this,
+                'specular_strength',
+                parseFloat(this._specular_glare ? this._specular_strength : 0.0)
+            );
+        }
+
+        get webcam_gloss() {
             return this._webcam_gloss;
         }
 

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -194,7 +194,21 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
             }
         }
 
-        get webcam_gloss() {
+        get fresnel_width() {
+            return this._fresnel_width;
+        }
+
+        set fresnel_width(value) {
+            const fresnelWidth = utils.clamp(
+                value, 0.5, 6, DEFAULT_PARAMS.fresnel_width
+            );
+            if (this._fresnel_width !== fresnelWidth) {
+                this._fresnel_width = fresnelWidth;
+
+                uniforms.set_uniform(this, 'fresnel_width', parseFloat(this._fresnel_width - 1e-6));
+            }
+        }
+            get webcam_gloss() {
             return this._webcam_gloss;
         }
 

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -189,7 +189,7 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
                 uniforms.set_uniform(
                     this,
                     'fresnel_angle',
-                    parseFloat(this._fresnel_angle * Math.PI / 180.0)
+                    parseFloat((this._fresnel_angle + 90.0) * Math.PI / 180.0)
                 );
             }
         }

--- a/src/effects/refraction_config.js
+++ b/src/effects/refraction_config.js
@@ -13,6 +13,7 @@ export const DEFAULT_PARAMS = {
     rim_width: 4.8,
     rgb_fringing: 0.1,
     gloss: 1,
+    fresnel_angle: -45,
     webcam_gloss: false,
     webcam_device: '',
     tint: 0.2,
@@ -47,7 +48,7 @@ export const REFRACTION_EFFECT_META = {
         ),
         edge_size: doubleProperty(
             'edge_size', 'Edge Size', 'Refraction edge size',
-            1, 200, DEFAULT_PARAMS.edge_size
+            1, 500, DEFAULT_PARAMS.edge_size
         ),
         blur_radius: doubleProperty(
             'blur_radius', 'Blur Radius', 'Internal glass blur radius',
@@ -55,7 +56,7 @@ export const REFRACTION_EFFECT_META = {
         ),
         falloff: doubleProperty(
             'falloff', 'Falloff', 'Refraction falloff',
-            0.25, 8, DEFAULT_PARAMS.falloff
+            0.25, 20, DEFAULT_PARAMS.falloff
         ),
         corner_radius: doubleProperty(
             'corner_radius', 'Corner Radius', 'Refraction corner radius',
@@ -80,6 +81,10 @@ export const REFRACTION_EFFECT_META = {
         gloss: doubleProperty(
             'gloss', 'Gloss', 'Specular highlight strength',
             0, 1, DEFAULT_PARAMS.gloss
+        ),
+        fresnel_angle: doubleProperty(
+            'fresnel_angle', 'Fresnel Angle', 'Light direction of the fresnel glare, in degrees',
+            -180, 180, DEFAULT_PARAMS.fresnel_angle
         ),
         webcam_gloss: GObject.ParamSpec.boolean(
             'webcam_gloss',

--- a/src/effects/refraction_config.js
+++ b/src/effects/refraction_config.js
@@ -14,6 +14,7 @@ export const DEFAULT_PARAMS = {
     rgb_fringing: 0.1,
     gloss: 1,
     fresnel_angle: -45,
+    fresnel_width: 1,
     webcam_gloss: false,
     webcam_device: '',
     tint: 0.2,
@@ -85,6 +86,10 @@ export const REFRACTION_EFFECT_META = {
         fresnel_angle: doubleProperty(
             'fresnel_angle', 'Fresnel Angle', 'Light direction of the fresnel glare, in degrees',
             -180, 180, DEFAULT_PARAMS.fresnel_angle
+        ),
+        fresnel_width: doubleProperty(
+            'fresnel_width', 'Fresnel Width', 'Thickness multiplier of the fresnel glare ring',
+            0.5, 6, DEFAULT_PARAMS.fresnel_width
         ),
         webcam_gloss: GObject.ParamSpec.boolean(
             'webcam_gloss',

--- a/src/effects/refraction_config.js
+++ b/src/effects/refraction_config.js
@@ -15,8 +15,7 @@ export const DEFAULT_PARAMS = {
     gloss: 1,
     fresnel_angle: 45,
     fresnel_width: 1,
-    specular_glare: false,
-    specular_strength: 0.35,
+    specular_strength: 0,
     webcam_gloss: false,
     webcam_device: '',
     tint: 0.2,
@@ -92,10 +91,6 @@ export const REFRACTION_EFFECT_META = {
         fresnel_width: doubleProperty(
             'fresnel_width', 'Fresnel Width', 'Thickness multiplier of the fresnel glare ring',
             0.5, 6, DEFAULT_PARAMS.fresnel_width
-        ),
-        specular_glare: GObject.ParamSpec.boolean(
-            'specular_glare', 'Specular Glare', 'Specular glare showing the light direction',
-            GObject.ParamFlags.READWRITE, DEFAULT_PARAMS.specular_glare
         ),
         specular_strength: doubleProperty(
             'specular_strength', 'Specular Glare Strength', 'Strength of the specular glare',

--- a/src/effects/refraction_config.js
+++ b/src/effects/refraction_config.js
@@ -15,6 +15,8 @@ export const DEFAULT_PARAMS = {
     gloss: 1,
     fresnel_angle: 45,
     fresnel_width: 1,
+    specular_glare: false,
+    specular_strength: 0.35,
     webcam_gloss: false,
     webcam_device: '',
     tint: 0.2,
@@ -90,6 +92,14 @@ export const REFRACTION_EFFECT_META = {
         fresnel_width: doubleProperty(
             'fresnel_width', 'Fresnel Width', 'Thickness multiplier of the fresnel glare ring',
             0.5, 6, DEFAULT_PARAMS.fresnel_width
+        ),
+        specular_glare: GObject.ParamSpec.boolean(
+            'specular_glare', 'Specular Glare', 'Specular glare showing the light direction',
+            GObject.ParamFlags.READWRITE, DEFAULT_PARAMS.specular_glare
+        ),
+        specular_strength: doubleProperty(
+            'specular_strength', 'Specular Glare Strength', 'Strength of the specular glare',
+            0, 1, DEFAULT_PARAMS.specular_strength
         ),
         webcam_gloss: GObject.ParamSpec.boolean(
             'webcam_gloss',

--- a/src/effects/refraction_config.js
+++ b/src/effects/refraction_config.js
@@ -13,7 +13,7 @@ export const DEFAULT_PARAMS = {
     rim_width: 4.8,
     rgb_fringing: 0.1,
     gloss: 1,
-    fresnel_angle: -45,
+    fresnel_angle: 45,
     fresnel_width: 1,
     webcam_gloss: false,
     webcam_device: '',


### PR DESCRIPTION
## Summary

Updates the Liquid Glass refraction effect with the shader features from winaviation's Liquid (Gl)ass tweak 0.1.1b, building on the 0.1.0b refraction work and the unified rendering backend #976. The changes are ported from `LiquidAssBackboardd/Tweak.mm` (Metal) to GLSL for Blur my Shell.

## How it works

Builds on the 0.1.0b refraction work and updates the shader to 0.1.1b:

- Convex-circle refraction: #976 swapped 0.1.0b's squircles for convex-circle rounding to match GNOME's standard rounded corners
- Chromatic dispersion accumulation (3 + 4 taps split along the fresnel glare axis)
- Quartz edge profile (`1 - sqrt(t*(2-t))`) and highlight, keeping the edge falloff and glare band tight to the rounded-corner rim
- A fresnel glare angle setting (-180..180 deg, default +45 deg, 0 = light from above, positive clockwise) that rotates the glare and dispersion axis to match the original shader orientation
- A fresnel glare width setting (default 1.0)
- An optional specular glare that shows the light direction across the glass face, off by default (addition beyond the 0.1.1b shader) that scales the highlight ring thickness up or down
- Bezel width range widened to 500 and glass thickness to 20 for heavier glass looks
- The un-premultiplied backdrop sampling, tint and shadow are unchanged

## Known issues

- Not ported from 0.1.1b: glyph mask refraction (iOS clock and icons), and the coversheet mode, which refracts the lock screen around the edges when you swipe up to unlock. Neither maps to a surface Blur my Shell has

## Testing

- Tested manually on GNOME 50.3, Wayland
- Checked JavaScript syntax with `node --check src/effects/refraction.js`
- `make build` succeeds

## License

`refraction.glsl` is a port of winaviation's Liquid (Gl)ass 0.1.1b. winaviation confirmed in this PR (2026-09-11) that this ported shader file is re-licensed under **GPLv3** for blur-my-shell, with the same rights extending to anyone who reuses it from this repository. The original upstream project remains **CC BY-NC 4.0**. Attribution to the original work is retained in the file header.



