### PR TITLE
Add Copyous extension blur support

### DIFF
--- a/resources/ui/other.ui
+++ b/resources/ui/other.ui
@@ -115,6 +115,18 @@
 
     <child>
       <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Copyous extension blur</property>
+        <property name="description" translatable="yes">Blur the Copyous clipboard popup. Uses the blur settings and dialog corner radius from the Popups page. Popup blur must be enabled.</property>
+        <property name="header-suffix">
+          <object class="GtkSwitch" id="blur_copyous">
+            <property name="valign">center</property>
+          </object>
+        </property>
+      </object>
+    </child>
+
+    <child>
+      <object class="AdwPreferencesGroup">
         <property name="title" translatable="yes">Performance</property>
         <property name="description" translatable="yes">Various options to tweak the performance.</property>
 

--- a/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml
@@ -622,6 +622,11 @@
             <default>true</default>
             <summary>Boolean, whether to blur popup menus, notifications, switchers, and dialogs or not</summary>
         </key>
+        <!-- COPYOUS -->
+        <key type="b" name="blur-copyous">
+            <default>true</default>
+            <summary>Boolean, whether to blur the Copyous clipboard popup</summary>
+        </key>
         <!-- STATIC BLUR -->
         <key type="b" name="static-blur">
             <default>false</default>

--- a/src/components/popup/blur_surface.js
+++ b/src/components/popup/blur_surface.js
@@ -10,6 +10,7 @@ import { PopupBlurSurfaceSignals } from './surface_signals.js';
 import { PopupBlurSurfaceStyle } from './surface_style.js';
 import { PopupBlurSurfaceTransitions } from './surface_transitions.js';
 import { PopupBlurStaticActor } from './static_actor.js';
+import { CopyousContentStyle, is_copyous_surface } from './copyous_style.js';
 
 const NOTIFICATION_STYLE_CLASSES = ['notification-banner'];
 const FULL_GEOMETRY_STYLE_CLASSES = [
@@ -17,7 +18,7 @@ const FULL_GEOMETRY_STYLE_CLASSES = [
     'quick-settings', 'quick-toggle-menu', 'screenshot-ui-panel',
     'notification-banner', 'snap-assistant',
     'osd-window', 'resize-popup', 'workspace-switcher',
-    'modal-dialog', 'run-dialog',
+    'modal-dialog', 'run-dialog', 'clipboard-dialog',
     'bms-keyboard-surface',
 ];
 const IS_HEAVY_SURFACE_STYLE_CLASSES = [
@@ -29,7 +30,7 @@ const IS_QUICK_SETTINGS_STYLE_CLASSES = [
 ];
 
 export const PopupBlurSurface = class PopupBlurSurface {
-    constructor(connections, settings, effects_manager, target, root_actor, parent, sibling, corner_radius, is_enabled) {
+    constructor(connections, settings, effects_manager, target, root_actor, parent, sibling, corner_radius, is_enabled, get_background_style) {
         this.connections = connections;
         this.settings = settings;
         this.effects_manager = effects_manager;
@@ -39,10 +40,13 @@ export const PopupBlurSurface = class PopupBlurSurface {
         this.sibling = sibling;
         this.corner_radius = corner_radius;
         this.is_enabled = is_enabled;
+        this.get_background_style = get_background_style;
         this.paint_signals = new PaintSignals(connections);
         this.placement = new PopupBlurSurfacePlacement(this);
         this.signals = new PopupBlurSurfaceSignals(this);
         this.style = new PopupBlurSurfaceStyle(this);
+        this.copyous_style = settings.popup.BLUR_COPYOUS && is_copyous_surface(target)
+            ? new CopyousContentStyle(this) : null;
         this.transitions = new PopupBlurSurfaceTransitions(this);
         this.repaint_id = 0;
         this.update_id = 0;
@@ -73,6 +77,7 @@ export const PopupBlurSurface = class PopupBlurSurface {
         this.set_actor_position();
         this.style.capture_target_style();
         this.style.update_target_style();
+        this.copyous_style?.update();
 
         this.connect_repaints();
         this.signals.connect_actor(this.target);
@@ -401,6 +406,7 @@ export const PopupBlurSurface = class PopupBlurSurface {
 
     update_settings() {
         this.style.update_target_style();
+        this.copyous_style?.update();
         this.static_actor?.update_settings();
     }
 
@@ -461,6 +467,7 @@ export const PopupBlurSurface = class PopupBlurSurface {
 
     destroy(actor_already_destroyed = false) {
         this.destroyed = true;
+        this.copyous_style?.destroy();
         if (this.update_id)
             global.compositor.get_laters().remove(this.update_id);
         this.update_id = 0;

--- a/src/components/popup/copyous_style.js
+++ b/src/components/popup/copyous_style.js
@@ -1,0 +1,126 @@
+// Copyous paints its cards and controls separately from the dialog background.
+// Make those surfaces translucent over the dialog's existing blur; leave text,
+// images, color swatches, and other clipboard content untouched.
+const SURFACE_CLASSES = [
+    'clipboard-item', 'content-preview', 'clipboard-search-entry',
+    'dialog-header-button', 'dialog-header-icon-button',
+    'dialog-footer-button', 'dialog-footer-icon-button',
+    'clipboard-item-header-button', 'clipboard-item-tag-button',
+    'clipboard-item-title-entry', 'search-entry-button',
+    'popup-menu-item', 'popup-sub-menu',
+];
+
+export function is_copyous_surface(actor) {
+    const has_class = (target, name) =>
+        (target?.get_style_class_name?.() ?? '').split(/\s+/).includes(name);
+    if (has_class(actor, 'clipboard-dialog'))
+        return true;
+    if (!has_class(actor, 'popup-menu-content'))
+        return false;
+
+    for (let parent = actor.get_parent?.(); parent; parent = parent.get_parent?.()) {
+        if (has_class(parent, 'clipboard-item-menu') || has_class(parent, 'search-popup-menu'))
+            return true;
+    }
+    return false;
+}
+
+export class CopyousContentStyle {
+    constructor(surface) {
+        this.surface = surface;
+        this.actors = new Map();
+    }
+
+    update() {
+        if (!this.surface.settings.popup.OVERRIDE_BACKGROUND) {
+            this.destroy();
+            return;
+        }
+
+        this.track(this.surface.target);
+        this.actors.forEach((record, actor) => this.update_actor(actor, record));
+    }
+
+    track(actor) {
+        if (!actor || this.actors.has(actor))
+            return;
+
+        const record = { signals: [], original: null, applied: null, updating: false };
+        this.actors.set(actor, record);
+        const connect = (signal, callback) => record.signals.push(actor.connect(signal, callback));
+        connect('destroy', () => this.actors.delete(actor));
+        connect('child-added', (_, child) => this.track(child));
+        connect('child-removed', (_, child) => this.untrack(child));
+        if (actor.get_style) {
+            connect('style-changed', () => this.update_actor(actor, record));
+            connect('notify::hover', () => this.update_actor(actor, record));
+        }
+
+        this.update_actor(actor, record);
+        (actor.get_children?.() ?? []).forEach(child => this.track(child));
+    }
+
+    update_actor(actor, record) {
+        if (record.updating || !this.actors.has(actor) || !actor.set_style)
+            return;
+
+        record.updating = true;
+        try {
+            const current = actor.get_style();
+            if (current !== record.applied)
+                record.original = current;
+
+            const classes = (actor.get_style_class_name?.() ?? '').split(/\s+/);
+            if (!classes.some(name => SURFACE_CLASSES.includes(name))) {
+                this.restore(actor, record);
+                return;
+            }
+
+            // Keep hover/pressed feedback and the theme's existing focus rings.
+            const has_state = state => actor.has_style_pseudo_class?.(state);
+            const pressed = ['active', 'checked', 'selected'].some(has_state);
+            const hover = actor.hover || has_state('hover');
+            const is_menu = classes.includes('popup-menu-item') || classes.includes('popup-sub-menu');
+            const alpha = has_state('insensitive') ? (is_menu ? 0 : 0.06)
+                : pressed ? 0.28 : hover ? 0.20 : is_menu ? 0 : 0.12;
+            const rgb = this.surface.get_background_style() === 1 ? '0, 0, 0' : '255, 255, 255';
+            const base = record.original ?? '';
+            const separator = base.trim() && !base.trim().endsWith(';') ? ';' : '';
+            const style = `${base}${separator}background-color: rgba(${rgb}, ${alpha});`;
+            if (current !== style) {
+                record.applied = style;
+                actor.set_style(style);
+            }
+        } finally {
+            record.updating = false;
+        }
+    }
+
+    restore(actor, record) {
+        const applied = record.applied;
+        record.applied = null;
+        if (applied !== null && actor.get_style?.() === applied)
+            actor.set_style(record.original);
+    }
+
+    untrack(actor) {
+        const record = this.actors.get(actor);
+        if (!record)
+            return;
+
+        this.actors.delete(actor);
+        record.signals.forEach(id => actor.disconnect(id));
+        this.restore(actor, record);
+        (actor.get_children?.() ?? []).forEach(child => this.untrack(child));
+    }
+
+    destroy() {
+        // Disconnect before restoring styles so restoration cannot reapply them.
+        const actors = [...this.actors];
+        this.actors.clear();
+        actors.forEach(([actor, record]) => {
+            record.signals.forEach(id => actor.disconnect(id));
+            this.restore(actor, record);
+        });
+    }
+}

--- a/src/components/popup/index.js
+++ b/src/components/popup/index.js
@@ -223,7 +223,8 @@ export const PopupBlur = class PopupBlur {
             parent,
             sibling,
             this.get_corner_radius(target, root_actor),
-            () => this.enabled && this.surfaces.has(target)
+            () => this.enabled && this.surfaces.has(target),
+            () => this.get_background_style()
         );
 
         this.surfaces.set(target, surface);
@@ -288,7 +289,10 @@ export const PopupBlur = class PopupBlur {
             };
         }
 
-        let actor = root_actor;
+        // Start at the surface: a scan can discover several dialogs at once
+        // with modalDialogGroup as their shared root. Each blur must sit above
+        // earlier dialogs and immediately below the dialog it belongs to.
+        let actor = target;
         let child = null;
         while (actor && !this.destroyed_actors.has(actor)) {
             let parent = null;
@@ -301,7 +305,8 @@ export const PopupBlur = class PopupBlur {
             if (!parent)
                 break;
 
-            if (parent === Main.layoutManager?.unlockDialogGroup ||
+            if (parent === Main.layoutManager?.modalDialogGroup ||
+                parent === Main.layoutManager?.unlockDialogGroup ||
                 parent === Main.layoutManager?.screenShieldGroup ||
                 parent === Main.uiGroup || 
                 parent === Main.layoutManager?.uiGroup)

--- a/src/components/popup/surface_allocation.js
+++ b/src/components/popup/surface_allocation.js
@@ -1,0 +1,19 @@
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+
+// Modal dialogs use a BinLayout, which can shrink an overlay to the group's
+// preferred size. Its blur must instead cover the measured popup rectangle.
+export const PopupBlurAllocation = GObject.registerClass(
+class PopupBlurAllocation extends Clutter.Constraint {
+    set_geometry(x, y, width, height) {
+        this.geometry = { x, y, width, height };
+        this.actor?.queue_relayout();
+    }
+
+    vfunc_update_allocation(_actor, box) {
+        if (this.geometry) {
+            const { x, y, width, height } = this.geometry;
+            box.init_rect(x, y, width, height);
+        }
+    }
+});

--- a/src/components/popup/surface_placement.js
+++ b/src/components/popup/surface_placement.js
@@ -1,6 +1,7 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { PopupBlurSurfaceGeometry, transform_to_actor_space } from './surface_geometry.js';
+import { PopupBlurAllocation } from './surface_allocation.js';
 
 export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
     constructor(surface) {
@@ -283,6 +284,15 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
 
     update_dynamic_geometry(x, y, width, height) {
         try {
+            if (this.surface.parent === Main.layoutManager.modalDialogGroup
+                && (this.x !== x || this.y !== y || this.width !== width || this.height !== height)) {
+                if (!this.allocation_constraint) {
+                    this.allocation_constraint = new PopupBlurAllocation();
+                    this.surface.blur_actor.add_constraint(this.allocation_constraint);
+                }
+                this.allocation_constraint.set_geometry(x, y, width, height);
+            }
+
             if (this.x !== x || this.y !== y) {
                 this.surface.blur_actor.set_position(x, y);
                 this.x = x;

--- a/src/components/popup/surface_signals.js
+++ b/src/components/popup/surface_signals.js
@@ -41,6 +41,10 @@ export const PopupBlurSurfaceSignals = class PopupBlurSurfaceSignals {
         SURFACE_SIGNALS.forEach(signal => {
             try {
             let id = actor.connect(signal, () => {
+                if (signal === 'style-changed' && actor === this.surface.target
+                    && this.surface.copyous_style)
+                    this.surface.style.update_target_style();
+
                 this.clear_pending_idles();
                 const is_visibility_change = signal === 'notify::visible' || signal === 'notify::mapped';
                 if (is_heavy_surface || is_visibility_change) {

--- a/src/components/popup/surface_style.js
+++ b/src/components/popup/surface_style.js
@@ -1,8 +1,11 @@
+import { is_copyous_surface } from './copyous_style.js';
+
 export const PopupBlurSurfaceStyle = class PopupBlurSurfaceStyle {
     constructor(surface) {
         this.surface = surface;
         this.original_target_style = null;
         this.target_style_set = false;
+        this.applied_target_style = null;
     }
 
     capture_target_style() {
@@ -14,6 +17,17 @@ export const PopupBlurSurfaceStyle = class PopupBlurSurfaceStyle {
     }
 
     update_target_style() {
+        if (this.surface.destroyed)
+            return;
+
+        // Copyous updates its inline margins when its layout settings change.
+        // Keep those updates when applying or removing our corner radius.
+        const current_style = this.surface.target.get_style?.() ?? null;
+        if (current_style !== this.applied_target_style) {
+            this.original_target_style = current_style;
+            this.target_style_set = false;
+        }
+
         if (
             !this.surface.target.set_style
             || !this.surface.settings.popup.OVERRIDE_BACKGROUND
@@ -31,10 +45,20 @@ export const PopupBlurSurfaceStyle = class PopupBlurSurfaceStyle {
         const separator = base_style.trim() && !base_style.trim().endsWith(';') ? '; ' : '';
 
         try {
-            this.surface.target.set_style(
-                `${base_style}${separator}border-radius: ${this.surface.get_corner_radius()}px;`
-            );
+            let style = `${base_style}${separator}border-radius: ${this.surface.get_corner_radius()}px;`;
+            if (this.surface.settings.popup.BLUR_COPYOUS && is_copyous_surface(this.surface.target)) {
+                // Copyous loads its own stylesheet, which can take precedence
+                // over our imported popup CSS. Override its opaque background
+                // inline, and restore it together with the corner radius.
+                const backgrounds = ['transparent', 'rgba(255, 255, 255, 0.58)', 'rgba(45, 45, 50, 0.22)'];
+                const background = backgrounds[this.surface.get_background_style()];
+                style += `background-color: ${background};`;
+            }
+            if (current_style === style)
+                return;
+            this.applied_target_style = style;
             this.target_style_set = true;
+            this.surface.target.set_style(style);
         } catch (e) {
             return;
         }
@@ -45,8 +69,11 @@ export const PopupBlurSurfaceStyle = class PopupBlurSurfaceStyle {
             return;
 
         try {
-            this.surface.target.set_style(this.original_target_style);
+            const current_style = this.surface.target.get_style?.() ?? null;
             this.target_style_set = false;
+            if (current_style === this.applied_target_style)
+                this.surface.target.set_style(this.original_target_style);
+            this.applied_target_style = null;
         } catch (e) { }
     }
 

--- a/src/components/popup/targets.js
+++ b/src/components/popup/targets.js
@@ -33,7 +33,7 @@ export const POPUP_CORNER_RADII = [
     {
         key: 'dialog-corner-radius',
         property: 'DIALOG_CORNER_RADIUS',
-        style_classes: ['modal-dialog', 'run-dialog'],
+        style_classes: ['modal-dialog', 'run-dialog', 'clipboard-dialog'],
     },
     {
         key: 'osk-corner-radius',
@@ -58,6 +58,9 @@ export const PopupBlurTargets = class PopupBlurTargets {
 
         const targets = this.create_targets();
         const delegate = this.actor.get_actor_delegate(actor);
+
+        if (this.is_copyous_target(actor))
+            this.add(targets, actor);
 
         if (this.prefers_descendant_targets(actor)) {
             this.find_target_children(actor, targets);
@@ -148,10 +151,16 @@ export const PopupBlurTargets = class PopupBlurTargets {
 
     is_blur_target_actor(actor) {
         return (
-            this.has_any_style_class(actor, POPUP_TARGET_STYLE_CLASSES)
+            this.is_copyous_target(actor)
+            || this.has_any_style_class(actor, POPUP_TARGET_STYLE_CLASSES)
             || this.has_any_style_class(actor, POPUP_TARGET_STYLE_CLASSES_OSK)
             || this.has_any_style_class(actor, POPUP_CHILD_STYLE_CLASSES)
         );
+    }
+
+    is_copyous_target(actor) {
+        return this.actor.settings.popup.BLUR_COPYOUS
+            && this.has_style_class(actor, 'clipboard-dialog');
     }
 
     get_corner_radius(target, root_actor) {

--- a/src/conveniences/keys.js
+++ b/src/conveniences/keys.js
@@ -103,6 +103,7 @@ export const KEYS = [
     {
         component: "popup", schemas: [
             { type: Type.B, name: "blur" },
+            { type: Type.B, name: "blur-copyous" },
             { type: Type.B, name: "static-blur" },
             { type: Type.S, name: "pipeline" },
             { type: Type.I, name: "sigma" },

--- a/src/extension.js
+++ b/src/extension.js
@@ -678,6 +678,11 @@ export default class BlurMyShell extends Extension {
                 this._popup.disable();
         });
 
+        this._settings.popup.BLUR_COPYOUS_changed(() => {
+            if (this._settings.popup.BLUR)
+                this._popup.reset();
+        });
+
         this._settings.popup.STATIC_BLUR_changed(() => {
             if (this._settings.popup.BLUR)
                 this._popup.reset();

--- a/src/preferences/other.js
+++ b/src/preferences/other.js
@@ -21,6 +21,8 @@ export const Other = GObject.registerClass({
         'coverflow_alt_tab_blur',
         'coverflow_alt_tab_pipeline_choose_row',
 
+        'blur_copyous',
+
         'hack_level',
         'debug',
         'reset'
@@ -70,6 +72,11 @@ export const Other = GObject.registerClass({
         );
         this._coverflow_alt_tab_pipeline_choose_row.initialize(
             this.preferences.coverflow_alt_tab, this.pipelines_manager, this.pipelines_page
+        );
+
+        this.preferences.popup.settings.bind(
+            'blur-copyous', this._blur_copyous, 'active',
+            Gio.SettingsBindFlags.DEFAULT
         );
 
         this.preferences.settings.bind(

--- a/tests/copyous-content-style.js
+++ b/tests/copyous-content-style.js
@@ -1,0 +1,95 @@
+// Run with: gjs -m tests/copyous-content-style.js
+import { CopyousContentStyle, is_copyous_surface } from '../src/components/popup/copyous_style.js';
+
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message);
+}
+
+class Actor {
+    constructor(classes = '', style = null) {
+        this.classes = classes;
+        this.style = style;
+        this.children = [];
+        this.signals = new Map();
+        this.states = new Set();
+        this.next_id = 0;
+    }
+    get_style_class_name() { return this.classes; }
+    get_style() { return this.style; }
+    set_style(value) { this.style = value; this.emit('style-changed'); }
+    get_children() { return this.children; }
+    get_parent() { return this.parent ?? null; }
+    has_style_pseudo_class(state) { return this.states.has(state); }
+    connect(signal, callback) { this.signals.set(++this.next_id, [signal, callback]); return this.next_id; }
+    disconnect(id) { this.signals.delete(id); }
+    emit(signal, ...args) {
+        [...this.signals.values()].forEach(([name, callback]) => {
+            if (name === signal)
+                callback(this, ...args);
+        });
+    }
+    add(child) { child.parent = this; this.children.push(child); this.emit('child-added', child); }
+    remove(child) { child.parent = null; this.children = this.children.filter(c => c !== child); this.emit('child-removed', child); }
+}
+
+const root = new Actor('clipboard-dialog', 'margin: 6px;');
+const card = new Actor('clipboard-item', 'padding: 8px;');
+const text = new Actor('text-item-content');
+const image = new Actor('image-item-image', 'background-image: url(test.png);');
+card.add(text);
+card.add(image);
+root.add(card);
+let background = 2;
+const surface = { target: root, settings: { popup: { OVERRIDE_BACKGROUND: true } }, get_background_style: () => background };
+const styles = new CopyousContentStyle(surface);
+styles.update();
+assert(card.style.includes('rgba(255, 255, 255, 0.12)'), 'Card becomes translucent');
+assert(text.style === null && image.style === 'background-image: url(test.png);', 'Clipboard content stays untouched');
+assert(root.style === 'margin: 6px;', 'Dialog styling stays separate');
+card.states.add('hover');
+card.emit('style-changed');
+assert(card.style.includes('0.2)'), 'Hover feedback remains visible');
+card.states.add('active');
+card.emit('style-changed');
+assert(card.style.includes('0.28)'), 'Pressed state is distinct');
+const button = new Actor('dialog-footer-button');
+root.add(button);
+assert(button.style.includes('background-color'), 'New controls are styled immediately');
+card.set_style('padding: 12px;');
+assert(card.style.startsWith('padding: 12px;'), 'Copyous inline changes are retained');
+background = 1;
+styles.update();
+assert(button.style.includes('rgba(0, 0, 0,'), 'Light background uses a dark translucent tint');
+root.remove(card);
+assert(card.style === 'padding: 12px;' && card.signals.size === 0 && text.signals.size === 0, 'Removed cards and descendants are restored and disconnected');
+root.add(card);
+surface.settings.popup.OVERRIDE_BACKGROUND = false;
+styles.update();
+assert(card.style === 'padding: 12px;' && button.style === null && styles.actors.size === 0, 'Disabling override restores all controls');
+surface.settings.popup.OVERRIDE_BACKGROUND = true;
+styles.update();
+button.emit('destroy');
+assert(!styles.actors.has(button), 'Destroyed actors are released');
+styles.destroy();
+assert(card.style === 'padding: 12px;' && root.signals.size === 0, 'Disabling blur restores styles and disconnects observers');
+print('Copyous content styling lifecycle checks passed');
+
+// Copyous menus are separate top-level actors, outside the clipboard dialog.
+const menuRoot = new Actor('popup-menu clipboard-item-menu');
+const menu = new Actor('popup-menu-content');
+const item = new Actor('popup-menu-item');
+menuRoot.add(menu);
+menu.add(item);
+assert(is_copyous_surface(menu), 'Recognize a three-dot menu by its ancestor');
+assert(!is_copyous_surface(new Actor('popup-menu-content')), 'Leave unrelated menus alone');
+assert(!is_copyous_surface(new Actor('modal-dialog clipboard-item-edit-dialog')), 'Keep edit dialogs on the standard modal styling path');
+const menuStyles = new CopyousContentStyle({ ...surface, target: menu });
+menuStyles.update();
+assert(item.style.includes('0)'), 'Menu rows stay transparent at rest');
+item.states.add('hover');
+item.emit('style-changed');
+assert(item.style.includes('0.2)'), 'Menu hover feedback stays translucent');
+menuStyles.destroy();
+assert(item.style === null, 'Menu row styles restore on disable');
+print('Copyous menu scope and restoration checks passed');

--- a/tests/popup-copyous.js
+++ b/tests/popup-copyous.js
@@ -1,0 +1,70 @@
+// Run with: gjs -m tests/popup-copyous.js
+import { PopupBlurTargets } from '../src/components/popup/targets.js';
+import { PopupBlurSurfaceStyle } from '../src/components/popup/surface_style.js';
+
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message);
+}
+
+function actor(classes = '', children = []) {
+    return {
+        get_style_class_name: () => classes,
+        get_children: () => children,
+    };
+}
+
+const settings = { popup: { BLUR_COPYOUS: true, OVERRIDE_BACKGROUND: true } };
+const owner = {
+    settings,
+    is_internal_actor: () => false,
+    watch_actor: target => !!target,
+    get_actor_delegate: target => target._delegate,
+    get_actor_dialog_layout: target => target.dialogLayout,
+};
+const targets = new PopupBlurTargets(owner);
+const clipboard = actor('clipboard-dialog horizontal', [actor('clipboard-item')]);
+const wrapper = actor('', [clipboard]);
+const menu = actor('popup-menu-content');
+
+assert(targets.find(wrapper)[0] === clipboard, 'Find Copyous inside its modal wrapper');
+assert(targets.find(clipboard).length === 1, 'Blur the dialog once, without blurring its cards');
+assert(targets.get_corner_radius(clipboard, wrapper).key === 'dialog-corner-radius',
+    'Use the dialog corner radius');
+settings.popup.BLUR_COPYOUS = false;
+assert(targets.find(wrapper).length === 0, 'Do not blur Copyous when disabled');
+assert(!targets.is_blur_target_actor(clipboard), 'Do not track disabled Copyous as a target');
+assert(targets.find(menu)[0] === menu, 'Keep regular popup blur enabled');
+settings.popup.BLUR_COPYOUS = true;
+assert(targets.find(wrapper)[0] === clipboard, 'Rediscover an existing dialog after enabling');
+const vertical = actor('clipboard-dialog vertical');
+assert(targets.find(actor('', [vertical]))[0] === vertical, 'Support vertical Copyous layouts');
+
+let inline_style = 'margin: 10px;';
+let on_style_changed = () => {};
+const styled_target = {
+    get_style_class_name: () => 'clipboard-dialog',
+    get_style: () => inline_style,
+    set_style: value => {
+        inline_style = value;
+        on_style_changed();
+    },
+};
+const surface = { settings, target: styled_target, get_corner_radius: () => 18, get_background_style: () => 2 };
+const style = new PopupBlurSurfaceStyle(surface);
+style.capture_target_style();
+on_style_changed = () => style.update_target_style();
+style.update_target_style();
+assert(inline_style === 'margin: 10px;border-radius: 18px;background-color: rgba(45, 45, 50, 0.22);', 'Preserve original margins');
+styled_target.set_style('margin: 20px;');
+assert(inline_style === 'margin: 20px;border-radius: 18px;background-color: rgba(45, 45, 50, 0.22);', 'Preserve live margin updates');
+settings.popup.OVERRIDE_BACKGROUND = false;
+style.update_target_style();
+assert(inline_style === 'margin: 20px;', 'Restore the latest margins when override is disabled');
+settings.popup.OVERRIDE_BACKGROUND = true;
+style.update_target_style();
+surface.destroyed = true;
+style.restore_target_style();
+assert(inline_style === 'margin: 20px;', 'Restore Copyous styling on surface destruction');
+
+print('Copyous popup detection and style lifecycle checks passed');


### PR DESCRIPTION
Adds optional blur support for the Copyous clipboard manager extension.
Since Copyous creates a popup, the existing popup code is used.
The toggle is in Other, below Coverflow.

Also fixes modal blur placement so the edit dialog blurs the clipboard popup behind it. (Thanks to Codex, because I had absolutely no idea how to fix that.)

Works with GNOME Shell 50.4 and Copyous 2.0.1. 
I tested dynamic/static blur, toggle restoration, and ran the tests.