### PR TITLE
Fix blur stacking for modal dialogs

### DIFF
--- a/src/components/popup/index.js
+++ b/src/components/popup/index.js
@@ -316,7 +316,9 @@ export const PopupBlur = class PopupBlur {
             };
         }
 
-        let actor = root_actor;
+        // A scan can discover several dialogs with a shared container as root.
+        // Place each blur above earlier dialogs and below its own dialog.
+        let actor = target;
         let child = null;
         while (actor && !this.destroyed_actors.has(actor)) {
             let parent = null;
@@ -329,7 +331,8 @@ export const PopupBlur = class PopupBlur {
             if (!parent)
                 break;
 
-            if (parent === Main.layoutManager?.unlockDialogGroup ||
+            if (parent === Main.layoutManager?.modalDialogGroup ||
+                parent === Main.layoutManager?.unlockDialogGroup ||
                 parent === Main.layoutManager?.screenShieldGroup ||
                 parent === Main.uiGroup || 
                 parent === Main.layoutManager?.uiGroup)

--- a/src/components/popup/static_actor.js
+++ b/src/components/popup/static_actor.js
@@ -3,6 +3,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { Pipeline } from '../../conveniences/pipeline.js';
 import { transform_to_actor_space } from './surface_geometry.js';
+import { PopupBlurAllocation } from './surface_allocation.js';
 import { RoundedPipeline } from '../../render/rounded_pipeline.js';
 
 export const PopupBlurStaticActor = class PopupBlurStaticActor {
@@ -37,6 +38,10 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         });
         this.background_group.hide();
         this.connect_destroy(this.background_group, () => this.background_group_destroyed = true);
+        if (this.parent === Main.layoutManager.modalDialogGroup) {
+            this.allocation_constraint = new PopupBlurAllocation();
+            this.background_group.add_constraint(this.allocation_constraint);
+        }
 
         return this.update_background();
     }
@@ -128,7 +133,11 @@ export const PopupBlurStaticActor = class PopupBlurStaticActor {
         const clip_height = Math.ceil(target_geometry.height);
 
         try {
-            if (this.is_screenshot_ui() && this.background_group && !this.background_group_destroyed) {
+            // The wallpaper child already uses monitor-relative positioning and
+            // clipping. Keep its container at the parent's origin under BinLayout.
+            this.allocation_constraint?.set_geometry(0, 0, monitor_geometry.width, monitor_geometry.height);
+            if ((this.allocation_constraint || this.is_screenshot_ui())
+                && this.background_group && !this.background_group_destroyed) {
                 this.background_group.set_position(0, 0);
                 this.background_group.set_size(monitor_geometry.width, monitor_geometry.height);
             }

--- a/src/components/popup/surface_allocation.js
+++ b/src/components/popup/surface_allocation.js
@@ -1,0 +1,19 @@
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+
+// Modal dialogs use a BinLayout, which can shrink an overlay to the group's
+// preferred size. Its blur must instead cover the measured popup rectangle.
+export const PopupBlurAllocation = GObject.registerClass(
+class PopupBlurAllocation extends Clutter.Constraint {
+    set_geometry(x, y, width, height) {
+        this.geometry = { x, y, width, height };
+        this.actor?.queue_relayout();
+    }
+
+    vfunc_update_allocation(_actor, box) {
+        if (this.geometry) {
+            const { x, y, width, height } = this.geometry;
+            box.init_rect(x, y, width, height);
+        }
+    }
+});

--- a/src/components/popup/surface_allocation.js
+++ b/src/components/popup/surface_allocation.js
@@ -1,11 +1,15 @@
 import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 
-// Modal dialogs use a BinLayout, which can shrink an overlay to the group's
-// preferred size. Its blur must instead cover the measured popup rectangle.
+// Modal dialogs use a BinLayout, which can resize or center blur overlays.
+// Preserve the requested bounds for dynamic blur and static wallpaper containers.
 export const PopupBlurAllocation = GObject.registerClass(
 class PopupBlurAllocation extends Clutter.Constraint {
     set_geometry(x, y, width, height) {
+        if (this.geometry?.x === x && this.geometry?.y === y
+            && this.geometry?.width === width && this.geometry?.height === height)
+            return;
+
         this.geometry = { x, y, width, height };
         this.actor?.queue_relayout();
     }

--- a/src/components/popup/surface_placement.js
+++ b/src/components/popup/surface_placement.js
@@ -2,6 +2,7 @@ import Graphene from 'gi://Graphene';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { PopupBlurSurfaceGeometry, transform_to_actor_space } from './surface_geometry.js';
+import { PopupBlurAllocation } from './surface_allocation.js';
 
 const MIN_SURFACE_DIMENSION = 2;
 
@@ -294,6 +295,16 @@ export const PopupBlurSurfacePlacement = class PopupBlurSurfacePlacement {
             const transform = this.get_target_transform(local);
             if (!transform)
                 return false;
+
+            if (this.surface.parent === Main.layoutManager.modalDialogGroup
+                && (!this.allocation_constraint || this.width !== local.width || this.height !== local.height)) {
+                if (!this.allocation_constraint) {
+                    this.allocation_constraint = new PopupBlurAllocation();
+                    this.surface.blur_actor.add_constraint(this.allocation_constraint);
+                }
+                // The transform positions the blur; constrain its local bounds only.
+                this.allocation_constraint.set_geometry(0, 0, local.width, local.height);
+            }
 
             this.surface.blur_actor.set_position(0, 0);
             this.surface.blur_actor.set_size(local.width, local.height);


### PR DESCRIPTION
While working on PR #991 I found a general bug in the handling of stacked modal dialogs.

Currently blurs for modal dialogs are placed below the entire `modalDialogGroup`. This works when there is only one dialog, but when another modal dialog is opened on top of an existing one, its blur is still below both dialogs and therefore cannot blur the dialog behind it.

The fix treats `modalDialogGroup` as the parent for these blur actors and places each blur directly below its own dialog. It also starts the parent lookup from the actual blur target instead of the root of the scan. So multiple dialogs found below the same root get the correct indiviudal stacking position.

Since modal dialogs use `Clutter.BinLayout`, simply moving the blur into `modalDialogGroup` is not enough. The layout manager can override the blur actor's geometry. The added allocation constraint makes sure the blur keeps the exact position and size calculated for the dialog.

This is what I mean:

### Current master branch
<img width="1280" height="800" alt="master" src="https://github.com/user-attachments/assets/2e2f9b2b-2b8c-45b4-a971-f3eedbb3cf8c" />

### Fixed version
<img width="1280" height="800" alt="fixed" src="https://github.com/user-attachments/assets/23fc0df7-5940-474f-9572-26706f572a98" />

This test can be reproduced with [this test extension](https://github.com/aunetx/blur-my-shell/tree/994e6daa40014da56c33e74ae9c1940211cb27a4/bms-modal-blur-reproducer).
