### PR TITLE
Add refraction style slider and retune chromatic dispersion scale

### DIFF
--- a/src/effects/effects.js
+++ b/src/effects/effects.js
@@ -318,6 +318,16 @@ export function get_supported_effects(_ = () => "") {
                     big_increment: 0.5,
                     digits: 2
                 },
+                refraction_style: {
+                    name: _("Refraction style"),
+                    description: _("0 is the vanilla 0.1.1b edge profile (soft, monotonic); higher blends toward the old 0.1.0b Snell-style S-curve that overbends at the very edge."),
+                    type: "float",
+                    min: 0.,
+                    max: 1.,
+                    increment: 0.05,
+                    big_increment: 0.25,
+                    digits: 2
+                },
                 gloss: {
                     name: _("Fresnel glare"),
                     description: _("Strength of the directional fresnel glare from the glass edge."),

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -49,7 +49,7 @@ float quartzGlassEdgeProfile(float distanceFromEdge,
     return 1.0 - sqrt(t * (2.0 - t));
 }
 
-// ---- 0.1.0b Snell-style profile (convex squircle surface + IOR) ------
+// 0.1.0b Snell-style displacement profile
 float surfaceConvexSquircle(float x) {
     return pow(1.0 - pow(1.0 - x, 4.0), 0.25);
 }

--- a/src/effects/refraction.glsl
+++ b/src/effects/refraction.glsl
@@ -17,6 +17,7 @@ uniform float height;
 uniform float strength;
 uniform float edge_size;
 uniform float falloff;
+uniform float refraction_style;
 uniform float corner_radius;
 uniform int corners_top;
 uniform int corners_bottom;
@@ -40,12 +41,45 @@ uniform float clip_y0;
 uniform float clip_width;
 uniform float clip_height;
 
-const float DISPERSION_SCALE = 20.0;
+const float DISPERSION_SCALE = 10.0;
 
 float quartzGlassEdgeProfile(float distanceFromEdge,
                              float refractionHeight) {
     float t = clamp(distanceFromEdge / max(refractionHeight, 0.001), 0.0, 1.0);
     return 1.0 - sqrt(t * (2.0 - t));
+}
+
+// ---- 0.1.0b Snell-style profile (convex squircle surface + IOR) ------
+float surfaceConvexSquircle(float x) {
+    return pow(1.0 - pow(1.0 - x, 4.0), 0.25);
+}
+
+vec2 snellRefractRay(vec2 normal, float eta) {
+    float cosI = -normal.y;
+    float k = 1.0 - eta * eta * (1.0 - cosI * cosI);
+    if (k < 0.0) return vec2(0.0);
+    float sq = sqrt(k);
+    return vec2(-(eta * cosI + sq) * normal.x,
+                eta - (eta * cosI + sq) * normal.y);
+}
+
+float snellRawRefraction(float br, float gt, float bw, float eta) {
+    float x = clamp(br, 0.05, 0.95);
+    float y = surfaceConvexSquircle(x);
+    float y2 = surfaceConvexSquircle(x + 0.001);
+    float d = (y2 - y) / 0.001;
+    float m = sqrt(d * d + 1.0);
+    vec2 n = vec2(-d / m, -1.0 / m);
+    vec2 r = snellRefractRay(n, eta);
+    if (length(r) < 0.0001 || abs(r.y) < 0.0001) return 0.0;
+    return r.x * (y * bw + gt) / r.y;
+}
+
+float snellDisplacementAtRatio(float br, float gt, float bw, float eta) {
+    float peak = snellRawRefraction(0.05, gt, bw, eta);
+    if (abs(peak) < 0.0001) return 0.0;
+    float raw = snellRawRefraction(br, gt, bw, eta);
+    return (raw / peak) * (1.0 - smoothstep(0.0, 1.0, br));
 }
 
 float quartzGlassRing(float distanceFromEdge,
@@ -326,12 +360,21 @@ if (!useCircularSurface && (roundingRadius == 0.0 || R < shortestSide * 0.45)
     float normDisp = distFromSide < refractionBand
         ? quartzGlassEdgeProfile(distFromSide, max(glassThickness, 1.0))
         : 0.0;
+    if (refraction_style > 0.001) {
+        float bezelRatio = clamp(distFromSide / max(refractionBand, 0.001), 0.0, 1.0);
+        float eta = 1.0 / 1.5;
+        float snellDisp = (distFromSide < refractionBand)
+            ? snellDisplacementAtRatio(bezelRatio, max(1.0, glassThickness),
+                                       max(1.0, refractionBand), eta)
+            : 0.0;
+        normDisp = mix(normDisp, snellDisp, clamp(refraction_style, 0.0, 1.0));
+    }
     float dispStrength = edgeBand;
     vec2 dispPx = -dir * normDisp * refractionBand * strength * dispStrength;
 
     float dispersion = clamp(rgb_fringing * DISPERSION_SCALE, 0.0, 20.0);
     vec4 sourceColor = sampleGlassBackdrop(actorUV);
-    vec2 aberrationPx = -dir * normDisp * dispersion * 8.0 * dispStrength;
+    vec2 aberrationPx = -dir * normDisp * dispersion * 0.35 * dispStrength;
     vec4 bgColor = sampleDispersed(actorUV, dispPx, aberrationPx, dispersion);
 
     vec3 outRGB = mix(bgColor.rgb, vec3(tint_r, tint_g, tint_b),

--- a/src/effects/refraction.js
+++ b/src/effects/refraction.js
@@ -95,6 +95,20 @@ const RefractionEffectClass = utils.IS_IN_PREFERENCES ? null : class RefractionE
             }
         }
 
+        get refraction_style() {
+            return this._refraction_style;
+        }
+
+        set refraction_style(value) {
+            const refractionStyle = utils.clamp(value, 0, 1, DEFAULT_PARAMS.refraction_style);
+            if (this._refraction_style !== refractionStyle) {
+                this._refraction_style = refractionStyle;
+
+                uniforms.set_uniform(this, 'refraction_style', parseFloat(this._refraction_style - 1e-6));
+
+            }
+        }
+
         get corner_radius() {
             return this._corner_radius;
         }

--- a/src/effects/refraction_config.js
+++ b/src/effects/refraction_config.js
@@ -7,6 +7,7 @@ export const DEFAULT_PARAMS = {
     blur_radius: 10,
     edge_size: 22,
     falloff: 2.4,
+    refraction_style: 0,
     corner_radius: 0,
     corners_top: true,
     corners_bottom: true,
@@ -59,6 +60,10 @@ export const REFRACTION_EFFECT_META = {
         falloff: doubleProperty(
             'falloff', 'Falloff', 'Refraction falloff',
             0.25, 20, DEFAULT_PARAMS.falloff
+        ),
+        refraction_style: doubleProperty(
+            'refraction_style', 'Refraction Style', '0 is vanilla 0.1.1b profile; higher blends toward the old Snell-style S-curve',
+            0, 1, DEFAULT_PARAMS.refraction_style
         ),
         corner_radius: doubleProperty(
             'corner_radius', 'Corner Radius', 'Refraction corner radius',


### PR DESCRIPTION
## Summary

Adds a `refraction_style` setting to the Liquid Glass effect, blending the edge displacement between the current 0.1.1b profile and the old 0.1.0b Snell-style profile (convex squircle, IOR 1.5). At 0 it renders identically to before, and at 1 you get the signature Snell-style look back at the edge.

Retunes the chromatic dispersion scale (20 -> 10 and the aberration factor 8.0 -> 0.35), so fringing stays subtle at the default value and only shows up strongly when you actually want it.